### PR TITLE
feat: support building universal/arm64 from x64_86 Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ What does it do?
 ----------------
 
 |   | macOS Intel | macOS Apple Silicon | Windows 64bit | Windows 32bit | manylinux x86_64 | manylinux i686 | manylinux aarch64 | manylinux ppc64le | manylinux s390x |
-|---|---|---|---|---|---|---|---|---|---|
-| CPython 3.6     | ✅ | N/A | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CPython 3.7     | ✅ | N/A | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CPython 3.8     | ✅ | N/A¹ | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CPython 3.9     | ✅ | ✅ | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CPython 3.10²   | ✅ | ✅ | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| PyPy 3.7 v7.3   | ✅ | N/A | ✅  | N/A | ✅ | ✅  | ✅  | N/A | N/A |
+|---------------|----|-----|-----|-----|----|-----|----|-----|-----|
+| CPython 3.6   | ✅ | N/A | ✅  | ✅  | ✅ | ✅  | ✅ | ✅  | ✅  |
+| CPython 3.7   | ✅ | N/A | ✅  | ✅  | ✅ | ✅  | ✅ | ✅  | ✅  |
+| CPython 3.8   | ✅ | ✅  | ✅  | ✅  | ✅ | ✅  | ✅ | ✅  | ✅  |
+| CPython 3.9   | ✅ | ✅  | ✅  | ✅  | ✅ | ✅  | ✅ | ✅  | ✅  |
+| CPython 3.10¹ | ✅ | ✅  | ✅  | ✅  | ✅ | ✅  | ✅ | ✅  | ✅  |
+| PyPy 3.7 v7.3 | ✅ | N/A | ✅  | N/A | ✅ | ✅  | ✅ | N/A | N/A |
 
-<sup>¹ CPython 3.8's final binary release has experimental Universal2 support, but does not support macOS 10.x, so this is not currently available.</sup><br>
-<sup>² Available as a prerelease under a [flag](https://cibuildwheel.readthedocs.io/en/stable/options/#prerelease-pythons)</sup><br>
+<sup>¹ Available as a prerelease under a [flag](https://cibuildwheel.readthedocs.io/en/stable/options/#prerelease-pythons)</sup><br>
 
 - Builds manylinux, macOS 10.9+, and Windows wheels for CPython and PyPy
 - Works on GitHub Actions, Azure Pipelines, Travis CI, AppVeyor, CircleCI, and GitLab CI
@@ -48,7 +47,7 @@ Usage
 
 |                 | Linux | macOS | Windows | Linux ARM |
 |-----------------|-------|-------|---------|--------------|
-| GitHub Actions  | ✅    | ✅    | ✅      | ✅¹           |
+| GitHub Actions  | ✅    | ✅    | ✅      | ✅¹          |
 | Azure Pipelines | ✅    | ✅    | ✅      |              |
 | Travis CI       | ✅    |       | ✅      | ✅           |
 | AppVeyor        | ✅    | ✅    | ✅      |              |

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -270,22 +270,20 @@ def setup_python(
     config_is_arm64 = python_configuration.identifier.endswith("arm64")
     config_is_universal2 = python_configuration.identifier.endswith("universal2")
 
-    if python_configuration.version not in {"3.6", "3.7", "3.8"}:
-        if python_configuration.identifier.endswith("x86_64"):
-            # even on the macos11.0 Python installer, on the x86_64 side it's
-            # compatible back to 10.9.
-            env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-x86_64")
-            env.setdefault("ARCHFLAGS", "-arch x86_64")
-        elif config_is_arm64:
+    if python_configuration.version not in {"3.6", "3.7"}:
+        if config_is_arm64:
             # macOS 11 is the first OS with arm64 support, so the wheels
             # have that as a minimum.
             env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-11.0-arm64")
             env.setdefault("ARCHFLAGS", "-arch arm64")
         elif config_is_universal2:
-            if get_macos_version() < (10, 16):
-                # we can do universal2 builds on macos 10.15, but we need to
-                # set ARCHFLAGS otherwise CPython sets it to `-arch x86_64`
-                env.setdefault("ARCHFLAGS", "-arch arm64 -arch x86_64")
+            env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-universal2")
+            env.setdefault("ARCHFLAGS", "-arch arm64 -arch x86_64")
+        elif python_configuration.identifier.endswith("x86_64"):
+            # even on the macos11.0 Python installer, on the x86_64 side it's
+            # compatible back to 10.9.
+            env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-x86_64")
+            env.setdefault("ARCHFLAGS", "-arch x86_64")
 
     building_arm64 = config_is_arm64 or config_is_universal2
     if building_arm64 and get_macos_version() < (10, 16) and "SDKROOT" not in env:

--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -35,6 +35,8 @@ python_configurations = [
   { identifier = "cp36-macosx_x86_64", version = "3.6", url = "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg" },
   { identifier = "cp37-macosx_x86_64", version = "3.7", url = "https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg" },
   { identifier = "cp38-macosx_x86_64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
+  { identifier = "cp38-macosx_arm64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
+  { identifier = "cp38-macosx_universal2", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
   { identifier = "cp39-macosx_x86_64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.5/python-3.9.5-macos11.pkg" },
   { identifier = "cp39-macosx_arm64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.5/python-3.9.5-macos11.pkg" },
   { identifier = "cp39-macosx_universal2", version = "3.9", url = "https://www.python.org/ftp/python/3.9.5/python-3.9.5-macos11.pkg" },


### PR DESCRIPTION
This adds support for creating wheels with CPython 3.8 for Apple Silicon. This is significant because 3.8 is the default Python on macOS's Xcode CLT.

---
Orignal message:

This currently produces an "x86_64" tagged wheel instead of the correct universal2 tag (but the wheel is fine if you rename it, other than having the wrong tag also listed in WHEEL). See https://github.com/scipy/oldest-supported-numpy/pull/20 and grab example wheels at https://github.com/scikit-hep/boost-histogram/pull/583.﻿
