### PR TITLE
Access host environment variables from a Linux build

### DIFF
--- a/cibuildwheel/docker_container.py
+++ b/cibuildwheel/docker_container.py
@@ -174,11 +174,11 @@ class DockerContainer:
         self.bash_stdin.write(
             bytes(
                 f"""(
-            {chdir}
-            env {env_assignments} {command}
-            printf "%04d%s\n" $? {end_of_message}
-        )
-        """,
+                    {chdir}
+                    env {env_assignments} {command}
+                    printf "%04d%s\n" $? {end_of_message}
+                )
+                """,
                 encoding="utf8",
                 errors="surrogateescape",
             )

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -1,8 +1,9 @@
+import os
 import subprocess
 import sys
 import textwrap
 from pathlib import Path, PurePath
-from typing import List, NamedTuple, Set
+from typing import Dict, List, NamedTuple, Set
 
 from .architecture import Architecture
 from .docker_container import DockerContainer
@@ -105,7 +106,7 @@ def build(options: BuildOptions) -> None:
                 if options.before_all:
                     log.step("Running before_all...")
 
-                    env = docker.get_environment()
+                    env = {**get_prefixed_host_environment(), **docker.get_environment()}
                     env["PATH"] = f'/opt/python/cp38-cp38/bin:{env["PATH"]}'
                     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
                     env = options.environment.as_dictionary(
@@ -135,7 +136,7 @@ def build(options: BuildOptions) -> None:
 
                     log.step("Setting up build environment...")
 
-                    env = docker.get_environment()
+                    env = {**get_prefixed_host_environment(), **docker.get_environment()}
 
                     # put this config's python top of the list
                     python_bin = config.path / "bin"
@@ -338,3 +339,7 @@ def troubleshoot(package_dir: Path, error: Exception) -> None:
             print("  Files detected:")
             print("\n".join(f"    {f}" for f in so_files))
             print("")
+
+
+def get_prefixed_host_environment() -> Dict[str, str]:
+    return {f"HOST_{k}": v for k, v in os.environ.items()}

--- a/docs/options.md
+++ b/docs/options.md
@@ -481,6 +481,8 @@ A list of environment variables to set during the build. Bash syntax should be u
 
 You must set this variable to pass variables to Linux builds (since they execute in a Docker container). It also works for the other platforms.
 
+On Linux, host environment variables are available inside the Docker container with a `HOST_` prefix.
+
 You can use `$PATH` syntax to insert other variables, or the `$(pwd)` syntax to insert the output of other shell commands.
 
 To specify more than one environment variable, separate the assignments by spaces.
@@ -511,6 +513,12 @@ Platform-specific environment variables are also available:<br/>
 
     # Set two flags on linux only
     CIBW_ENVIRONMENT_LINUX: BUILD_TIME="$(date)" SAMPLE_TEXT="sample text"
+
+    # pass an environment variable from the host into the linux docker build
+    CIBW_ENVIRONMENT_LINUX: PACKAGE_VERSION=$HOST_PACKAGE_VERSION
+
+    # passthrough and rewrite the host environment variable "DATA_DIR"
+    CIBW_ENVIRONMENT_LINUX: DATA_DIR=/host/$HOST_DATA_DIR
     ```
 
     Separate multiple values with a space.
@@ -546,6 +554,13 @@ Platform-specific environment variables are also available:<br/>
     [tool.cibuildwheel.linux.environment]
     BUILD_TIME = "$(date)"
     SAMPLE_TEXT = "sample text"
+
+    [tool.cibuildwheel.linux]
+    # pass an environment variable from the host into the linux docker build
+    environment = { PACKAGE_VERSION="$HOST_PACKAGE_VERSION" }
+
+    # passthrough and rewrite the host environment variable "DATA_DIR"
+    environment = { DATA_DIR="/host/$HOST_DATA_DIR" }
     ```
 
     In configuration mode, you can use a [TOML][] table instead of a raw string as shown above.

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -24,8 +24,8 @@ project_with_environment_asserts = test_projects.new_c_project(
             raise Exception('CIBW_TEST_VAR_2 should equal "1". It was "%s"' % CIBW_TEST_VAR_2)
         if CIBW_TEST_VAR_3 != "test string 3":
             raise Exception('CIBW_TEST_VAR_3 should equal "test string 3". It was "%s"' % CIBW_TEST_VAR_3)
-        if CIBW_TEST_VAR_4 != "Host var: 12345":
-            raise Exception('CIBW_TEST_VAR_4 should equal "Host var: 12345". It was "%s"' % CIBW_TEST_VAR_4)
+        if CIBW_TEST_VAR_4 != "12345":
+            raise Exception('CIBW_TEST_VAR_4 should equal "12345". It was "%s"' % CIBW_TEST_VAR_4)
         if "/opt/cibw_test_path" not in PATH:
             raise Exception('PATH should contain "/opt/cibw_test_path". It was "%s"' % PATH)
         if "$PATH" in PATH:
@@ -39,7 +39,7 @@ def test(tmp_path, monkeypatch):
     project_dir = tmp_path / "project"
     project_with_environment_asserts.generate(project_dir)
 
-    monkeypatch.setenv("SOME_VARIABLE", "12345")
+    monkeypatch.setenv("CIBW_TEST_VAR_4", "12345")
 
     # write some information into the CIBW_ENVIRONMENT, for expansion and
     # insertion into the environment by cibuildwheel. This is checked
@@ -47,8 +47,8 @@ def test(tmp_path, monkeypatch):
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
         add_env={
-            "CIBW_ENVIRONMENT": """CIBW_TEST_VAR="a b c" CIBW_TEST_VAR_2=1 CIBW_TEST_VAR_3="$(echo 'test string 3')" CIBW_TEST_VAR_4="Host var: $HOST_SOME_VARIABLE" PATH=$PATH:/opt/cibw_test_path""",
-            "CIBW_ENVIRONMENT_WINDOWS": '''CIBW_TEST_VAR="a b c" CIBW_TEST_VAR_2=1 CIBW_TEST_VAR_3="$(echo 'test string 3')" CIBW_TEST_VAR_4="Host var: $HOST_SOME_VARIABLE" PATH="$PATH;/opt/cibw_test_path"''',
+            "CIBW_ENVIRONMENT": """CIBW_TEST_VAR="a b c" CIBW_TEST_VAR_2=1 CIBW_TEST_VAR_3="$(echo 'test string 3')" CIBW_TEST_VAR_4="$HOST_CIBW_TEST_VAR_4" PATH=$PATH:/opt/cibw_test_path""",
+            "CIBW_ENVIRONMENT_WINDOWS": '''CIBW_TEST_VAR="a b c" CIBW_TEST_VAR_2=1 CIBW_TEST_VAR_3="$(echo 'test string 3')" CIBW_TEST_VAR_4="$HOST_CIBW_TEST_VAR_4" PATH="$PATH;/opt/cibw_test_path"''',
         },
     )
 


### PR DESCRIPTION
Docker builds can access host environment variables by writing them with a $HOST_ prefix. This has long been a feature request and seemed quite simple to do, so I've finally got around to it!

Fixes #730 and fixes #117.
