### PR TITLE
ci: fix circle ci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   osx-python3.6:
     macos:
-      xcode: 10.3.0
+      xcode: 12.5.1
     environment:
       PYTHON: python3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   osx-python3.6:
     macos:
-      xcode: 9.4.1
+      xcode: 10.3.0
     environment:
       PYTHON: python3
     steps:

--- a/examples/circleci-minimal.yml
+++ b/examples/circleci-minimal.yml
@@ -19,7 +19,7 @@ jobs:
   osx-wheels:
     working_directory: ~/osx-wheels
     macos:
-      xcode: 10.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run:

--- a/examples/circleci-minimal.yml
+++ b/examples/circleci-minimal.yml
@@ -19,7 +19,7 @@ jobs:
   osx-wheels:
     working_directory: ~/osx-wheels
     macos:
-      xcode: 10.0.0
+      xcode: 10.3.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This closes #745. I think we should probably recommend the latest image supported rather than the oldest image supported, similar to other platforms (and would be needed for things like Apple Silicon support anyway), but this PR has the minimum required change.
