### PR TITLE
Doc: fix syntax in pyproject.toml for TEST_EXTRAS

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1132,7 +1132,7 @@ Platform-specific environment variables are also available:<br/>
     ```toml
     [tool.cibuildwheel]
     # Will cause the wheel to be installed with `pip install <wheel_file>[test,qt]`
-    test-extras: ["test", "qt"]
+    test-extras = ["test", "qt"]
     ```
 
     In configuration files, you can use an inline array, and the items will be joined with a comma.


### PR DESCRIPTION
Closes: #863 