### PR TITLE
Show auditwheel/delocate version in default repair command.

### DIFF
--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -29,10 +29,14 @@ manylinux-pypy_aarch64-image = "manylinux2014"
 
 
 [tool.cibuildwheel.linux]
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
+repair-wheel-command = [
+  "auditwheel --version",
+  "auditwheel repair -w {dest_dir} {wheel}",
+]
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = [
+  "delocate-wheel --version",
   "delocate-listdeps {wheel}",
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]


### PR DESCRIPTION
I'm facing an issue right now where it would be helpful to know the auditwheel version that is used to repair the wheel. https://github.com/glotzerlab/freud/issues/803

This information might be generally helpful to show before performing repairs.

I'm happy to have this PR accepted/edited/rejected, I just wanted to offer the idea. cibuildwheel is amazing and I appreciate your hard work. 👍  I can fix the failing tests if this sounds like a helpful addition.

The expected output would be a line like this for auditwheel (tested on `manylinux2010_x86_64:latest`):
```
auditwheel 4.0.0 installed at /opt/_internal/tools/lib/python3.9/site-packages (python 3.9)
```
or for delocate:
```
delocate-wheel 0.8.2
```