### PR TITLE
chore: add pycln to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
     exclude: ^(cibuildwheel|unit_test|test)/
     args: ["--py37-plus"]
 
+# Autoremoves unused imports
+- repo: https://github.com/hadialqattan/pycln
+  rev: v1.0.3
+  hooks:
+  - id: pycln
+    args: [--config=pyproject.toml]
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ module = [
     "github",
 ]
 ignore_missing_imports = true
+
+[tool.pycln]
+all = true


### PR DESCRIPTION
This automatically cleans up unused imports, for faster development than just having flake8 complain at you and tell you to do completely trivial work.
