### PR TITLE
fix: docker run example and requirements paths

### DIFF
--- a/bin/update_dependencies.py
+++ b/bin/update_dependencies.py
@@ -18,18 +18,15 @@ env = os.environ.copy()
 # regenerate the constraints files
 env["CUSTOM_COMPILE_COMMAND"] = "bin/update_dependencies.py"
 
-if python_version == "36":
-    # Bug with click and Python 3.6
-    env["LC_ALL"] = "C.UTF-8"
-    env["LANG"] = "C.UTF-8"
+os.chdir(DIR.parent)
 
 subprocess.run(
     [
         "pip-compile",
         "--allow-unsafe",
         "--upgrade",
-        f"{RESOURCES}/constraints.in",
-        f"--output-file={RESOURCES}/constraints-python{python_version}.txt",
+        "cibuildwheel/resources/constraints.in",
+        f"--output-file=cibuildwheel/resources/constraints-python{python_version}.txt",
     ],
     check=True,
     env=env,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,7 +52,7 @@ nox -s build         # Make SDist and wheel
 More advanced users can run the update scripts. `update_pins` should work directly, but `update_constraints` needs all versions of Python installed. If you don't want to do that locally, a fast way to run it to use docker to run nox:
 
 ```console
-docker run --rm -it -v $PWD:/src quay.io/pypa/manylinux2010_x86_64:latest pipx run nox -f src/noxfile.py -s update_constraints
+docker run --rm -itv $PWD:/src -w /src quay.io/pypa/manylinux_2_24_x86_64:latest pipx run nox -s update_constraints
 ```
 
 ### Local testing


### PR DESCRIPTION
The current docker command doesn't work.

For Python 3.6, the `manylinux{1,2010,2014}` images have an ~~incorrectly configured encoding~~, so click just crashes with complaints about the encoding. `manylinux_2_24` doesn't have this issue. (It's also more compatible == better for _running_ wheels) This was in #661 but got changed to manylinux2010 before merging. EDIT: No, it was forcing the locale to one that was missing; removing that fixes it. I still think this might be a slightly better image?

Second, the paths printed out in the constraint files are wrong - they have a `/src` added to them. Fixed, and setting the working directory makes the docker line a little simpler, I think.

