### PR TITLE
fix: fix the libffi package name in doc

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -576,7 +576,7 @@ Platform-specific environment variables also available:<br/>
     CIBW_BEFORE_ALL: make -C third_party_lib
 
     # Install system library
-    CIBW_BEFORE_ALL_LINUX: yum install -y libffi-dev
+    CIBW_BEFORE_ALL_LINUX: yum install -y libffi-devel
 
     # Chain multiple commands using && and > in a YAML file, like:
     CIBW_BEFORE_ALL: >
@@ -598,7 +598,7 @@ Platform-specific environment variables also available:<br/>
 
     # Install system library
     [tool.cibuildwheel.linux]
-    before-all = "yum install -y libffi-dev"
+    before-all = "yum install -y libffi-devel"
 
     # Run multiple commands using an array
     before-all = [


### PR DESCRIPTION
The package name is `libffi-devel` in yum.
https://centos.pkgs.org/7/centos-x86_64/libffi-devel-3.0.13-19.el7.x86_64.rpm.html