### PR TITLE
feat: configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Options
 |   | [`CIBW_TEST_SKIP`](https://cibuildwheel.readthedocs.io/en/stable/options/#test-skip)  | Skip running tests on some builds |
 | **Other** | [`CIBW_BUILD_VERBOSITY`](https://cibuildwheel.readthedocs.io/en/stable/options/#build-verbosity)  | Increase/decrease the output of pip wheel |
 
+These options can be specified in a pyproject.toml file, as well; see [configuration](https://cibuildwheel.readthedocs.io/en/stable/options/#configuration).
 
 Working examples
 ----------------

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -16,7 +16,7 @@ import cibuildwheel.util
 import cibuildwheel.windows
 from cibuildwheel.architecture import Architecture, allowed_architectures_check
 from cibuildwheel.environment import EnvironmentParseError, parse_environment
-from cibuildwheel.options import ConfigNamespace, ConfigOptions
+from cibuildwheel.options import ConfigOptions
 from cibuildwheel.projectfiles import get_requires_python_str
 from cibuildwheel.typing import PLATFORMS, PlatformName, assert_never
 from cibuildwheel.util import (
@@ -147,12 +147,12 @@ def main() -> None:
     output_dir = Path(
         args.output_dir
         if args.output_dir is not None
-        else options("output-dir", namespace=ConfigNamespace.MAIN)
+        else os.environ.get("CIBW_OUTPUT_DIR", "wheelhouse")
     )
 
-    build_config = options("build", namespace=ConfigNamespace.MAIN) or "*"
-    skip_config = options("skip", namespace=ConfigNamespace.MAIN)
-    test_skip = options("test-skip", namespace=ConfigNamespace.MAIN)
+    build_config = options("build", env_plat=False) or "*"
+    skip_config = options("skip", env_plat=False)
+    test_skip = options("test-skip", env_plat=False)
 
     archs_config_str = options("archs") if args.archs is None else args.archs
 
@@ -262,7 +262,7 @@ def main() -> None:
         ]:
             pinned_images = all_pinned_docker_images[build_platform]
 
-            config_value = options(f"{build_platform}-image", namespace=ConfigNamespace.MANYLINUX)
+            config_value = options(f"manylinux.{build_platform}-image")
 
             if config_value is None:
                 # default to manylinux2010 if it's available, otherwise manylinux2014

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -262,7 +262,7 @@ def main() -> None:
         ]:
             pinned_images = all_pinned_docker_images[build_platform]
 
-            config_value = options(f"manylinux.{build_platform}-image")
+            config_value = options(f"manylinux-{build_platform}-image")
 
             if config_value is None:
                 # default to manylinux2010 if it's available, otherwise manylinux2014

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -185,7 +185,7 @@ def main() -> None:
 
     archs_config_str = args.archs or options("archs", sep=" ")
 
-    environment_config = options("environment", sep=" ")
+    environment_config = options("environment", table={"item": '{k}="{v}"', "sep": " "})
     before_all = options("before-all", sep=" && ")
     before_build = options("before-build", sep=" && ")
     repair_command = options("repair-wheel-command", sep=" && ")

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -157,15 +157,15 @@ def main() -> None:
     archs_config_str = options("archs") if args.archs is None else args.archs
 
     environment_config = options("environment")
-    before_all = options("before-all")
-    before_build = options("before-build")
-    repair_command = options("repair-wheel-command")
+    before_all = options("before-all", sep=" && ")
+    before_build = options("before-build", sep=" && ")
+    repair_command = options("repair-wheel-command", sep=" && ")
 
     dependency_versions = options("dependency-versions")
-    test_command = options("test-command")
-    before_test = options("before-test")
+    test_command = options("test-command", sep=" && ")
+    before_test = options("before-test", sep=" && ")
     test_requires = options("test-requires").split()
-    test_extras = options("test-extras")
+    test_extras = options("test-extras", sep=",")
     build_verbosity_str = options("build-verbosity")
 
     prerelease_pythons = args.prerelease_pythons or cibuildwheel.util.strtobool(

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -36,8 +36,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Build wheels for all the platforms.",
         epilog="""
-            Most options are supplied via environment variables.
-            See https://github.com/pypa/cibuildwheel#options for info.
+            Most options are supplied via environment variables or in
+            --config-file (pyproject.toml usually). See
+            https://github.com/pypa/cibuildwheel#options for info.
         """,
     )
 
@@ -76,8 +77,11 @@ def main() -> None:
 
     parser.add_argument(
         "--config-file",
-        help="TOML config file for cibuildwheel; usually pyproject.toml, but can be overridden with this option. Use {project} for the project directory",
-        default="{project}/pyproject.toml",
+        help="""
+            TOML config file for cibuildwheel; usually pyproject.toml, but
+            can be overridden with this option. Use {package} for the package
+            directory.""",
+        default="{package}/pyproject.toml",
     )
 
     parser.add_argument(

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -89,10 +89,9 @@ def main() -> None:
     parser.add_argument(
         "--config-file",
         help="""
-            TOML config file for cibuildwheel; usually pyproject.toml, but
-            can be overridden with this option. Use {package} for the package
-            directory.""",
-        default="{package}/pyproject.toml",
+            TOML config file for cibuildwheel. Defaults to pyproject.toml, but
+            can be overridden with this option.
+        """,
     )
 
     parser.add_argument(

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -75,6 +75,12 @@ def main() -> None:
     )
 
     parser.add_argument(
+        "--config-file",
+        help="TOML config file for cibuildwheel; usually pyproject.toml, but can be overridden with this option. Use {project} for the project directory",
+        default="{project}/pyproject.toml",
+    )
+
+    parser.add_argument(
         "package_dir",
         default=".",
         nargs="?",
@@ -143,7 +149,7 @@ def main() -> None:
 
     package_dir = Path(args.package_dir)
 
-    options = ConfigOptions(package_dir, platform=platform)
+    options = ConfigOptions(package_dir, args.config_file, platform=platform)
     output_dir = Path(
         args.output_dir
         if args.output_dir is not None

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -150,13 +150,13 @@ def main() -> None:
         else os.environ.get("CIBW_OUTPUT_DIR", "wheelhouse")
     )
 
-    build_config = options("build", env_plat=False) or "*"
-    skip_config = options("skip", env_plat=False)
-    test_skip = options("test-skip", env_plat=False)
+    build_config = options("build", env_plat=False, sep=" ") or "*"
+    skip_config = options("skip", env_plat=False, sep=" ")
+    test_skip = options("test-skip", env_plat=False, sep=" ")
 
-    archs_config_str = options("archs") if args.archs is None else args.archs
+    archs_config_str = options("archs", sep=" ") if args.archs is None else args.archs
 
-    environment_config = options("environment")
+    environment_config = options("environment", sep=" ")
     before_all = options("before-all", sep=" && ")
     before_build = options("before-build", sep=" && ")
     repair_command = options("repair-wheel-command", sep=" && ")
@@ -164,7 +164,7 @@ def main() -> None:
     dependency_versions = options("dependency-versions")
     test_command = options("test-command", sep=" && ")
     before_test = options("before-test", sep=" && ")
-    test_requires = options("test-requires").split()
+    test_requires = options("test-requires", sep=" ").split()
     test_extras = options("test-extras", sep=",")
     build_verbosity_str = options("build-verbosity")
 

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -5,9 +5,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 import toml
 
 from .typing import PLATFORMS, TypedDict
-
-DIR = Path(__file__).parent.resolve()
-
+from .util import resources_dir
 
 Setting = Union[Dict[str, str], List[str], str]
 
@@ -34,99 +32,95 @@ def _dig_first(*pairs: Tuple[Mapping[str, Any], str]) -> Setting:
 
 class ConfigOptions:
     """
-    Gets options from the environment, optionally scoped by the platform.
+    Gets options from the environment, config or defaults, optionally scoped
+    by the platform.
 
     Example:
-      ConfigOptions(package_dir, 'platform='macos')
-      options('cool-color')
+      >>> options = ConfigOptions(package_dir, platform='macos')
+      >>> options('cool-color')
 
-      This will return the value of CIBW_COOL_COLOR_MACOS if it exists, otherwise the value of
-      CIBW_COOL_COLOR, otherwise 'tool.cibuildwheel.cool-color' from pyproject.toml or from
-      cibuildwheel/resources/defaults.toml. An error is thrown if there are any unexpected
-      keys or sections in tool.cibuildwheel.
+      This will return the value of CIBW_COOL_COLOR_MACOS if it exists,
+      otherwise the value of CIBW_COOL_COLOR, otherwise
+      'tool.cibuildwheel.macos.cool-color' or 'tool.cibuildwheel.cool-color'
+      from pyproject.toml, or from cibuildwheel/resources/defaults.toml. An
+      error is thrown if there are any unexpected keys or sections in
+      tool.cibuildwheel.
     """
 
     def __init__(
         self,
-        project_path: Path,
-        config_file: str = "{package}/pyproject.toml",
+        package_path: Path,
+        config_file: Optional[str] = None,
         *,
         platform: str,
         disallow: Optional[Dict[str, Set[str]]] = None,
     ) -> None:
         self.platform = platform
-        self.config: Dict[str, Any] = {}
         self.disallow = disallow or {}
 
-        # Open defaults.toml and load tool.cibuildwheel.global, then update with tool.cibuildwheel.<platform>
-        self._load_file(DIR.joinpath("resources", "defaults.toml"), update=False)
+        # Open defaults.toml, loading both global and platform sections
+        defaults_path = resources_dir / "defaults.toml"
+        self.default_options, self.default_platform_options = self._load_file(defaults_path)
 
-        # Open pyproject.toml or user specified file
-        config_toml = Path(config_file.format(package=project_path))
-        if config_toml != project_path / "pyproject.toml" and not config_toml.exists():
-            raise FileNotFoundError(f"{config_toml} required.")
-        self._load_file(config_toml, update=True)
+        # load the project config file
+        config_options: Dict[str, Any] = {}
+        config_platform_options: Dict[str, Any] = {}
 
-    def _update(
-        self,
-        old_dict: Dict[str, Any],
-        new_dict: Dict[str, Any],
-        *,
-        update: bool,
-        _platform: bool = False,
-    ) -> None:
-        """
-        Updates a dict with a new dict - optionally checking to see if the key
-        is unexpected based on the current global options - call this with
-        check=False when loading the defaults.toml file, and all future files
-        will be forced to have no new keys.
-        """
-
-        # _platform will be True if this is being called on tool.cibuildwheel.<platform>
-        # for the new_dict (old_dict does not have platforms in it)
-        if _platform:
-            normal_keys = set(new_dict)
-            bad_keys = self.disallow.get(self.platform, set()) & normal_keys
-            if bad_keys:
-                msg = f"Options {bad_keys} not allowed in {self.platform}"
-                raise ConfigOptionError(msg)
+        if config_file is not None:
+            config_path = Path(config_file.format(package=package_path))
+            config_options, config_platform_options = self._load_file(config_path)
         else:
-            normal_keys = set(new_dict) - PLATFORMS
+            # load pyproject.toml, if it's available
+            pyproject_toml_path = package_path / "pyproject.toml"
+            if pyproject_toml_path.exists():
+                config_options, config_platform_options = self._load_file(pyproject_toml_path)
 
-        for key in normal_keys:
-            # Check to see if key is already present
-            if update:
-                # TODO: Also check nested items
-                if key not in self.config:
-                    msg = f"Key not supported, problem in config file: {key}"
-                    raise ConfigOptionError(msg)
+        # validate project config
+        for option_name in config_options:
+            if not self._is_valid_global_option(option_name):
+                raise ConfigOptionError(f'Option "{option_name}" not supported in a config file')
 
-            old_dict[key] = new_dict[key]
+        for option_name in config_platform_options:
+            if not self._is_valid_platform_option(option_name):
+                raise ConfigOptionError(
+                    f'Option "{option_name}" not supported in the "{self.platform}" section'
+                )
 
-        # Allow new_dict[<platform>][key] to override old_dict[key]
-        if not _platform and self.platform in new_dict:
-            self._update(old_dict, new_dict[self.platform], update=update, _platform=True)
+        self.config_options = config_options
+        self.config_platform_options = config_platform_options
 
-    def _load_file(self, filename: Path, *, update: bool) -> None:
+    def _is_valid_global_option(self, name: str) -> bool:
         """
-        Load a toml file, global and current platform. Raise an error if any
-        unexpected sections are present in tool.cibuildwheel if updating, and
-        raise if any are missing if not.
+        Returns True if an option with this name is allowed in the
+        [tool.cibuildwheel] section of a config file.
         """
-        # Only load if present.
-        try:
-            config = toml.load(filename)
-        except FileNotFoundError:
-            assert update, "Missing default.toml, this should not happen!"
-            return
+        allowed_option_names = self.default_options.keys() | PLATFORMS
 
-        # If these sections are not present, go on.
-        tool_cibuildwheel = config.get("tool", {}).get("cibuildwheel")
-        if not tool_cibuildwheel:
-            assert update, "Malformed internal default.toml, this should not happen!"
-            return
+        return name in allowed_option_names
 
-        self._update(self.config, tool_cibuildwheel, update=update)
+    def _is_valid_platform_option(self, name: str) -> bool:
+        """
+        Returns True if an option with this name is allowed in the
+        [tool.cibuildwheel.<current-platform>] section of a config file.
+        """
+        disallowed_platform_options = self.disallow.get(self.platform, set())
+        if name in disallowed_platform_options:
+            return False
+
+        allowed_option_names = self.default_options.keys() | self.default_platform_options.keys()
+
+        return name in allowed_option_names
+
+    def _load_file(self, filename: Path) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Load a toml file, returns global and platform as separate dicts.
+        """
+        config = toml.load(filename)
+
+        global_options = config.get("tool", {}).get("cibuildwheel", {})
+        platform_options = global_options.get(self.platform, {})
+
+        return global_options, platform_options
 
     def __call__(
         self,
@@ -137,32 +131,31 @@ class ConfigOptions:
         table: Optional[TableFmt] = None,
     ) -> str:
         """
-        Get and return envvar for name or the override or the default. If
-        env_plat is False, then don't accept platform versions of the
-        environment variable. If this is an array it will be merged with "sep"
-        before returning. If it is a table, it will be formatted with
-        "table['item']" using {k} and {v} and merged with "table['sep']".
+        Get and return the value for the named option from environment,
+        configuration file, or the default. If env_plat is False, then don't
+        accept platform versions of the environment variable. If this is an
+        array it will be merged with "sep" before returning. If it is a table,
+        it will be formatted with "table['item']" using {k} and {v} and merged
+        with "table['sep']".
         """
 
-        if name not in self.config:
+        if name not in self.default_options and name not in self.default_platform_options:
             raise ConfigOptionError(f"{name} must be in cibuildwheel/resources/defaults.toml file")
 
         # Environment variable form
-        envvar = f"CIBW_{name.upper().replace('-', '_').replace('.', '_')}"
+        envvar = f"CIBW_{name.upper().replace('-', '_')}"
         plat_envvar = f"{envvar}_{self.platform.upper()}"
 
-        # Let environment variable override setting in config
-        if env_plat:
-            result = _dig_first(
-                (os.environ, plat_envvar),
-                (os.environ, envvar),
-                (self.config, name),
-            )
-        else:
-            result = _dig_first(
-                (os.environ, envvar),
-                (self.config, name),
-            )
+        # get the option from the environment, then the config file, then finally the default.
+        # platform-specific options are preferred, if they're allowed.
+        result = _dig_first(
+            (os.environ if env_plat else {}, plat_envvar),  # type: ignore
+            (os.environ, envvar),
+            (self.config_platform_options, name),
+            (self.config_options, name),
+            (self.default_platform_options, name),
+            (self.default_options, name),
+        )
 
         if isinstance(result, dict):
             if table is None:

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -44,7 +44,7 @@ class ConfigOptions:
     def __init__(
         self,
         project_path: Path,
-        config_file: str = "{project}/pyproject.toml",
+        config_file: str = "{package}/pyproject.toml",
         *,
         platform: str,
     ) -> None:
@@ -55,7 +55,7 @@ class ConfigOptions:
         self._load_file(DIR.joinpath("resources", "defaults.toml"), update=False)
 
         # Open pyproject.toml or user specified file
-        config_toml = Path(config_file.format(project=project_path))
+        config_toml = Path(config_file.format(package=project_path))
         if config_toml != project_path / "pyproject.toml" and not config_toml.exists():
             raise FileNotFoundError(f"{config_toml} required.")
         self._load_file(config_toml, update=True)

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -1,0 +1,121 @@
+import os
+from pathlib import Path
+from typing import Dict, Mapping, Tuple
+
+import toml
+
+from .typing import PLATFORMS
+
+DIR = Path(__file__).parent.resolve()
+
+Setting = str
+
+
+class ConfigOptionError(KeyError):
+    pass
+
+
+def _dig_first(*pairs: Tuple[Mapping[str, Setting], str]) -> Setting:
+    """
+    Return the first dict item that matches from pairs of dicts and keys.
+    Final result is will throw a KeyError if missing.
+
+    _dig_first((dict1, "key1"), (dict2, "key2"), ...)
+    """
+    (dict_like, key), *others = pairs
+    return dict_like.get(key, _dig_first(*others)) if others else dict_like[key]
+
+
+class ConfigOptions:
+    """
+    Gets options from the environment, optionally scoped by the platform.
+
+    Example:
+      ConfigOptions(package_dir, 'platform='macos')
+      options('cool-color')
+
+      This will return the value of CIBW_COOL_COLOR_MACOS if it exists, otherwise the value of
+      CIBW_COOL_COLOR, otherwise 'tool.cibuildwheel.cool-color' from pyproject.toml or from
+      cibuildwheel/resources/defaults.toml. An error is thrown if there are any unexpected
+      keys or sections in tool.cibuildwheel.
+    """
+
+    def __init__(self, project_path: Path, *, platform: str) -> None:
+        self.platform = platform
+        self.global_options: Dict[str, Setting] = {}
+        self.platform_options: Dict[str, Setting] = {}
+
+        # Open defaults.toml and load tool.cibuildwheel.global, then update with tool.cibuildwheel.<platform>
+        self._load_file(DIR.joinpath("resources", "defaults.toml"), check=False)
+
+        # Open pyproject.toml if it exists and load from there
+        pyproject_toml = project_path.joinpath("pyproject.toml")
+        self._load_file(pyproject_toml, check=True)
+
+        # Open cibuildwheel.toml if it exists and load from there
+        cibuildwheel_toml = project_path.joinpath("cibuildwheel.toml")
+        self._load_file(cibuildwheel_toml, check=True)
+
+    def _update(
+        self, old_dict: Dict[str, Setting], new_dict: Dict[str, Setting], *, check: bool
+    ) -> None:
+        """
+        Updates a dict with a new dict - optionally checking to see if the key
+        is unexpected based on the current global options - call this with
+        check=False when loading the defaults.toml file, and all future files
+        will be forced to have no new keys.
+        """
+        for key in new_dict:
+            if check and key not in self.global_options:
+                raise ConfigOptionError(f"Key not supported, problem in config file: {key}")
+
+            old_dict[key] = new_dict[key]
+
+    def _load_file(self, filename: Path, *, check: bool) -> None:
+        """
+        Load a toml file, global and current platform. Raise an error if any unexpected
+        sections are present in tool.cibuildwheel, and pass on check to _update.
+        """
+        # Only load if present.
+        try:
+            config = toml.load(filename)
+        except FileNotFoundError:
+            return
+
+        # If these sections are not present, go on.
+        if not config.get("tool", {}).get("cibuildwheel"):
+            return
+
+        unsupported = set(config["tool"]["cibuildwheel"]) - (PLATFORMS | {"global"})
+        if unsupported:
+            raise ConfigOptionError(f"Unsupported configuration section(s): {unsupported}")
+
+        self._update(self.global_options, config["tool"]["cibuildwheel"]["global"], check=check)
+        self._update(
+            self.platform_options, config["tool"]["cibuildwheel"][self.platform], check=check
+        )
+
+    def __call__(self, name: str, *, platform_variants: bool = True) -> Setting:
+        """
+        Get and return envvar for name or the override or the default.
+        """
+        if name not in self.global_options:
+            raise ConfigOptionError(
+                f"{name} was not loaded from the cibuildwheel/resources/defaults.toml file"
+            )
+
+        envvar = f"CIBW_{name.upper().replace('-', '_')}"
+
+        if platform_variants:
+            plat_envvar = f"{envvar}_{self.platform.upper()}"
+            return _dig_first(
+                (os.environ, plat_envvar),
+                (self.platform_options, name),
+                (os.environ, envvar),
+                (self.global_options, name),
+            )
+        else:
+            return _dig_first(
+                (os.environ, envvar),
+                (self.global_options, name),
+            )

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import toml
 
@@ -121,7 +121,7 @@ class ConfigOptions:
 
         self._update(self.config, tool_cibuildwheel, update=update)
 
-    def __call__(self, name: str, *, env_plat: bool = True, sep: str = " ") -> str:
+    def __call__(self, name: str, *, env_plat: bool = True, sep: Optional[str] = None) -> str:
         """
         Get and return envvar for name or the override or the default. If env_plat is False,
         then don't accept platform versions of the environment variable. If this is an array
@@ -157,8 +157,12 @@ class ConfigOptions:
             )
 
         if isinstance(result, dict):
+            if sep is None:
+                raise ConfigOptionError(f"{name} does not accept a table")
             return sep.join(f'{k}="{v}"' for k, v in result.items())
         elif isinstance(result, list):
+            if sep is None:
+                raise ConfigOptionError(f"{name} does not accept a list")
             return sep.join(result)
         elif isinstance(result, int):
             return str(result)

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -41,16 +41,24 @@ class ConfigOptions:
       keys or sections in tool.cibuildwheel.
     """
 
-    def __init__(self, project_path: Path, *, platform: str) -> None:
+    def __init__(
+        self,
+        project_path: Path,
+        config_file: str = "{project}/pyproject.toml",
+        *,
+        platform: str,
+    ) -> None:
         self.platform = platform
         self.config: Dict[str, Any] = {}
 
         # Open defaults.toml and load tool.cibuildwheel.global, then update with tool.cibuildwheel.<platform>
         self._load_file(DIR.joinpath("resources", "defaults.toml"), update=False)
 
-        # Open pyproject.toml if it exists and load from there
-        pyproject_toml = project_path.joinpath("pyproject.toml")
-        self._load_file(pyproject_toml, update=True)
+        # Open pyproject.toml or user specified file
+        config_toml = Path(config_file.format(project=project_path))
+        if config_toml != project_path / "pyproject.toml" and not config_toml.exists():
+            raise FileNotFoundError(f"{config_toml} required.")
+        self._load_file(config_toml, update=True)
 
     def _update(
         self,

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -160,5 +160,7 @@ class ConfigOptions:
             return sep.join(f'{k}="{v}"' for k, v in result.items())
         elif isinstance(result, list):
             return sep.join(result)
+        elif isinstance(result, int):
+            return str(result)
         else:
             return result

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -17,16 +17,14 @@ before-test = ""
 test-requires = []
 test-extras = []
 
-
-[tool.cibuildwheel.manylinux]
-x86_64-image = "manylinux2010"
-i686-image = "manylinux2010"
-aarch64-image = "manylinux2014"
-ppc64le-image = "manylinux2014"
-s390x-image = "manylinux2014"
-pypy_x86_64-image = "manylinux2010"
-pypy_i686-image = "manylinux2010"
-pypy_aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"
+manylinux-aarch64-image = "manylinux2014"
+manylinux-ppc64le-image = "manylinux2014"
+manylinux-s390x-image = "manylinux2014"
+manylinux-pypy_x86_64-image = "manylinux2010"
+manylinux-pypy_i686-image = "manylinux2010"
+manylinux-pypy_aarch64-image = "manylinux2014"
 
 
 [tool.cibuildwheel.linux]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -8,10 +8,12 @@ output-dir = "wheelhouse"
 [tool.cibuildwheel.manylinux]
 x86_64-image = "manylinux2010"
 i686-image = "manylinux2010"
-pypy_x86_64-image = "manylinux2010"
 aarch64-image = "manylinux2014"
 ppc64le-image = "manylinux2014"
 s390x-image = "manylinux2014"
+pypy_x86_64-image = "manylinux2010"
+pypy_i686-image = "manylinux2010"
+pypy_aarch64-image = "manylinux2014"
 
 
 [tool.cibuildwheel.global]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -3,9 +3,9 @@ build = "*"
 skip = ""
 test-skip = ""
 
-archs = "auto"
+archs = ["auto"]
 dependency-versions = "pinned"
-environment = ""
+environment = {}
 build-verbosity = ""
 
 before-all = ""
@@ -14,8 +14,8 @@ repair-wheel-command = ""
 
 test-command = ""
 before-test = ""
-test-requires = ""
-test-extras = ""
+test-requires = []
+test-extras = []
 
 
 [tool.cibuildwheel.manylinux]
@@ -33,6 +33,9 @@ pypy_aarch64-image = "manylinux2014"
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+repair-wheel-command = [
+  "delocate-listdeps {wheel}",
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
+]
 
 [tool.cibuildwheel.windows]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -1,31 +1,39 @@
-[tool.cibuildwheel.global]
+[tool.cibuildwheel]
 build = "*"
 skip = ""
 test-skip = ""
+output-dir = "wheelhouse"
 
+
+[tool.cibuildwheel.manylinux]
+x86_64-image = "manylinux2010"
+i686-image = "manylinux2010"
+pypy_x86_64-image = "manylinux2010"
+aarch64-image = "manylinux2014"
+ppc64le-image = "manylinux2014"
+s390x-image = "manylinux2014"
+
+
+[tool.cibuildwheel.global]
 archs = "auto"
-
+dependency-versions = "pinned"
 environment = ""
+build-verbosity = ""
 
 before-all = ""
 before-build = ""
-
-repair-command = ""
-
-dependency-versions = "pinned"
+repair-wheel-command = ""
 
 test-command = ""
 before-test = ""
 test-requires = ""
 test-extras = ""
 
-build-verbosity = ""
-
 
 [tool.cibuildwheel.linux]
-repair-command = "auditwheel repair -w {dest_dir} {wheel}"
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-repair-command = "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -2,21 +2,7 @@
 build = "*"
 skip = ""
 test-skip = ""
-output-dir = "wheelhouse"
 
-
-[tool.cibuildwheel.manylinux]
-x86_64-image = "manylinux2010"
-i686-image = "manylinux2010"
-aarch64-image = "manylinux2014"
-ppc64le-image = "manylinux2014"
-s390x-image = "manylinux2014"
-pypy_x86_64-image = "manylinux2010"
-pypy_i686-image = "manylinux2010"
-pypy_aarch64-image = "manylinux2014"
-
-
-[tool.cibuildwheel.global]
 archs = "auto"
 dependency-versions = "pinned"
 environment = ""
@@ -30,6 +16,17 @@ test-command = ""
 before-test = ""
 test-requires = ""
 test-extras = ""
+
+
+[tool.cibuildwheel.manylinux]
+x86_64-image = "manylinux2010"
+i686-image = "manylinux2010"
+aarch64-image = "manylinux2014"
+ppc64le-image = "manylinux2014"
+s390x-image = "manylinux2014"
+pypy_x86_64-image = "manylinux2010"
+pypy_i686-image = "manylinux2010"
+pypy_aarch64-image = "manylinux2014"
 
 
 [tool.cibuildwheel.linux]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -1,0 +1,31 @@
+[tool.cibuildwheel.global]
+build = "*"
+skip = ""
+test-skip = ""
+
+archs = "auto"
+
+environment = ""
+
+before-all = ""
+before-build = ""
+
+repair-command = ""
+
+dependency-versions = "pinned"
+
+test-command = ""
+before-test = ""
+test-requires = ""
+test-extras = ""
+
+build-verbosity = ""
+
+
+[tool.cibuildwheel.linux]
+repair-command = "auditwheel repair -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos]
+repair-command = "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.windows]

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -167,14 +167,26 @@ h1, h2, h3, h4, h5, h6 {
 /* Examples tabs styling */
 
 .tabs.examples .tabs-header {
-  /* justify-content: flex-end; */
+  justify-content: flex-end;
   background-color: transparent;
-  /* background: #f6f8fa; */
+  background: #f6f8fa;
   border-bottom-style: none;
+  padding: 0 4px;
 }
+.tabs.examples .tabs-header button {
+  padding: 6px 8px;
+  border-bottom: none;
+  color: rgba(0, 0, 0, 0.3);
+  font-size: 0.8em;
+}
+.tabs-header button:hover {
+  background-color: unset;
+}
+
 .tabs.examples .tabs-header button.active {
   border-bottom-style: none;
   background: #f6f8fa;
+  color: inherit;
 }
 .tabs.examples .tabs-content {
   padding: 0;
@@ -188,7 +200,10 @@ h1, h2, h3, h4, h5, h6 {
 .tabs.examples .tabs-content .tab > pre {
   padding-left: 0;
   padding-right: 0;
-  margin-bottom: 0;
+  margin-bottom: 0.5em;
+}
+.tabs.examples .tabs-content .tab > pre > code {
+  padding-top: 0.5em;
 }
 .tabs.examples pre:first-child {
   margin-top: 0;

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,6 +1,10 @@
 
 /* Global styles */
 
+body {
+    overflow-wrap: break-word;
+}
+
 p {
     margin-bottom: 12px;
     line-height: 26px;
@@ -113,6 +117,8 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   justify-content: flex-start;
   border-bottom: 2px solid #ccc;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 /* Style the buttons that are used to open the tab content */
@@ -153,4 +159,24 @@ h1, h2, h3, h4, h5, h6 {
   background-color: #f1f6fa;
   padding: 1px 1em;
   padding-top: 0.8em;
+}
+
+/* Examples tabs styling */
+
+.tabs.examples .tabs-header {
+  /* justify-content: flex-end; */
+  background-color: transparent;
+  /* background: #f6f8fa; */
+  border-bottom-style: none;
+}
+.tabs.examples .tabs-header button.active {
+  border-bottom-style: none;
+  background: #f6f8fa;
+}
+.tabs.examples .tabs-content {
+  padding: 0;
+  background-color: transparent;
+}
+.tabs.examples pre:first-child {
+  margin-top: 0;
 }

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -159,6 +159,9 @@ h1, h2, h3, h4, h5, h6 {
   background-color: #f1f6fa;
   padding: 1px 1em;
   padding-top: 0.8em;
+
+  /* don't collapse inner margins */
+  overflow-y: hidden;
 }
 
 /* Examples tabs styling */

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -24,9 +24,9 @@ code, pre, tt {
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 }
 
-.hljs {
-    padding: 1em;
-    background-color: #f6f8fa;
+pre code, pre code.hljs {
+  padding: 1em;
+  background-color: #f6f8fa;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -179,6 +179,16 @@ h1, h2, h3, h4, h5, h6 {
 .tabs.examples .tabs-content {
   padding: 0;
   background-color: transparent;
+  background-color: #f6f8fa;
+}
+.tabs.examples .tabs-content .tab > * {
+  padding-left: 0.8em;
+  padding-right: 0.8em;
+}
+.tabs.examples .tabs-content .tab > pre {
+  padding-left: 0;
+  padding-right: 0;
+  margin-bottom: 0;
 }
 .tabs.examples pre:first-child {
   margin-top: 0;

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -169,7 +169,6 @@ h1, h2, h3, h4, h5, h6 {
 .tabs.examples .tabs-header {
   justify-content: flex-end;
   background-color: transparent;
-  background: #f6f8fa;
   border-bottom-style: none;
   padding: 0 4px;
 }

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -116,9 +116,21 @@ h1, h2, h3, h4, h5, h6 {
   background-color: white;
   display: flex;
   justify-content: flex-start;
-  border-bottom: 2px solid #ccc;
   overflow-x: auto;
   overflow-y: hidden;
+  position: relative;
+}
+.tabs-header::before {
+  position: absolute;
+  content: "";
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #ccc;
+}
+.tabs-header > * {
+  position: relative;
 }
 
 /* Style the buttons that are used to open the tab content */
@@ -132,15 +144,13 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 0.9em;
   font-weight: 600;
   padding: 8px 16px;
-  border-bottom: 2px solid transparent;
-
-  /* put the border on top of the parent border */
-  margin-bottom: -2px;
+  border-bottom: 2px solid #ccc;
 }
 
 .tabs-header button:focus-visible {
   /* preserve an outline for accesibility purposes */
   outline: 1px solid currentColor;
+  outline-offset: -1px;
 }
 
 /* Change background color of buttons on hover */

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -180,13 +180,18 @@ h1, h2, h3, h4, h5, h6 {
   justify-content: flex-end;
   background-color: transparent;
   border-bottom-style: none;
-  padding: 0 4px;
+  padding: 0;
+}
+.tabs.examples .tabs-header::before {
+  height: 0;
 }
 .tabs.examples .tabs-header button {
-  padding: 6px 8px;
+  padding: 6px 12px;
   border-bottom: none;
   color: rgba(0, 0, 0, 0.3);
   font-size: 0.8em;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 .tabs-header button:hover {
   background-color: unset;
@@ -210,9 +215,6 @@ h1, h2, h3, h4, h5, h6 {
   padding-left: 0;
   padding-right: 0;
   margin-bottom: 0.5em;
-}
-.tabs.examples .tabs-content .tab > pre > code {
-  padding-top: 0.5em;
 }
 .tabs.examples pre:first-child {
   margin-top: 0;

--- a/docs/extra.js
+++ b/docs/extra.js
@@ -20,6 +20,17 @@ while (true) {
   tabContainer.insertBefore(firstTab);
   tabContainer.append(headerContainer, contentContainer)
 
+  // add extra classes from the first tab to the container
+  const classes = Array.from(firstTab[0].classList)
+
+  for (let i = 0; i < classes.length; i++) {
+    const element = classes[i];
+    if (element == 'tab' || element == 'admonition') {
+      continue
+    }
+    tabContainer.addClass(element)
+  }
+
   const selectTab = function (index) {
     headerContainer.children().removeClass('active')
     headerContainer.children().eq(index).addClass('active')

--- a/docs/options.md
+++ b/docs/options.md
@@ -753,30 +753,26 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
 
     # Build using the manylinux1 image to ensure manylinux1 wheels are produced
     # Not setting PyPy to manylinux1, since there is no manylinux1 PyPy image.
-    manylinux.x86_64-image = "manylinux1"
-    manylinux.i686-image = "manylinux1"
+    manylinux-x86_64-image = "manylinux1"
+    manylinux-i686-image = "manylinux1"
 
     # Build using the manylinux2014 image
-    manylinux.x86_64_image = "manylinux2014"
-    manylinux.i686-image = "manylinux2014"
-    manylinux.pypy_x86_64-image = "manylinux2014"
-    manylinux.pypy_i686-image = "manylinux2014"
+    manylinux-x86_64_image = "manylinux2014"
+    manylinux-i686-image = "manylinux2014"
+    manylinux-pypy_x86_64-image = "manylinux2014"
+    manylinux-pypy_i686-image = "manylinux2014"
 
     # Build using the latest manylinux2010 release, instead of the cibuildwheel
     # pinned version
-    manylinux.x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
-    manylinux.i686-image = "quay.io/pypa/manylinux2010_i686:latest"
-    manylinux.pypy_x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
-    manylinux.pypy_i686-image = "quay.io/pypa/manylinux2010_i686:latest"
+    manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
+    manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:latest"
+    manylinux-pypy_x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
+    manylinux-pypy_i686-image = "quay.io/pypa/manylinux2010_i686:latest"
 
     # Build using a different image from the docker registry
-    manylinux.x86_64-image = "dockcross/manylinux-x64"
-    manylinux.i686-image = "dockcross/manylinux-x86"
+    manylinux-x86_64-image = "dockcross/manylinux-x64"
+    manylinux-i686-image = "dockcross/manylinux-x86"
     ```
-
-    You can also place these inside `[tool.cibuildwheel.linux.manylinux]` to
-    above repeating the `manylinux.` portion on each line, following [standard
-    TOML rules][TOML].
 
 ### `CIBW_DEPENDENCY_VERSIONS` {: #dependency-versions}
 > Specify how cibuildwheel controls the versions of the tools it uses

--- a/docs/options.md
+++ b/docs/options.md
@@ -85,8 +85,7 @@ You can configure cibuildwheel with a `pyproject.toml` file. Options have the
 same names as the environment variable overrides, but are placed in
 `[tool.cibuildwheel]` and are lower case, with dashes, following common [TOML][]
 practice. Anything placed in subsections `linux`, `windows`, or `macos` will
-only affect those platforms. Lists can be used most places instead of strings
-where applicable, such as when listing commands (will be joined by `&&`).
+only affect those platforms. Lists can be used instead of strings for items that are natually a list.
 Multiline strings also work just like in in the environment variables.
 Environment variables will take precedence if defined.
 
@@ -129,7 +128,7 @@ Default: `auto`
 - For `macos`, you need a Mac machine. Note that cibuildwheel is going to install MacPython on your system, so you probably don't want to run this on your development machine.
 - For `windows`, you need to run in Windows. cibuildwheel will install required versions of Python to `C:\cibw\python` using NuGet.
 
-This option can also be set using the [command-line option](#command-line) `--platform`.
+This option can also be set using the [command-line option](#command-line) `--platform`. This option is not available in the `pyproject.toml` config.
 
 !!! tip
     If you have Docker installed, you can locally debug your cibuildwheel Linux config, instead of pushing to CI to test every change. For example:
@@ -140,7 +139,6 @@ This option can also be set using the [command-line option](#command-line) `--pl
     cibuildwheel --platform linux .
     ```
 
-This option is not available in the `pyproject.toml` config.
 
 ### `CIBW_BUILD`, `CIBW_SKIP` {: #build-skip}
 
@@ -170,6 +168,7 @@ For CPython, the minimally supported macOS version is 10.9; for PyPy 3.7, macOS 
 
 See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.x/) for past end of life versions of Python, and PyPy2.7.
 
+#### Examples
 
 !!! tab "Environment examples"
 
@@ -210,41 +209,49 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Only build on CPython 3.6
+    [tool.cibuildwheel]
     build = "cp36-*"
 
     # Skip building on CPython 3.6 on the Mac
+    [tool.cibuildwheel]
     skip = "cp36-macosx_x86_64"
 
     # Skip building on CPython 3.8 on the Mac
+    [tool.cibuildwheel]
     skip = "cp38-macosx_x86_64"
 
     # Skip building on CPython 3.6 on all platforms
+    [tool.cibuildwheel]
     skip = "cp36-*"
 
     # Skip CPython 3.6 on Windows
+    [tool.cibuildwheel]
     skip = "cp36-win*"
 
     # Skip CPython 3.6 on 32-bit Windows
+    [tool.cibuildwheel]
     skip = "cp36-win32"
 
     # Skip CPython 3.6 and CPython 3.7
+    [tool.cibuildwheel]
     skip = ["cp36-*", "cp37-*"]
 
     # Skip Python 3.6 on Linux
+    [tool.cibuildwheel]
     skip = "cp36-manylinux*"
 
     # Skip 32-bit builds
+    [tool.cibuildwheel]
     skip = ["*-win32", "*-manylinux_i686"]
 
     # Disable building PyPy wheels on all platforms
+    [tool.cibuildwheel]
     skip = "pp*"
     ```
 
     It is generally recommened to set `CIBW_BUILD` as a variable, though `skip`
-    tends to be useful in a config file; you can statically declare you don't
+    tends to be useful in a config file; you can statically declare that you don't
     support pypy, for example.
 
 <style>
@@ -310,6 +317,8 @@ Platform-specific variants also available:<br/>
 
 This option can also be set using the [command-line option](#command-line) `--archs`.
 
+#### Examples
+
 !!! tab "Environment examples"
 
     ```yaml
@@ -339,9 +348,9 @@ This option can also be set using the [command-line option](#command-line) `--ar
     archs: ["auto", "aarch64"]
     ```
 
-    It is generally recommmended to use the environment variable for Linux, as
-    selecting archs often depends on your specific runner having qemu
-    installed.
+    It is generally recommmended to use the environment variable or
+    command-line option for Linux, as selecting archs often depends
+    on your specific runner having qemu installed.
 
 
 ###  `CIBW_PROJECT_REQUIRES_PYTHON` {: #requires-python}
@@ -422,7 +431,7 @@ like to test wheel building with these versions, you can enable this flag.
 
 Default: Off (0) if Python is available in beta phase. No effect otherwise.
 
-This option can also be set using the [command-line option](#command-line) `--prerelease-pythons`.
+This option can also be set using the [command-line option](#command-line) `--prerelease-pythons`. This option is not available in the `pyproject.toml` config.
 
 #### Examples
 
@@ -446,6 +455,8 @@ To specify more than one environment variable, separate the assignments by space
 
 Platform-specific variants also available:<br/>
 `CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
+
+#### Examples
 
 !!! tab "Environment examples"
 
@@ -471,18 +482,20 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Set some compiler flags
+    [tool.cibuildwheel]
     environment = { CFLAGS="-g -Wall", CXXFLAGS="-Wall" }
 
     # Append a directory to the PATH variable (this is expanded in the build environment)
+    [tool.cibuildwheel]
     environment = { PATH="$PATH:/usr/local/bin" }
 
     # Set BUILD_TIME to the output of the `date` command
+    [tool.cibuildwheel]
     environment = { BUILD_TIME="$(date)" }
 
     # Supply options to `pip` to affect how it downloads dependencies
+    [tool.cibuildwheel]
     environment = { PIP_EXTRA_INDEX_URL="https://pypi.myorg.com/simple" }
 
     # Set two flags on linux only
@@ -557,6 +570,7 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific variants also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
+#### Examples
 
 !!! tab "Environment examples"
 
@@ -598,7 +612,8 @@ Platform-specific variants also available:<br/>
     before-build = "{package}/script/prepare_for_build.sh"
     ```
 
-    In configuration mode, you can use an inline array, and the items will be joined with `&&`.
+    In configuration mode, you can use an inline array, and the items will be joined with `&&`. In TOML, using a single-quote string will avoid escapes - useful for
+    Windows paths.
 
 !!! note
     If you need dependencies installed for the build, we recommend using
@@ -626,6 +641,7 @@ Platform-specific variants also available:<br/>
     [PyPA-build]: https://pypa-build.readthedocs.io/en/latest/
     [PEP 517]: https://www.python.org/dev/peps/pep-0517/
     [PEP 518]: https://www.python.org/dev/peps/pep-0517/
+
 
 ### `CIBW_REPAIR_WHEEL_COMMAND` {: #repair-wheel-command}
 > Execute a shell command to repair each (non-pure Python) built wheel
@@ -658,6 +674,8 @@ Platform-specific variants also available:<br/>
     Because delvewheel is still relatively early-stage, cibuildwheel does not yet run it by default. However, we'd recommend giving it a try! See the examples below for usage.
 
     [Delvewheel]: https://github.com/adang1345/delvewheel
+
+#### Examples
 
 !!! tab "Environment variables"
 
@@ -749,14 +767,14 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel.linux]
-
     # Build using the manylinux1 image to ensure manylinux1 wheels are produced
     # Not setting PyPy to manylinux1, since there is no manylinux1 PyPy image.
+    [tool.cibuildwheel]
     manylinux-x86_64-image = "manylinux1"
     manylinux-i686-image = "manylinux1"
 
     # Build using the manylinux2014 image
+    [tool.cibuildwheel]
     manylinux-x86_64_image = "manylinux2014"
     manylinux-i686-image = "manylinux2014"
     manylinux-pypy_x86_64-image = "manylinux2014"
@@ -764,15 +782,20 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
 
     # Build using the latest manylinux2010 release, instead of the cibuildwheel
     # pinned version
+    [tool.cibuildwheel]
     manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
     manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:latest"
     manylinux-pypy_x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
     manylinux-pypy_i686-image = "quay.io/pypa/manylinux2010_i686:latest"
 
     # Build using a different image from the docker registry
+    [tool.cibuildwheel]
     manylinux-x86_64-image = "dockcross/manylinux-x64"
     manylinux-i686-image = "dockcross/manylinux-x86"
     ```
+
+    Like any other option, these can be placed in `[tool.cibuildwheel.linux]`
+    if you perfer; they have no effect on `macos` and `windows`.
 
 ### `CIBW_DEPENDENCY_VERSIONS` {: #dependency-versions}
 > Specify how cibuildwheel controls the versions of the tools it uses
@@ -810,6 +833,8 @@ Platform-specific variants also available:<br/>
     dependency versions on Linux, use the [CIBW_MANYLINUX_*](#manylinux-image)
     options.
 
+#### Examples
+
 !!! tab "Environment examples"
 
     ```yaml
@@ -826,15 +851,16 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Use tools versions that are bundled with cibuildwheel (this is the default)
+    [tool.cibuildwheel]
     dependency-versions = "pinned"
 
     # Use the latest versions available on PyPI
+    [tool.cibuildwheel]
     dependency-versions = "latest"
 
     # Use your own pip constraints file
+    [tool.cibuildwheel]
     dependency-versions = "./constraints.txt"
     ```
 
@@ -861,6 +887,8 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific variants also available:<br/>
 `CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
+#### Examples
+
 !!! tab "Environment examples"
 
     ```yaml
@@ -877,15 +905,16 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Run the project tests against the installed wheel using `nose`
+    [tool.cibuildwheel]
     test-command = "nosetests {project}/tests"
 
     # Run the package tests using `pytest`
+    [tool.cibuildwheel]
     test-command = "pytest {package}/tests"
 
     # Trigger an install of the package, but run nothing of note
+    [tool.cibuildwheel]
     test-command = "echo Wheel installed"
     ```
 
@@ -904,6 +933,8 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
 Platform-specific variants also available:<br/>
  `CIBW_BEFORE_TEST_MACOS` | `CIBW_BEFORE_TEST_WINDOWS` | `CIBW_BEFORE_TEST_LINUX`
+
+#### Examples
 
 !!! tab "Environment examples"
 
@@ -924,18 +955,19 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Install test dependencies with overwritten environment variables.
+    [tool.cibuildwheel]
     before-test = "CC=gcc CXX=g++ pip install -r requirements.txt"
 
     # Chain commands using && or an Array
+    [tool.cibuildwheel]
     before-test = [
         "rm -rf ./data/cache",
         "mkdir -p ./data/cache",
     ]
 
     # Install non pip python package
+    [tool.cibuildwheel]
     before-test = [
         "cd some_dir",
         "./configure",
@@ -944,6 +976,7 @@ Platform-specific variants also available:<br/>
     ]
 
     # Install python packages that are required to install test dependencies
+    [tool.cibuildwheel]
     before-test = "pip install cmake scikit-build"
     ```
 
@@ -958,6 +991,8 @@ Space-separated list of dependencies required for running the tests.
 Platform-specific variants also available:<br/>
 `CIBW_TEST_REQUIRES_MACOS` | `CIBW_TEST_REQUIRES_WINDOWS` | `CIBW_TEST_REQUIRES_LINUX`
 
+#### Examples
+
 !!! tab "Environment examples"
 
     ```yaml
@@ -971,12 +1006,12 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Install pytest before running CIBW_TEST_COMMAND
+    [tool.cibuildwheel]
     test-requires = "pytest"
 
     # Install specific versions of test dependencies
+    [tool.cibuildwheel]
     test-requires = ["nose==1.3.7", "moto==0.4.31"]
     ```
 
@@ -1010,9 +1045,8 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
+    [tool.cibuildwheel]
     test-extras: ["test", "qt"]
     ```
 
@@ -1040,12 +1074,12 @@ With macOS `universal2` wheels, you can also skip the individual archs inside th
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Will avoid testing on emulated architectures
+    [tool.cibuildwheel]
     test-skip = "*-manylinux_{aarch64,ppc64le,s390x}"
 
     # Skip trying to test arm64 builds on Intel Macs
+    [tool.cibuildwheel]
     test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
     ```
 
@@ -1060,6 +1094,8 @@ An number from 1 to 3 to increase the level of verbosity (corresponding to invok
 Platform-specific variants also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX`
 
+#### Examples
+
 !!! tab "Environment examples"
 
     ```yaml
@@ -1070,9 +1106,8 @@ Platform-specific variants also available:<br/>
 !!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Increase pip debugging output
+    [tool.cibuildwheel]
     build-verbosity = 1
     ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -109,7 +109,8 @@ The complete set of defaults for the current version of cibuildwheel are shown b
     you run `cibuildwheel --plat linux`. This is preferred, but environment
     variables are better if you need to change per-matrix element
     (`CIBW_BUILD` is often in this category, for example), or if you cannot or do
-    not want to change a `pyproject.toml` file.
+    not want to change a `pyproject.toml` file. You can specify a different file to
+    use with `--config-file` on the command line, as well.
 
 
 ## Build selection
@@ -1117,18 +1118,18 @@ Platform-specific variants also available:<br/>
 ```text
 usage: cibuildwheel [-h] [--platform {auto,linux,macos,windows}]
                     [--archs ARCHS] [--output-dir OUTPUT_DIR]
-                    [--print-build-identifiers] [--allow-empty]
-                    [--prerelease-pythons]
+                    [--config-file CONFIG_FILE] [--print-build-identifiers]
+                    [--allow-empty] [--prerelease-pythons]
                     [package_dir]
 
 Build wheels for all the platforms.
 
 positional arguments:
   package_dir           Path to the package that you want wheels for. Must be
-                        a subdirectory of the working directory. When set, the
-                        working directory is still considered the 'project'
-                        and is copied into the Docker container on Linux.
-                        Default: the working directory.
+                        a subdirectory of the working directory. When set,
+                        the working directory is still considered the
+                        'project' and is copied into the Docker container on
+                        Linux. Default: the working directory.
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -1138,23 +1139,32 @@ optional arguments:
                         machine, and note that this script is going to
                         automatically install MacPython on your system, so
                         don't run on your development machine. For "windows",
-                        you need to run in Windows, and it will build and test
-                        for all versions of Python. Default: auto.
+                        you need to run in Windows, and it will build and
+                        test for all versions of Python. Default: auto.
   --archs ARCHS         Comma-separated list of CPU architectures to build
                         for. When set to 'auto', builds the architectures
-                        natively supported on this machine. Set this option to
-                        build an architecture via emulation, for example,
+                        natively supported on this machine. Set this option
+                        to build an architecture via emulation, for example,
                         using binfmt_misc and QEMU. Default: auto. Choices:
                         auto, auto64, auto32, native, all, x86_64, i686,
-                        aarch64, ppc64le, s390x, universal2, arm64, x86, AMD64
+                        aarch64, ppc64le, s390x, universal2, arm64, x86,
+                        AMD64
   --output-dir OUTPUT_DIR
                         Destination folder for the wheels.
+  --config-file CONFIG_FILE
+                        TOML config file for cibuildwheel; usually
+                        pyproject.toml, but can be overridden with this
+                        option. Use {package} for the package directory
   --print-build-identifiers
                         Print the build identifiers matched by the current
                         invocation and exit.
   --allow-empty         Do not report an error code if the build does not
                         match any wheels.
   --prerelease-pythons  Enable pre-release Python versions if available.
+
+Most options are supplied via environment variables or in --config-file
+(pyproject.toml usually). See https://github.com/pypa/cibuildwheel#options
+for info.
 ```
 
 <style>

--- a/docs/options.md
+++ b/docs/options.md
@@ -146,7 +146,7 @@ This option is not available in the `pyproject.toml` config.
 
 > Choose the Python versions to build
 
-Space-separated list of builds to build and skip. Each build has an identifier like `cp38-manylinux_x86_64` or `cp37-macosx_x86_64` - you can list specific ones to build and cibuildwheel will only build those, and/or list ones to skip and cibuildwheel won't try to build them.
+List of builds to build and skip. Each build has an identifier like `cp38-manylinux_x86_64` or `cp37-macosx_x86_64` - you can list specific ones to build and cibuildwheel will only build those, and/or list ones to skip and cibuildwheel won't try to build them.
 
 When both options are specified, both conditions are applied and only builds with a tag that matches `CIBW_BUILD` and does not match `CIBW_SKIP` will be built.
 
@@ -205,7 +205,9 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
     CIBW_SKIP: pp*
     ```
 
-!!! tab "Configuration examples"
+    Separate multiple selectors with a space.
+
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -229,13 +231,13 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
     skip = "cp36-win32"
 
     # Skip CPython 3.6 and CPython 3.7
-    skip = "cp36-* cp37-*"
+    skip = ["cp36-*", "cp37-*"]
 
     # Skip Python 3.6 on Linux
     skip = "cp36-manylinux*"
 
     # Skip 32-bit builds
-    skip = "*-win32 *-manylinux_i686"
+    skip = ["*-win32", "*-manylinux_i686"]
 
     # Disable building PyPy wheels on all platforms
     skip = "pp*"
@@ -268,7 +270,7 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
 ### `CIBW_ARCHS` {: #archs}
 > Change the architectures built on your machine by default.
 
-A space-separated list of architectures to build.
+A list of architectures to build.
 
 On macOS, this option can be used to cross-compile between `x86_64`,
 `universal2` and `arm64` for Apple Silicon support.
@@ -320,21 +322,24 @@ This option can also be set using the [command-line option](#command-line) `--ar
     CIBW_ARCHS_LINUX: "auto aarch64"
     ```
 
-!!! tab "Configuration examples"
+    Separate multiple archs with a space.
+
+!!! tab "pyproject.toml"
 
     ```toml
-    [cibuildwheel.toml]
 
     # Build `universal2` and `arm64` wheels on an Intel runner.
     # Note that the `arm64` wheel and the `arm64` part of the `universal2`
     # wheel cannot be tested in this configuration.
-    macos.archs: ["x86_64", "universal2", "arm64"]
+    [tool.cibuildwheel.macos]
+    archs: ["x86_64", "universal2", "arm64"]
 
     # On an Linux Intel runner with qemu installed, build Intel and ARM wheels
-    linux.archs: ["auto", "aarch64"]
+    [tool.cibuildwheel.linux]
+    archs: ["auto", "aarch64"]
     ```
 
-    It is generally recommmended to use the environment variable for Linx, as
+    It is generally recommmended to use the environment variable for Linux, as
     selecting archs often depends on your specific runner having qemu
     installed.
 
@@ -431,7 +436,7 @@ CIBW_PRERELEASE_PYTHONS: True
 ### `CIBW_ENVIRONMENT` {: #environment}
 > Set environment variables needed during the build
 
-A space-separated list of environment variables to set during the build. Bash syntax should be used, even on Windows.
+A list of environment variables to set during the build. Bash syntax should be used, even on Windows.
 
 You must set this variable to pass variables to Linux builds (since they execute in a Docker container). It also works for the other platforms.
 
@@ -461,7 +466,9 @@ Platform-specific variants also available:<br/>
     CIBW_ENVIRONMENT_LINUX: "BUILD_TIME=$(date) SAMPLE_TEXT=\"sample text\""
     ```
 
-!!! tab "Configuration examples"
+    Separate multiple values with a space.
+
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -479,7 +486,8 @@ Platform-specific variants also available:<br/>
     environment = { PIP_EXTRA_INDEX_URL="https://pypi.myorg.com/simple" }
 
     # Set two flags on linux only
-    linux.environment = { BUILD_TIME="$(date)", SAMPLE_TEXT="sample text" }
+    [tool.cibuildwheel.linux]
+    environment = { BUILD_TIME="$(date)", SAMPLE_TEXT="sample text" }
 
     # Alternate form with out-of-line table
     [tool.cibuildwheel.linux.environment]
@@ -516,16 +524,16 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_ALL_LINUX: yum install -y libffi-dev
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
-
     # Build third party library
+    [tool.cibuildwheel]
     before-all = "make -C third_party_lib"
 
     # Install system library
-    linux.before-all = "yum install -y libffi-dev"
+    [tool.cibuildwheel.linux]
+    before-all = "yum install -y libffi-dev"
     ```
 
     In configuration mode, you can use an inline array, and the items will be joined with `&&`.
@@ -566,24 +574,27 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_BUILD: "{package}/script/prepare_for_build.sh"
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
 
     # Install something required for the build (you might want to use pyproject.toml instead)
+    [tool.cibuildwheel]
     before-build = "pip install pybind11"
 
     # Chain commands using && or make an array.
-    linux.before-build = [
+    [tool.cibuildwheel.linux]
+    before-build = [
         "yum install -y libffi-dev",
         "make clean",
     ]
 
     # Run a script that's inside your project
+    [tool.cibuildwheel]
     before-build = "bash scripts/prepare_for_build.sh"
 
     # If cibuildwheel is called with a package_dir argument, it's available as {package}
+    [tool.cibuildwheel]
     before-build = "{package}/script/prepare_for_build.sh"
     ```
 
@@ -591,7 +602,8 @@ Platform-specific variants also available:<br/>
 
 !!! note
     If you need dependencies installed for the build, we recommend using
-    `pyproject.toml`. This is an example `pyproject.toml` file:
+    `pyproject.toml`'s `build-system.requires` instead. This is an example
+    `pyproject.toml` file:
 
         [build-system]
         requires = [
@@ -647,7 +659,7 @@ Platform-specific variants also available:<br/>
 
     [Delvewheel]: https://github.com/adang1345/delvewheel
 
-!!! tab "Environment examples"
+!!! tab "Environment variables"
 
     ```yaml
     # Use delvewheel on windows
@@ -661,7 +673,7 @@ Platform-specific variants also available:<br/>
     CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     # Use delvewheel on windows
@@ -734,10 +746,10 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
     CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
-    [tool.cibuildwheel]
+    [tool.cibuildwheel.linux]
 
     # Build using the manylinux1 image to ensure manylinux1 wheels are produced
     # Not setting PyPy to manylinux1, since there is no manylinux1 PyPy image.
@@ -762,9 +774,9 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
     manylinux.i686-image = "dockcross/manylinux-x86"
     ```
 
-    You can also place these inside `[tool.cibuildwheel.manylinux]` to above
-    repeating the `manylinux.` portion on each line, following
-    [standard TOML rules][TOML].
+    You can also place these inside `[tool.cibuildwheel.linux.manylinux]` to
+    above repeating the `manylinux.` portion on each line, following [standard
+    TOML rules][TOML].
 
 ### `CIBW_DEPENDENCY_VERSIONS` {: #dependency-versions}
 > Specify how cibuildwheel controls the versions of the tools it uses
@@ -815,7 +827,7 @@ Platform-specific variants also available:<br/>
     CIBW_DEPENDENCY_VERSIONS: ./constraints.txt
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -866,7 +878,7 @@ Platform-specific variants also available:<br/>
     CIBW_TEST_COMMAND: "echo Wheel installed"
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -913,7 +925,7 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_TEST: pip install cmake scikit-build
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -960,7 +972,7 @@ Platform-specific variants also available:<br/>
     CIBW_TEST_REQUIRES: nose==1.3.7 moto==0.4.31
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -978,7 +990,7 @@ Platform-specific variants also available:<br/>
 ### `CIBW_TEST_EXTRAS` {: #test-extras}
 > Install your wheel for testing using `extras_require`
 
-Comma-separated list of
+List of
 [extras_require](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies)
 options that should be included when installing the wheel prior to running the
 tests. This can be used to avoid having to redefine test dependencies in
@@ -994,10 +1006,12 @@ Platform-specific variants also available:<br/>
 
     ```yaml
     # Will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
-    CIBW_TEST_EXTRAS: test,qt
+    CIBW_TEST_EXTRAS: "test,qt"
     ```
 
-!!! tab "Configuration examples"
+    Seperate multiple items with a comma.
+
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -1027,7 +1041,7 @@ With macOS `universal2` wheels, you can also skip the individual archs inside th
     CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]
@@ -1057,7 +1071,7 @@ Platform-specific variants also available:<br/>
     CIBW_BUILD_VERBOSITY: 1
     ```
 
-!!! tab "Configuration examples"
+!!! tab "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel]

--- a/docs/options.md
+++ b/docs/options.md
@@ -4,13 +4,13 @@
 
 ## Setting options
 
-cibuildwheel is configured using environment variables that can be set using
-your CI config. You can also set these values in your `pyproject.toml` file,
-in a `[tool.cibuildwheel]` section.
+cibuildwheel can either be configured using environment variables, or from
+config file such as `pyproject.toml`.
 
-For example, to configure cibuildwheel to run tests, add the following YAML to
-your CI config file:
+### Environment variables {: #environment}
 
+Environment variables can be set in your CI config. For example, to configure
+cibuildwheel to run tests, add the following YAML to your CI config file:
 
 !!! tab "GitHub Actions"
 
@@ -77,9 +77,7 @@ your CI config file:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
     ```
 
-
-
-## Configuration {: #configuration}
+### Configuration file {: #configuration}
 
 You can configure cibuildwheel with a `pyproject.toml` file. Options have the
 same names as the environment variable overrides, but are placed in
@@ -313,7 +311,7 @@ If not listed above, `auto` is the same as `native`.
 [setup-qemu-action]: https://github.com/docker/setup-qemu-action
 [binfmt]: https://hub.docker.com/r/tonistiigi/binfmt
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
  `CIBW_ARCHS_MACOS` | `CIBW_ARCHS_WINDOWS` | `CIBW_ARCHS_LINUX`
 
 This option can also be set using the [command-line option](#command-line) `--archs`.
@@ -453,7 +451,7 @@ You can use `$PATH` syntax to insert other variables, or the `$(pwd)` syntax to 
 
 To specify more than one environment variable, separate the assignments by spaces.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_ENVIRONMENT_MACOS` | `CIBW_ENVIRONMENT_WINDOWS` | `CIBW_ENVIRONMENT_LINUX`
 
 #### Examples
@@ -524,8 +522,10 @@ The placeholder `{package}` can be used here; it will be replaced by the path to
 
 On Windows and macOS, the version of Python available inside `CIBW_BEFORE_ALL` is whatever is available on the host machine. On Linux, a modern Python version is available on PATH.
 
-Platform-specific variants also available:<br/>
- `CIBW_BEFORE_ALL_MACOS` | `CIBW_BEFORE_ALL_WINDOWS` | `CIBW_BEFORE_ALL_LINUX`
+Platform-specific environment variables also available:<br/>
+`CIBW_BEFORE_ALL_MACOS` | `CIBW_BEFORE_ALL_WINDOWS` | `CIBW_BEFORE_ALL_LINUX`
+
+#### Examples
 
 !!! tab examples "Environment variables"
 
@@ -567,7 +567,7 @@ The active Python binary can be accessed using `python`, and pip with `pip`; cib
 
 The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX`
 
 #### Examples
@@ -663,7 +663,7 @@ The following placeholders must be used inside the command and will be replaced 
 
 The command is run in a shell, so you can run multiple commands like `cmd1 && cmd2`.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_REPAIR_WHEEL_COMMAND_MACOS` | `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` | `CIBW_REPAIR_WHEEL_COMMAND_LINUX`
 
 !!! tip
@@ -824,7 +824,7 @@ here and it will be used instead.
     `./constraints-python37.txt` on Python 3.7, or fallback to
     `./constraints.txt` if that's not found.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_DEPENDENCY_VERSIONS_MACOS` | `CIBW_DEPENDENCY_VERSIONS_WINDOWS`
 
 !!! note
@@ -884,7 +884,7 @@ not be installed after building.
 
 The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
 #### Examples
@@ -931,7 +931,7 @@ The active Python binary can be accessed using `python`, and pip with `pip`; cib
 
 The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
  `CIBW_BEFORE_TEST_MACOS` | `CIBW_BEFORE_TEST_WINDOWS` | `CIBW_BEFORE_TEST_LINUX`
 
 #### Examples
@@ -988,7 +988,7 @@ Platform-specific variants also available:<br/>
 
 Space-separated list of dependencies required for running the tests.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_REQUIRES_MACOS` | `CIBW_TEST_REQUIRES_WINDOWS` | `CIBW_TEST_REQUIRES_LINUX`
 
 #### Examples
@@ -1028,7 +1028,7 @@ tests. This can be used to avoid having to redefine test dependencies in
 `CIBW_TEST_REQUIRES` if they are already defined in `setup.py` or
 `setup.cfg`.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_EXTRAS_MACOS` | `CIBW_TEST_EXTRAS_WINDOWS` | `CIBW_TEST_EXTRAS_LINUX`
 
 #### Examples
@@ -1091,7 +1091,7 @@ With macOS `universal2` wheels, you can also skip the individual archs inside th
 
 An number from 1 to 3 to increase the level of verbosity (corresponding to invoking pip with `-v`, `-vv`, and `-vvv`), between -1 and -3 (`-q`, `-qq`, and `-qqq`), or just 0 (default verbosity). These flags are useful while debugging a build when the output of the actual build invoked by `pip wheel` is required.
 
-Platform-specific variants also available:<br/>
+Platform-specific environment variables are also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX`
 
 #### Examples

--- a/docs/options.md
+++ b/docs/options.md
@@ -7,7 +7,7 @@
 cibuildwheel can either be configured using environment variables, or from
 config file such as `pyproject.toml`.
 
-### Environment variables {: #environment}
+### Environment variables {: #environment-variables}
 
 Environment variables can be set in your CI config. For example, to configure
 cibuildwheel to run tests, add the following YAML to your CI config file:
@@ -77,7 +77,7 @@ cibuildwheel to run tests, add the following YAML to your CI config file:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
     ```
 
-### Configuration file {: #configuration}
+### Configuration file {: #configuration-file}
 
 You can configure cibuildwheel with a `pyproject.toml` file. Options have the
 same names as the environment variable overrides, but are placed in

--- a/docs/options.md
+++ b/docs/options.md
@@ -531,7 +531,7 @@ Platform-specific environment variables also available:<br/>
     # Install system library
     CIBW_BEFORE_ALL_LINUX: yum install -y libffi-dev
 
-    # chain multiple commands using && and > in a YAML file, like:
+    # Chain multiple commands using && and > in a YAML file, like:
     CIBW_BEFORE_ALL: >
       yum install bzip2 -y &&
       make third_party
@@ -539,7 +539,8 @@ Platform-specific environment variables also available:<br/>
 
     For multiline commands, see the last example. The character `>` means that
     whitespace is collapsed to a single line, and '&&' between each command
-    ensures that errors are not ignored.
+    ensures that errors are not ignored. [Further reading on multiline YAML
+    here.](https://yaml-multiline.info).
 
 !!! tab examples "pyproject.toml"
 
@@ -552,10 +553,10 @@ Platform-specific environment variables also available:<br/>
     [tool.cibuildwheel.linux]
     before-all = "yum install -y libffi-dev"
 
-    # run multiple commands using an array
+    # Run multiple commands using an array
     before-all = [
-      'yum install bzip2 -y',
-      'make third_party',
+      "yum install bzip2 -y",
+      "make third_party",
     ]
     ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -171,7 +171,7 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Only build on CPython 3.6
@@ -207,7 +207,7 @@ See the [cibuildwheel 1 documentation](https://cibuildwheel.readthedocs.io/en/1.
 
     Separate multiple selectors with a space.
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Only build on CPython 3.6
@@ -320,7 +320,7 @@ This option can also be set using the [command-line option](#command-line) `--ar
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Build `universal2` and `arm64` wheels on an Intel runner.
@@ -334,10 +334,9 @@ This option can also be set using the [command-line option](#command-line) `--ar
 
     Separate multiple archs with a space.
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
-
     # Build `universal2` and `arm64` wheels on an Intel runner.
     # Note that the `arm64` wheel and the `arm64` part of the `universal2`
     # wheel cannot be tested in this configuration.
@@ -459,7 +458,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Set some compiler flags
@@ -480,7 +479,7 @@ Platform-specific variants also available:<br/>
 
     Separate multiple values with a space.
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Set some compiler flags
@@ -528,7 +527,7 @@ On Windows and macOS, the version of Python available inside `CIBW_BEFORE_ALL` i
 Platform-specific variants also available:<br/>
  `CIBW_BEFORE_ALL_MACOS` | `CIBW_BEFORE_ALL_WINDOWS` | `CIBW_BEFORE_ALL_LINUX`
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Build third party library
@@ -538,7 +537,7 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_ALL_LINUX: yum install -y libffi-dev
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Build third party library
@@ -573,7 +572,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Install something required for the build (you might want to use pyproject.toml instead)
@@ -589,7 +588,7 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_BUILD: "{package}/script/prepare_for_build.sh"
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
 
@@ -678,7 +677,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment variables"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Use delvewheel on windows
@@ -692,7 +691,7 @@ Platform-specific variants also available:<br/>
     CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Use delvewheel on windows
@@ -739,7 +738,7 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
 #### Examples
 
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Build using the manylinux1 image to ensure manylinux1 wheels are produced
@@ -765,7 +764,7 @@ Auditwheel detects the version of the manylinux standard in the Docker image thr
     CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Build using the manylinux1 image to ensure manylinux1 wheels are produced
@@ -836,7 +835,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Use tools versions that are bundled with cibuildwheel (this is the default)
@@ -849,7 +848,7 @@ Platform-specific variants also available:<br/>
     CIBW_DEPENDENCY_VERSIONS: ./constraints.txt
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Use tools versions that are bundled with cibuildwheel (this is the default)
@@ -890,7 +889,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Run the project tests against the installed wheel using `nose`
@@ -903,7 +902,7 @@ Platform-specific variants also available:<br/>
     CIBW_TEST_COMMAND: "echo Wheel installed"
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Run the project tests against the installed wheel using `nose`
@@ -937,7 +936,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Install test dependencies with overwritten environment variables.
@@ -953,7 +952,7 @@ Platform-specific variants also available:<br/>
     CIBW_BEFORE_TEST: pip install cmake scikit-build
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Install test dependencies with overwritten environment variables.
@@ -994,7 +993,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Install pytest before running CIBW_TEST_COMMAND
@@ -1004,7 +1003,7 @@ Platform-specific variants also available:<br/>
     CIBW_TEST_REQUIRES: nose==1.3.7 moto==0.4.31
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Install pytest before running CIBW_TEST_COMMAND
@@ -1034,7 +1033,7 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
@@ -1043,7 +1042,7 @@ Platform-specific variants also available:<br/>
 
     Seperate multiple items with a comma.
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
@@ -1062,7 +1061,7 @@ With macOS `universal2` wheels, you can also skip the individual archs inside th
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Will avoid testing on emulated architectures
@@ -1072,7 +1071,7 @@ With macOS `universal2` wheels, you can also skip the individual archs inside th
     CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Will avoid testing on emulated architectures
@@ -1097,14 +1096,14 @@ Platform-specific variants also available:<br/>
 
 #### Examples
 
-!!! tab "Environment examples"
+!!! tab examples "Environment variables"
 
     ```yaml
     # Increase pip debugging output
     CIBW_BUILD_VERBOSITY: 1
     ```
 
-!!! tab "pyproject.toml"
+!!! tab examples "pyproject.toml"
 
     ```toml
     # Increase pip debugging output

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,7 +1,3 @@
-## Options summary
-
-<div class="options-toc"></div>
-
 ## Setting options
 
 cibuildwheel can either be configured using environment variables, or from
@@ -79,13 +75,14 @@ cibuildwheel to run tests, add the following YAML to your CI config file:
 
 ### Configuration file {: #configuration-file}
 
-You can configure cibuildwheel with a `pyproject.toml` file. Options have the
-same names as the environment variable overrides, but are placed in
-`[tool.cibuildwheel]` and are lower case, with dashes, following common [TOML][]
-practice. Anything placed in subsections `linux`, `windows`, or `macos` will
-only affect those platforms. Lists can be used instead of strings for items that are natually a list.
-Multiline strings also work just like in in the environment variables.
-Environment variables will take precedence if defined.
+You can configure cibuildwheel with a config file, such as `pyproject.toml`.
+Options have the same names as the environment variable overrides, but are
+placed in `[tool.cibuildwheel]` and are lower case, with dashes, following
+common [TOML][] practice. Anything placed in subsections `linux`, `windows`,
+or `macos` will only affect those platforms. Lists can be used instead of
+strings for items that are natually a list. Multiline strings also work just
+like in in the environment variables. Environment variables will take
+precedence if defined.
 
 The example above using environment variables could have been written like this:
 
@@ -110,6 +107,9 @@ The complete set of defaults for the current version of cibuildwheel are shown b
     not want to change a `pyproject.toml` file. You can specify a different file to
     use with `--config-file` on the command line, as well.
 
+## Options summary
+
+<div class="options-toc"></div>
 
 ## Build selection
 
@@ -1124,10 +1124,10 @@ Build wheels for all the platforms.
 
 positional arguments:
   package_dir           Path to the package that you want wheels for. Must be
-                        a subdirectory of the working directory. When set,
-                        the working directory is still considered the
-                        'project' and is copied into the Docker container on
-                        Linux. Default: the working directory.
+                        a subdirectory of the working directory. When set, the
+                        working directory is still considered the 'project'
+                        and is copied into the Docker container on Linux.
+                        Default: the working directory.
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -1137,22 +1137,21 @@ optional arguments:
                         machine, and note that this script is going to
                         automatically install MacPython on your system, so
                         don't run on your development machine. For "windows",
-                        you need to run in Windows, and it will build and
-                        test for all versions of Python. Default: auto.
+                        you need to run in Windows, and it will build and test
+                        for all versions of Python. Default: auto.
   --archs ARCHS         Comma-separated list of CPU architectures to build
                         for. When set to 'auto', builds the architectures
-                        natively supported on this machine. Set this option
-                        to build an architecture via emulation, for example,
+                        natively supported on this machine. Set this option to
+                        build an architecture via emulation, for example,
                         using binfmt_misc and QEMU. Default: auto. Choices:
                         auto, auto64, auto32, native, all, x86_64, i686,
-                        aarch64, ppc64le, s390x, universal2, arm64, x86,
-                        AMD64
+                        aarch64, ppc64le, s390x, universal2, arm64, x86, AMD64
   --output-dir OUTPUT_DIR
                         Destination folder for the wheels.
   --config-file CONFIG_FILE
                         TOML config file for cibuildwheel; usually
                         pyproject.toml, but can be overridden with this
-                        option. Use {package} for the package directory
+                        option. Use {package} for the package directory.
   --print-build-identifiers
                         Print the build identifiers matched by the current
                         invocation and exit.
@@ -1161,8 +1160,9 @@ optional arguments:
   --prerelease-pythons  Enable pre-release Python versions if available.
 
 Most options are supplied via environment variables or in --config-file
-(pyproject.toml usually). See https://github.com/pypa/cibuildwheel#options
-for info.
+(pyproject.toml usually). See https://github.com/pypa/cibuildwheel#options for
+info.
+```
 ```
 
 <style>

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -200,7 +200,7 @@ def test_test_command(
 
     main()
 
-    assert intercepted_build_args.args[0].test_command == test_command
+    assert intercepted_build_args.args[0].test_command == (test_command or "")
 
 
 @pytest.mark.parametrize("before_build", [None, "before --build"])
@@ -217,7 +217,7 @@ def test_before_build(
 
     main()
 
-    assert intercepted_build_args.args[0].before_build == before_build
+    assert intercepted_build_args.args[0].before_build == (before_build or "")
 
 
 @pytest.mark.parametrize("build_verbosity", [None, 0, 2, -2, 4, -4])
@@ -286,7 +286,4 @@ def test_before_all(before_all, platform_specific, platform, intercepted_build_a
 
     main()
 
-    if before_all is None:
-        before_all = ""
-
-    assert intercepted_build_args.args[0].before_all == before_all
+    assert intercepted_build_args.args[0].before_all == (before_all or "")

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -68,3 +68,53 @@ def test_envvar_override(tmp_path, platform, monkeypatch):
         options("test-requires") == {"windows": "docs", "macos": "docs", "linux": "scod"}[platform]
     )
     assert options("test-command") == "mytest"
+
+
+def test_project_global_override_default_platform(tmp_path, platform):
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.cibuildwheel.global]
+repair-wheel-command = "repair-project-global"
+"""
+    )
+    options = ConfigOptions(tmp_path, platform=platform)
+    assert options("repair-wheel-command") == "repair-project-global"
+
+
+def test_env_global_override_default_platform(tmp_path, platform, monkeypatch):
+    monkeypatch.setenv("CIBW_REPAIR_WHEEL_COMMAND", "repair-env-global")
+    options = ConfigOptions(tmp_path, platform=platform)
+    assert options("repair-wheel-command") == "repair-env-global"
+
+
+def test_env_global_override_project_platform(tmp_path, platform, monkeypatch):
+    monkeypatch.setenv("CIBW_REPAIR_WHEEL_COMMAND", "repair-env-global")
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.cibuildwheel.linux]
+repair-wheel-command = "repair-project-linux"
+[tool.cibuildwheel.windows]
+repair-wheel-command = "repair-project-windows"
+[tool.cibuildwheel.macos]
+repair-wheel-command = "repair-project-macos"
+"""
+    )
+    options = ConfigOptions(tmp_path, platform=platform)
+    assert options("repair-wheel-command") == "repair-env-global"
+
+
+def test_global_platform_order(tmp_path, platform):
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.cibuildwheel.linux]
+repair-wheel-command = "repair-project-linux"
+[tool.cibuildwheel.windows]
+repair-wheel-command = "repair-project-windows"
+[tool.cibuildwheel.macos]
+repair-wheel-command = "repair-project-macos"
+[tool.cibuildwheel.global]
+repair-wheel-command = "repair-project-global"
+"""
+    )
+    options = ConfigOptions(tmp_path, platform=platform)
+    assert options("repair-wheel-command") == f"repair-project-{platform}"

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -11,8 +11,7 @@ test-command = "pyproject"
 test-requires = "something"
 test-extras = ["one", "two"]
 
-[tool.cibuildwheel.manylinux]
-x86_64-image = "manylinux1"
+manylinux-x86_64-image = "manylinux1"
 
 [tool.cibuildwheel.macos]
 test-requires = "else"
@@ -45,8 +44,8 @@ def test_simple_settings(tmp_path, platform):
     assert options("environment", sep=" ") == 'THING="OTHER" FOO="BAR"'
     assert options("test-extras", sep=",") == "one,two"
 
-    assert options("manylinux.x86_64-image") == "manylinux1"
-    assert options("manylinux.i686-image") == "manylinux2010"
+    assert options("manylinux-x86_64-image") == "manylinux1"
+    assert options("manylinux-i686-image") == "manylinux2010"
 
 
 def test_envvar_override(tmp_path, platform, monkeypatch):
@@ -64,8 +63,8 @@ def test_envvar_override(tmp_path, platform, monkeypatch):
     assert options("archs", sep=" ") == "auto"
 
     assert options("build", sep=" ") == "cp38*"
-    assert options("manylinux.x86_64-image") == "manylinux2014"
-    assert options("manylinux.i686-image") == "manylinux2010"
+    assert options("manylinux-x86_64-image") == "manylinux2014"
+    assert options("manylinux-i686-image") == "manylinux2010"
 
     assert (
         options("test-requires", sep=" ")

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -31,7 +31,7 @@ def test_simple_settings(tmp_path, platform, fname):
     with tmp_path.joinpath(fname).open("w") as f:
         f.write(PYPROJECT_1)
 
-    options = ConfigOptions(tmp_path, f"{{project}}/{fname}", platform=platform)
+    options = ConfigOptions(tmp_path, f"{{package}}/{fname}", platform=platform)
 
     assert options("build", env_plat=False, sep=" ") == "cp39*"
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -5,9 +5,11 @@ from cibuildwheel.options import ConfigOptions
 PYPROJECT_1 = """
 [tool.cibuildwheel]
 build = "cp39*"
+environment = {THING = "OTHER", FOO="BAR"}
 
 test-command = "pyproject"
 test-requires = "something"
+test-extras = ["one", "two"]
 
 [tool.cibuildwheel.manylinux]
 x86_64-image = "manylinux1"
@@ -16,7 +18,7 @@ x86_64-image = "manylinux1"
 test-requires = "else"
 
 [tool.cibuildwheel.linux]
-test-requires = "other"
+test-requires = ["other", "many"]
 """
 
 
@@ -37,8 +39,11 @@ def test_simple_settings(tmp_path, platform):
     assert options("archs") == "auto"
     assert (
         options("test-requires")
-        == {"windows": "something", "macos": "else", "linux": "other"}[platform]
+        == {"windows": "something", "macos": "else", "linux": "other many"}[platform]
     )
+
+    assert options("environment") == 'THING="OTHER" FOO="BAR"'
+    assert options("test-extras", sep=",") == "one,two"
 
     assert options("manylinux.x86_64-image") == "manylinux1"
     assert options("manylinux.i686-image") == "manylinux2010"
@@ -58,12 +63,7 @@ def test_envvar_override(tmp_path, platform, monkeypatch):
 
     assert options("archs") == "auto"
 
-    assert (
-        options(
-            "build",
-        )
-        == "cp38*"
-    )
+    assert options("build") == "cp38*"
     assert options("manylinux.x86_64-image") == "manylinux2014"
     assert options("manylinux.i686-image") == "manylinux2010"
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -26,11 +26,12 @@ def platform(request):
     return request.param
 
 
-def test_simple_settings(tmp_path, platform):
-    with tmp_path.joinpath("pyproject.toml").open("w") as f:
+@pytest.mark.parametrize("fname", ["pyproject.toml", "cibuildwheel.toml"])
+def test_simple_settings(tmp_path, platform, fname):
+    with tmp_path.joinpath(fname).open("w") as f:
         f.write(PYPROJECT_1)
 
-    options = ConfigOptions(tmp_path, platform=platform)
+    options = ConfigOptions(tmp_path, f"{{project}}/{fname}", platform=platform)
 
     assert options("build", env_plat=False, sep=" ") == "cp39*"
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from cibuildwheel.options import ConfigNamespace, ConfigOptions
+
+PYPROJECT_1 = """
+[tool.cibuildwheel]
+build = "cp39*"
+
+[tool.cibuildwheel.manylinux]
+x86_64-image = "manylinux1"
+
+[tool.cibuildwheel.global]
+test-command = "pyproject"
+test-requires = "something"
+
+[tool.cibuildwheel.macos]
+test-requires = "else"
+
+[tool.cibuildwheel.linux]
+test-requires = "other"
+"""
+
+
+@pytest.fixture(params=["linux", "macos", "windows"])
+def platform(request):
+    return request.param
+
+
+def test_simple_settings(tmp_path, platform):
+    with tmp_path.joinpath("pyproject.toml").open("w") as f:
+        f.write(PYPROJECT_1)
+
+    options = ConfigOptions(tmp_path, platform=platform)
+
+    assert options("build", namespace=ConfigNamespace.MAIN) == "cp39*"
+    assert options("output-dir", namespace=ConfigNamespace.MAIN) == "wheelhouse"
+
+    assert options("test-command") == "pyproject"
+    assert options("archs") == "auto"
+    assert (
+        options("test-requires")
+        == {"windows": "something", "macos": "else", "linux": "other"}[platform]
+    )
+
+    assert options("x86_64-image", namespace=ConfigNamespace.MANYLINUX) == "manylinux1"
+    assert options("i686-image", namespace=ConfigNamespace.MANYLINUX) == "manylinux2010"
+
+
+def test_envvar_override(tmp_path, platform, monkeypatch):
+    monkeypatch.setenv("CIBW_BUILD", "cp38*")
+    monkeypatch.setenv("CIBW_MANYLINUX_X86_64_IMAGE", "manylinux2014")
+    monkeypatch.setenv("CIBW_TEST_COMMAND", "mytest")
+    monkeypatch.setenv("CIBW_TEST_REQUIRES", "docs")
+    monkeypatch.setenv("CIBW_TEST_REQUIRES_LINUX", "scod")
+
+    with tmp_path.joinpath("pyproject.toml").open("w") as f:
+        f.write(PYPROJECT_1)
+
+    options = ConfigOptions(tmp_path, platform=platform)
+
+    assert options("archs") == "auto"
+
+    assert options("build", namespace=ConfigNamespace.MAIN) == "cp38*"
+    assert options("x86_64-image", namespace=ConfigNamespace.MANYLINUX) == "manylinux2014"
+    assert options("i686-image", namespace=ConfigNamespace.MANYLINUX) == "manylinux2010"
+
+    assert (
+        options("test-requires") == {"windows": "docs", "macos": "docs", "linux": "scod"}[platform]
+    )
+    assert options("test-command") == "mytest"

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -161,3 +161,16 @@ build = ["1", "2"]
     assert "1, 2" == options("build", sep=", ")
     with pytest.raises(ConfigOptionError):
         options("build")
+
+
+def test_disallowed_a(tmp_path):
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.cibuildwheel.windows]
+manylinux-x64_86-image = "manylinux1"
+"""
+    )
+    disallow = {"windows": {"manylinux-x64_86-image"}}
+    ConfigOptions(tmp_path, platform="linux", disallow=disallow)
+    with pytest.raises(ConfigOptionError):
+        ConfigOptions(tmp_path, platform="windows", disallow=disallow)

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -42,11 +42,25 @@ def test_simple_settings(tmp_path, platform, fname):
         == {"windows": "something", "macos": "else", "linux": "other many"}[platform]
     )
 
-    assert options("environment", sep=" ") == 'THING="OTHER" FOO="BAR"'
+    # Also testing options for support for both lists and tables
+    assert (
+        options("environment", table={"item": '{k}="{v}"', "sep": " "}) == 'THING="OTHER" FOO="BAR"'
+    )
+    assert (
+        options("environment", sep="x", table={"item": '{k}="{v}"', "sep": " "})
+        == 'THING="OTHER" FOO="BAR"'
+    )
     assert options("test-extras", sep=",") == "one,two"
+    assert options("test-extras", sep=",", table={"item": '{k}="{v}"', "sep": " "}) == "one,two"
 
     assert options("manylinux-x86_64-image") == "manylinux1"
     assert options("manylinux-i686-image") == "manylinux2010"
+
+    with pytest.raises(ConfigOptionError):
+        options("environment", sep=" ")
+
+    with pytest.raises(ConfigOptionError):
+        options("test-extras", table={"item": '{k}="{v}"', "sep": " "})
 
 
 def test_envvar_override(tmp_path, platform, monkeypatch):

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -33,16 +33,16 @@ def test_simple_settings(tmp_path, platform):
 
     options = ConfigOptions(tmp_path, platform=platform)
 
-    assert options("build", env_plat=False) == "cp39*"
+    assert options("build", env_plat=False, sep=" ") == "cp39*"
 
     assert options("test-command") == "pyproject"
-    assert options("archs") == "auto"
+    assert options("archs", sep=" ") == "auto"
     assert (
-        options("test-requires")
+        options("test-requires", sep=" ")
         == {"windows": "something", "macos": "else", "linux": "other many"}[platform]
     )
 
-    assert options("environment") == 'THING="OTHER" FOO="BAR"'
+    assert options("environment", sep=" ") == 'THING="OTHER" FOO="BAR"'
     assert options("test-extras", sep=",") == "one,two"
 
     assert options("manylinux.x86_64-image") == "manylinux1"
@@ -61,14 +61,15 @@ def test_envvar_override(tmp_path, platform, monkeypatch):
 
     options = ConfigOptions(tmp_path, platform=platform)
 
-    assert options("archs") == "auto"
+    assert options("archs", sep=" ") == "auto"
 
-    assert options("build") == "cp38*"
+    assert options("build", sep=" ") == "cp38*"
     assert options("manylinux.x86_64-image") == "manylinux2014"
     assert options("manylinux.i686-image") == "manylinux2010"
 
     assert (
-        options("test-requires") == {"windows": "docs", "macos": "docs", "linux": "scod"}[platform]
+        options("test-requires", sep=" ")
+        == {"windows": "docs", "macos": "docs", "linux": "scod"}[platform]
     )
     assert options("test-command") == "mytest"
 


### PR DESCRIPTION
Closes #547.

Design:

`tool.cibuildwheel` holds options with a structure that exactly matches the environment variables, just with dashes used instead of `_` to match TOML style. `tool.cibuildwheel.<platform>` holds the platform specific commands; these are identical but override the global value if defined and running on that platform. The defaults are defined in `cibuildwheel/resources/defaults.toml`. Environment variables override the pyproject.toml values, which override the defaults.toml values. An error is thrown if an unexpected option is found inside `tool.cibuildwheel` or a section based on what was found in the defaults.toml file.

`CIBW_PROJECT_REQUIRES_PYTHON` does not participate, since it has a canonical location in the pyproject.toml file already, and `CIBW_PLATFORM` really is only intended to be non-static, so it also does not participate. I have also removed `CIBW_OUTPUT_DIR`; having that "hidden" in a config file might be confusing? It's already a command line option, an action option, and an environment variable. Also this avoids having a way to specify it per platform.

I have not added a check to see if `manylinux-*` is in windows/macOS sections (it would do nothing if placed there), or `dependency-versions` in linux. Those could be added later.

Tables and arrays automatically stringify using `sep`, so those are recommended but not required for use for things like environment and extras. Strings always behave exactly the same as in the environment variables.

`defaults.toml`, which serves as the canonical source for defaults, and an example:

```toml
[tool.cibuildwheel]
build = "*"
skip = ""
test-skip = ""

archs = ["auto"]
dependency-versions = "pinned"
environment = {}
build-verbosity = ""

before-all = ""
before-build = ""
repair-wheel-command = ""

test-command = ""
before-test = ""
test-requires = []
test-extras = []

manylinux-x86_64-image = "manylinux2010"
manylinux-i686-image = "manylinux2010"
manylinux-aarch64-image = "manylinux2014"
manylinux-ppc64le-image = "manylinux2014"
manylinux-s390x-image = "manylinux2014"
manylinux-pypy_x86_64-image = "manylinux2010"
manylinux-pypy_i686-image = "manylinux2010"
manylinux-pypy_aarch64-image = "manylinux2014"


[tool.cibuildwheel.linux]
repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"

[tool.cibuildwheel.macos]
repair-wheel-command = [
  "delocate-listdeps {wheel}",
  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
]

[tool.cibuildwheel.windows]
```
