### PR TITLE
Fix Travis CI tests on ppc64le/s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
       env: PYTHON=python
 
     - name: Linux | arm64 | Python 3.6
+      dist: focal
       language: python
       python: 3.6
       services: docker
@@ -20,6 +21,7 @@ jobs:
       env: PYTHON=python
 
     - name: Linux | ppc64le | Python 3.6
+      dist: focal
       language: python
       python: 3.6
       services: docker
@@ -36,17 +38,13 @@ jobs:
       env:
         - PYTHON=C:\\Python36\\python
 
-    - &linux_s390x_36
-      name: Linux | s390x | Python 3.6
+    - name: Linux | s390x | Python 3.6
+      dist: focal
       language: python
       python: 3.6
       services: docker
       arch: s390x
       env: PYTHON=python
-
-  allow_failures:
-    # must repeat the s390x job above exactly to match
-    - *linux_s390x_36
 
 install: $PYTHON -m pip install -e ".[dev]" pytest-custom-exit-code
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ jobs:
       arch: ppc64le
       env:
         - PYTHON=python
+        # skip test_manylinuxXXXX_only, it uses too much disk space
+        # c.f. https://travis-ci.community/t/running-out-of-disk-space-quota-when-using-docker-on-ppc64le/11634
         - PYTEST_ADDOPTS='-k "not test_manylinuxXXXX_only"'
 
     - name: Windows | x86_64 | Python 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ jobs:
       python: 3.6
       services: docker
       arch: ppc64le
-      env: PYTHON=python
+      env:
+        - PYTHON=python
+        - PYTEST_ADDOPTS='-k "not test_manylinuxXXXX_only"'
 
     - name: Windows | x86_64 | Python 3.6
       os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: minimal
+os: linux
+dist: focal
+language: python
 
 branches:
   only:
@@ -7,22 +9,17 @@ branches:
 jobs:
   include:
     - name: Linux | x86_64 + i686 | Python 3.6
-      language: python
       python: 3.6
       services: docker
       env: PYTHON=python
 
     - name: Linux | arm64 | Python 3.6
-      dist: focal
-      language: python
       python: 3.6
       services: docker
       arch: arm64
       env: PYTHON=python
 
     - name: Linux | ppc64le | Python 3.6
-      dist: focal
-      language: python
       python: 3.6
       services: docker
       arch: ppc64le
@@ -39,8 +36,6 @@ jobs:
         - PYTHON=C:\\Python36\\python
 
     - name: Linux | s390x | Python 3.6
-      dist: focal
-      language: python
       python: 3.6
       services: docker
       arch: s390x

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -1,6 +1,8 @@
 # As written, this configuration will build your wheels on every
 # commit, but will only push to PyPI on tagged commits.
 
+os: linux
+dist: focal
 language: python
 
 jobs:

--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: focal
 language: python
 
 jobs:

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -5,6 +5,8 @@
 # repo is yours (e.g. it won't run on a Pull Request). For convenience, a source
 # distribution is also created.
 
+os: linux
+dist: focal
 language: python
 python:
   - 3.6

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import textwrap
 
@@ -44,9 +45,12 @@ project_with_manylinux_symbols = test_projects.new_c_project(
     "manylinux_image", ["manylinux1", "manylinux2010", "manylinux2014", "manylinux_2_24"]
 )
 def test(manylinux_image, tmp_path):
+    pm = platform.machine()
     if utils.platform != "linux":
         pytest.skip("the docker test is only relevant to the linux build")
-    elif platform.machine() not in ["x86_64", "i686"]:
+    elif pm == "ppc64le" and "TRAVIS" in os.environ:
+        pytest.skip("this test requires too much disk space for this runner")
+    elif pm not in ["x86_64", "i686"]:
         if manylinux_image in ["manylinux1", "manylinux2010"]:
             pytest.skip("manylinux1 and 2010 doesn't exist for non-x86 architectures")
 

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import textwrap
 
@@ -45,12 +44,9 @@ project_with_manylinux_symbols = test_projects.new_c_project(
     "manylinux_image", ["manylinux1", "manylinux2010", "manylinux2014", "manylinux_2_24"]
 )
 def test(manylinux_image, tmp_path):
-    pm = platform.machine()
     if utils.platform != "linux":
         pytest.skip("the docker test is only relevant to the linux build")
-    elif pm == "ppc64le" and "TRAVIS" in os.environ:
-        pytest.skip("this test requires too much disk space for this runner")
-    elif pm not in ["x86_64", "i686"]:
+    elif platform.machine() not in ["x86_64", "i686"]:
         if manylinux_image in ["manylinux1", "manylinux2010"]:
             pytest.skip("manylinux1 and 2010 doesn't exist for non-x86 architectures")
 


### PR DESCRIPTION
- Disable manylinux only tests on Travis CI ppc64le
Those tests are taking too much disk space for the Travis CI runner right now.
c.f. https://travis-ci.community/t/running-out-of-disk-space-quota-when-using-docker-on-ppc64le/11634

- Use focal to run aarch64/ppc64le/s390x jobs on Travis CI
This removes allow_failures from the Travis CI s390x job which used a buggy xenial image.
