### PR TITLE
Bring 3.10 out of prerelease

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -67,7 +67,7 @@ class IdentifierSelector:
     """
 
     # a pattern that skips prerelease versions, when include_prereleases is False.
-    PRERELEASE_SKIP = "cp310-*"
+    PRERELEASE_SKIP = ""
 
     def __init__(
         self,

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -1,3 +1,4 @@
+import pytest
 from packaging.specifiers import SpecifierSet
 
 from cibuildwheel.util import BuildSelector
@@ -8,7 +9,7 @@ def test_build():
 
     assert build_selector("cp36-manylinux_x86_64")
     assert build_selector("cp37-manylinux_x86_64")
-    assert not build_selector("cp310-manylinux_x86_64")
+    assert build_selector("cp310-manylinux_x86_64")
     assert build_selector("pp36-manylinux_x86_64")
     assert build_selector("pp37-manylinux_x86_64")
     assert build_selector("cp36-manylinux_i686")
@@ -26,11 +27,12 @@ def test_build():
     assert not build_selector("pp37-win32")
     assert build_selector("cp36-win_amd64")
     assert build_selector("cp37-win_amd64")
-    assert not build_selector("cp310-win_amd64")
+    assert build_selector("cp310-win_amd64")
     assert not build_selector("pp36-win_amd64")
     assert not build_selector("pp37-win_amd64")
 
 
+@pytest.mark.skip("this test only makes sense when we have a prerelease python to test with")
 def test_build_filter_pre():
     build_selector = BuildSelector(
         build_config="cp3*-* *-manylinux*",


### PR DESCRIPTION
Python 3.10 is [now ABI stable](https://www.python.org/downloads/release/python-3100rc1/), and the core devs are calling for packagers to prepare for 3.10 compatibility, so we're bringing 3.10 out from behind the PRERELEASE_PYTHONS flag. Let see if the tests still pass!
