### PR TITLE
feat(CI): run linux tests with pytest-xdist

### DIFF
--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -17,7 +17,20 @@ if __name__ == "__main__":
     subprocess.run(unit_test_args, check=True)
 
     # run the integration tests
+    xdist_test_args = []
+    if sys.platform.startswith("linux"):
+        xdist_test_args = ["-n", "2"]
     subprocess.run(
-        [sys.executable, "-m", "pytest", "-x", "--durations", "0", "--timeout=2400", "test"],
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *xdist_test_args,
+            "-x",
+            "--durations",
+            "0",
+            "--timeout=2400",
+            "test",
+        ],
         check=True,
     )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras = {
         "jinja2",
         "pytest>=6",
         "pytest-timeout",
+        "pytest-xdist; sys_platform == 'linux'",
     ],
     "bin": [
         "click",


### PR DESCRIPTION
This revisits #412.
With musllinux around the corner, CI times are growing quite a bit.

This does not apply to Windows/macOS (yet) for the reasons outlined in #412.