### PR TITLE
fix(action): Output a single stream

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,12 @@ runs:
 
     # This needs powershell-core because github.action path is a Windows-style
     # path on Windows.  Powershell-core understands both types of paths.
+    # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
         pipx run
         --spec ${{ github.action_path }}
         cibuildwheel
         ${{ inputs.package-dir }}
         --output-dir ${{ inputs.output-dir }}
+        2>&1
       shell: pwsh


### PR DESCRIPTION
This should fix #587, at least from the GitHub Action. AFAICT, logging in GHA does not show stdout vs stderr, and they are interleaved incorrectly anyway.