### PR TITLE
Temporarily disable CircleCI mac 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,6 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      - osx-python3.6
+      # disabled until CircleCI enable open-source mac builds on pypa
+      # - osx-python3.6
       - linux-python3.6


### PR DESCRIPTION
I'm still waiting to hear back from CircleCI about the Mac builds, so I'm disabling this for now.
