### PR TITLE
Remove macOS build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,6 @@ jobs:
       arch: ppc64le
       env: PYTHON=python
 
-    - name: macOS | x86_64 | Python 3.x
-      os: osx
-      env:
-        - PYTHON=python3
-        - PYTEST_ADDOPTS='-k "unit_test or test_0_basic" --suppress-no-test-exit-code'
-
     - name: Windows | x86_64 | Python 3.6
       os: windows
       language: shell

--- a/CI.md
+++ b/CI.md
@@ -1,12 +1,11 @@
 This is a summary of the Python versions and platforms covered by the different CI platforms:
 
-|          | 3.6                          | 3.7                                      | 3.8              |
-|----------|------------------------------|------------------------------------------|------------------|
-| Linux    | Travis CI / CircleCI         | AppVeyor² / GitHub Actions               | Azure Pipelines  |
-| macOS    | CircleCI                     | AppVeyor² / Travis CI¹ / GitHub Actions  | Azure Pipelines  |
-| Windows  | Travis CI / Azure Pipelines  | AppVeyor² / GitHub Actions               | Azure Pipelines  |
+|          | 3.6                          | 3.7                         | 3.8              |
+|----------|------------------------------|-----------------------------|------------------|
+| Linux    | Travis CI / CircleCI         | AppVeyor¹ / GitHub Actions  | Azure Pipelines  |
+| macOS    | CircleCI                     | AppVeyor¹ / GitHub Actions  | Azure Pipelines  |
+| Windows  | Travis CI / Azure Pipelines  | AppVeyor¹ / GitHub Actions  | Azure Pipelines  |
 
-> ¹ Python version not really pinned, but dependent on the (default) version of image used.
-> ² AppVeyor only runs the "basic" test to reduce load.
+> ¹ AppVeyor only runs the "basic" test to reduce load.
 
 Non-x86 architectures are covered on Travis CI using Python 3.6.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Usage
 |-----------------|-------|-------|---------|--------------|
 | GitHub Actions  | ✅    | ✅    | ✅      | ✅¹           |
 | Azure Pipelines | ✅    | ✅    | ✅      |              |
-| Travis CI       | ✅    | ✅    | ✅      | ✅           |
+| Travis CI       | ✅    |       | ✅      | ✅           |
 | AppVeyor        | ✅    | ✅    | ✅      |              |
 | CircleCI        | ✅    | ✅    |         |              |
 | Gitlab CI       | ✅    |       |         |              |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -113,9 +113,9 @@ Commit this file, enable building of your repo on Azure Pipelines, and push.
 
 Wheels will be stored for you and available through the Pipelines interface. For more info on this file, check out the [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema).
 
-# Travis CI [linux/mac/windows] {: #travis-ci}
+# Travis CI [linux/windows] {: #travis-ci}
 
-To build Linux, Mac, and Windows wheels on Travis CI, create a `.travis.yml` file in your repo.
+To build Linux and Windows wheels on Travis CI, create a `.travis.yml` file in your repo.
 
 > .travis.yml
 

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -7,9 +7,6 @@ jobs:
   include:
     # perform a linux build
     - services: docker
-    # and a mac build
-    - os: osx
-      language: shell
     # and a windows build
     - os: windows
       language: shell

--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -13,9 +13,6 @@ jobs:
     # perform a linux S390X build
     - services: docker
       arch: s390x
-    # and a mac build
-    - os: osx
-      language: shell
     # and a windows build
     - os: windows
       language: shell

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -60,16 +60,6 @@ jobs:
       after_success: |
         python3 -m pip install twine
         python3 -m twine upload --skip-existing wheelhouse/*.whl
-    # Deploy on mac
-    - stage: deploy
-      name: Build and deploy macOS wheels
-      os: osx
-      language: shell
-      install: python3 -m pip install cibuildwheel==1.11.0
-      script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: |
-        python3 -m pip install twine
-        python3 -m twine upload --skip-existing wheelhouse/*.whl
     # Deploy on windows
     - stage: deploy
       name: Build and deploy Windows wheels


### PR DESCRIPTION
Leaving macOS results in an "Not enough credits" on travis-ci.com
