### PR TITLE
Error on creation of wheel with a name that already exists, and add Py_LIMITED_API to the docs' FAQ

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -218,6 +218,18 @@ def build(options: BuildOptions) -> None:
                         # clean up test environment
                         docker.call(['rm', '-rf', venv_dir])
 
+                    existing_output_files = docker.call(['ls'], cwd=container_output_dir).split('\n')
+                    for repaired_wheel in repaired_wheels:
+                        if repaired_wheel.name in existing_output_files:
+                            message = f'Created wheel ({repaired_wheel}) already exists in output directory.'
+                            if 'abi3' in repaired_wheel.name:
+                                message += ('\n'
+                                            "It looks like you are building wheels against Python's limited API/stable ABI;\n"
+                                            'please limit your Python selection to a single version when building limited API\n'
+                                            'wheels, with CIBW_BUILD.')
+                            log.error(message)
+                            sys.exit(1)
+
                     # move repaired wheels to output
                     docker.call(['mkdir', '-p', container_output_dir])
                     docker.call(['mv', *repaired_wheels, container_output_dir])

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -218,7 +218,7 @@ def build(options: BuildOptions) -> None:
                         # clean up test environment
                         docker.call(['rm', '-rf', venv_dir])
 
-                    existing_output_files = docker.call(['ls'], cwd=container_output_dir).split('\n')
+                    existing_output_files = docker.call(['ls'], capture_output=True, cwd=container_output_dir).split('\n')
                     for repaired_wheel in repaired_wheels:
                         if repaired_wheel.name in existing_output_files:
                             message = f'Created wheel ({repaired_wheel}) already exists in output directory.'

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -456,6 +456,16 @@ def build(options: BuildOptions) -> None:
                     # clean up
                     shutil.rmtree(venv_dir)
 
+            if (options.output_dir / repaired_wheel.name).exists():
+                message = f'Created wheel ({repaired_wheel}) already exists in output directory.'
+                if 'abi3' in repaired_wheel.name:
+                    message += ('\n'
+                                "It looks like you are building wheels against Python's limited API/stable ABI;\n"
+                                'please limit your Python selection to a single version when building limited API\n'
+                                'wheels, with CIBW_BUILD.')
+                log.error(message)
+                sys.exit(1)
+
             # we're all done here; move it to output (overwrite existing)
             shutil.move(str(repaired_wheel), options.output_dir)
             log.build_end()

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -325,6 +325,16 @@ def build(options: BuildOptions) -> None:
                 # clean up
                 shutil.rmtree(venv_dir)
 
+            if (options.output_dir / repaired_wheel.name).exists():
+                message = f'Created wheel ({repaired_wheel}) already exists in output directory.'
+                if 'abi3' in repaired_wheel.name:
+                    message += ('\n'
+                                "It looks like you are building wheels against Python's limited API/stable ABI;\n"
+                                'please limit your Python selection to a single version when building limited API\n'
+                                'wheels, with CIBW_BUILD.')
+                log.error(message)
+                sys.exit(1)
+
             # we're all done here; move it to output (remove if already exists)
             shutil.move(str(repaired_wheel), options.output_dir)
             log.build_end()

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -1,4 +1,7 @@
+import subprocess
 import textwrap
+
+import pytest
 
 from . import test_projects, utils
 
@@ -25,7 +28,7 @@ def test_setup_cfg(tmp_path):
     assert set(actual_wheels) == set(expected_wheels)
 
 
-def test_build_option_env(tmp_path):
+def test_build_option_env(tmp_path, capfd):
     project_dir = tmp_path / 'project'
     test_projects.new_c_project().generate(project_dir)
 
@@ -39,3 +42,17 @@ def test_build_option_env(tmp_path):
     expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0', limited_api='cp36')
                        if '-pp' not in w]
     assert set(actual_wheels) == set(expected_wheels)
+
+
+def test_duplicate_wheel_error(tmp_path, capfd):
+    project_dir = tmp_path / 'project'
+    limited_api_project.generate(project_dir)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        utils.cibuildwheel_run(project_dir, add_env={
+            'CIBW_BUILD': 'cp36-* cp37-*',
+        })
+
+    captured = capfd.readouterr()
+    assert "already exists in output directory" in captured.err
+    assert "It looks like you are building wheels against Python's limited API" in captured.err

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -2,7 +2,7 @@ import textwrap
 
 from . import test_projects, utils
 
-basic_project = test_projects.new_c_project(
+limited_api_project = test_projects.new_c_project(
     setup_cfg_add=textwrap.dedent(r'''
         [bdist_wheel]
         py_limited_api=cp36
@@ -12,13 +12,30 @@ basic_project = test_projects.new_c_project(
 
 def test_setup_cfg(tmp_path):
     project_dir = tmp_path / 'project'
-    basic_project.generate(project_dir)
+    limited_api_project.generate(project_dir)
 
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
-        'CIBW_BUILD': 'cp27-* cp36-* pp27-* pp36-*',
+        'CIBW_BUILD': 'cp27-* cp36-*',  # PyPy does not have a Py_LIMITED_API equivalent
     })
 
     # check that the expected wheels are produced
-    expected_wheels = utils.expected_wheels('spam', '0.1.0', limited_api='cp36')
+    expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0', limited_api='cp36')
+                       if '-pp' not in w]
+    assert set(actual_wheels) == set(expected_wheels)
+
+
+def test_build_option_env(tmp_path):
+    project_dir = tmp_path / 'project'
+    test_projects.new_c_project().generate(project_dir)
+
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
+        'CIBW_ENVIRONMENT': 'PIP_BUILD_OPTION="--py-limited-api=cp36"',
+        'CIBW_BUILD': 'cp27-* cp36-*',  # PyPy does not have a Py_LIMITED_API equivalent
+    })
+
+    # check that the expected wheels are produced
+    expected_wheels = [w for w in utils.expected_wheels('spam', '0.1.0', limited_api='cp36')
+                       if '-pp' not in w]
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -16,7 +16,7 @@ def test_setup_cfg(tmp_path):
 
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
-        'CIBW_BUILD': 'cp27-* cp36-*',
+        'CIBW_BUILD': 'cp27-* cp36-* pp27-* pp36-*',
     })
 
     # check that the expected wheels are produced

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -54,5 +54,7 @@ def test_duplicate_wheel_error(tmp_path, capfd):
         })
 
     captured = capfd.readouterr()
+    print('out', captured.out)
+    print('err', captured.err)
     assert "already exists in output directory" in captured.err
     assert "It looks like you are building wheels against Python's limited API" in captured.err

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -1,19 +1,24 @@
+import textwrap
+
 from . import test_projects, utils
 
 basic_project = test_projects.new_c_project(
-    setup_py_setup_args_add='py_limited_api=True',
+    setup_cfg_add=textwrap.dedent(r'''
+        [bdist_wheel]
+        py_limited_api=cp36
+    ''')
 )
 
 
-def test_setup_py(tmp_path):
+def test_setup_cfg(tmp_path):
     project_dir = tmp_path / 'project'
     basic_project.generate(project_dir)
 
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
-        'CIBW_BUILD': 'cp27-* cp35-*',
+        'CIBW_BUILD': 'cp27-* cp36-*',
     })
 
     # check that the expected wheels are produced
-    expected_wheels = utils.expected_wheels('spam', '0.1.0', limited_api=True)
+    expected_wheels = utils.expected_wheels('spam', '0.1.0', limited_api='cp36')
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_limited_api.py
+++ b/test/test_limited_api.py
@@ -1,0 +1,19 @@
+from . import test_projects, utils
+
+basic_project = test_projects.new_c_project(
+    setup_py_setup_args_add='py_limited_api=True',
+)
+
+
+def test_setup_py(tmp_path):
+    project_dir = tmp_path / 'project'
+    basic_project.generate(project_dir)
+
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env={
+        'CIBW_BUILD': 'cp27-* cp35-*',
+    })
+
+    # check that the expected wheels are produced
+    expected_wheels = utils.expected_wheels('spam', '0.1.0', limited_api=True)
+    assert set(actual_wheels) == set(expected_wheels)

--- a/test/utils.py
+++ b/test/utils.py
@@ -88,7 +88,8 @@ def _get_arm64_macosx_deployment_target(macosx_deployment_target: str) -> str:
 
 def expected_wheels(package_name, package_version, manylinux_versions=None,
                     macosx_deployment_target='10.9', machine_arch=None, *,
-                    exclude_27=IS_WINDOWS_RUNNING_ON_TRAVIS):
+                    exclude_27=IS_WINDOWS_RUNNING_ON_TRAVIS,
+                    limited_api=False):
     '''
     Returns a list of expected wheels from a run of cibuildwheel.
     '''
@@ -106,7 +107,10 @@ def expected_wheels(package_name, package_version, manylinux_versions=None,
         else:
             manylinux_versions = ['manylinux2014']
 
-    python_abi_tags = ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38', 'cp39-cp39']
+    if limited_api:
+        python_abi_tags = ['cp35-abi3']
+    else:
+        python_abi_tags = ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38', 'cp39-cp39']
 
     if machine_arch in ['x86_64', 'AMD64', 'x86']:
         python_abi_tags += ['cp27-cp27m', 'pp27-pypy_73', 'pp36-pypy36_pp73', 'pp37-pypy37_pp73']

--- a/test/utils.py
+++ b/test/utils.py
@@ -89,7 +89,7 @@ def _get_arm64_macosx_deployment_target(macosx_deployment_target: str) -> str:
 def expected_wheels(package_name, package_version, manylinux_versions=None,
                     macosx_deployment_target='10.9', machine_arch=None, *,
                     exclude_27=IS_WINDOWS_RUNNING_ON_TRAVIS,
-                    limited_api=False):
+                    limited_api=None):
     '''
     Returns a list of expected wheels from a run of cibuildwheel.
     '''
@@ -108,7 +108,7 @@ def expected_wheels(package_name, package_version, manylinux_versions=None,
             manylinux_versions = ['manylinux2014']
 
     if limited_api:
-        python_abi_tags = ['cp35-abi3']
+        python_abi_tags = [f'{limited_api}-abi3']
     else:
         python_abi_tags = ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38', 'cp39-cp39']
 


### PR DESCRIPTION
Closes #78﻿, by providing clear error messages and documentation on how to use `cibuildwheel` to create wheels with Python's limited API/stable ABI.

TODO:
- [x] Show error on copying an already existing file to the output directory
- [ ] Update the FAQ with some information about Python's limited API.
- [x] Add tests (?)