### PR TITLE
Revert "Temporarily disable CircleCI mac builds (#685)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,5 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      # disabled until CircleCI enable open-source mac builds on pypa
-      # - osx-python3.6
+      - osx-python3.6
       - linux-python3.6


### PR DESCRIPTION
This reverts commit af45aface9ca3366b7a75148dcd62b8ffb9640ce.