### PR TITLE
ci: cancel runs on new pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
     # allow manual runs on branches without a PR
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: Pre-commit checks (mypy, flake8, etc.)


### PR DESCRIPTION
See #860 

I've only used this a time or two, and for rather different use cases, so hopefully this is the right syntax. Most of the other CI systems do this automatically, but GHA doesn't cancel a run when you push a new commit without this.