### PR TITLE
chore: update packaging dev requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     files: ^(bin|docs)/.*py$
     args: ["--python-version=3.7", "--scripts-are-modules"]
     additional_dependencies:
-      - packaging
+      - packaging>=21.0
       - rich
       - types-jinja2
       - types-pyyaml

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -6,7 +6,7 @@ import copy
 import difflib
 import logging
 from pathlib import Path
-from typing import Any, Iterable, Union, cast
+from typing import Any, Union
 
 import click
 import requests
@@ -86,7 +86,7 @@ class WindowsVersions:
         # Specifier.filter selects all non pre-releases that match the spec,
         # unless there are only pre-releases, then it selects pre-releases
         # instead (like pip)
-        unsorted_versions = cast(Iterable[Version], spec.filter(self.version_dict))
+        unsorted_versions = spec.filter(self.version_dict)
         versions = sorted(unsorted_versions, reverse=True)
 
         log.debug(f"Windows {self.arch} {spec} has {', '.join(str(v) for v in versions)}")
@@ -201,7 +201,7 @@ class CPythonVersions:
     ) -> ConfigMacOS | None:
 
         # see note above on Specifier.filter
-        unsorted_versions = cast(Iterable[Version], spec.filter(self.versions_dict))
+        unsorted_versions = spec.filter(self.versions_dict)
         sorted_versions = sorted(unsorted_versions, reverse=True)
 
         if version <= Version("3.8.9999"):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras = {
         "pyyaml",
         "requests",
         "rich>=9.6",
-        "packaging>=20.8",
+        "packaging>=21.0",
     ],
     "mypy": [
         "mypy>=0.901",


### PR DESCRIPTION
Requires packaging>=21.0
This allows to simplify a bit `bin/update_pythons.py` with regards to typing.