### PR TITLE
fix(action): use bash instead of powershell

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,12 @@ runs:
   using: composite
   steps:
 
-    # This needs powershell-core because github.action path is a Windows-style
-    # path on Windows.  Powershell-core understands both types of paths.
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
         pipx run
-        --spec ${{ github.action_path }}
+        --spec '${{ github.action_path }}'
         cibuildwheel
         ${{ inputs.package-dir }}
         --output-dir ${{ inputs.output-dir }}
         2>&1
-      shell: pwsh
+      shell: bash


### PR DESCRIPTION
Fixing #752. Have no idea why this is broken, but it seems to be broken. Switching to bash fixes it. I'm not sure if we need the `2>&1` in bash;  was the interleaving only showing up in the action (powershell)? Given that redirection was buggy, maybe the output was too?