### PR TITLE
chore: TOML 1.0 support: drop toml, use tomli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
       - types-jinja2
       - types-certifi
       - types-toml
+      - tomli
   - id: mypy
     name: mypy 3.7+ on bin/
     files: ^((bin|docs)/.*py|noxfile.py)$
@@ -69,7 +70,7 @@ repos:
       - types-pyyaml
       - types-click
       - types-requests
-      - types-toml
+      - tomli
 
 - repo: https://github.com/PyCQA/flake8
   rev: 4.0.1

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -11,13 +11,13 @@ from typing import Any, Union
 import click
 import requests
 import rich
-import toml
+import tomli
 from packaging.specifiers import Specifier
 from packaging.version import Version
 from rich.logging import RichHandler
 from rich.syntax import Syntax
 
-from cibuildwheel.extra import InlineArrayDictEncoder
+from cibuildwheel.extra import dump_python_configurations
 from cibuildwheel.typing import Final, Literal, TypedDict
 
 log = logging.getLogger("cibw")
@@ -291,7 +291,8 @@ def update_pythons(force: bool, level: str) -> None:
     toml_file_path = RESOURCES_DIR / "build-platforms.toml"
 
     original_toml = toml_file_path.read_text()
-    configs = toml.loads(original_toml)
+    with toml_file_path.open("rb") as f:
+        configs = tomli.load(f)
 
     for config in configs["windows"]["python_configurations"]:
         all_versions.update_config(config)
@@ -299,7 +300,7 @@ def update_pythons(force: bool, level: str) -> None:
     for config in configs["macos"]["python_configurations"]:
         all_versions.update_config(config)
 
-    result_toml = toml.dumps(configs, encoder=InlineArrayDictEncoder())  # type: ignore
+    result_toml = dump_python_configurations(configs)
 
     rich.print()  # spacer
 

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
-import toml
+import tomli
 from packaging.specifiers import SpecifierSet
 
 from .architecture import Architecture
@@ -143,7 +143,8 @@ class ConfigOptions:
         """
         Load a toml file, returns global and platform as separate dicts.
         """
-        config = toml.load(filename)
+        with filename.open("rb") as f:
+            config = tomli.load(f)
 
         global_options = config.get("tool", {}).get("cibuildwheel", {})
         platform_options = global_options.get(self.platform, {})

--- a/cibuildwheel/projectfiles.py
+++ b/cibuildwheel/projectfiles.py
@@ -4,7 +4,7 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Optional
 
-import toml
+import tomli
 
 if sys.version_info < (3, 8):
     Constant = ast.Str
@@ -56,7 +56,8 @@ def get_requires_python_str(package_dir: Path) -> Optional[str]:
 
     # Read in from pyproject.toml:project.requires-python
     try:
-        info = toml.load(package_dir / "pyproject.toml")
+        with (package_dir / "pyproject.toml").open("rb") as f1:
+            info = tomli.load(f1)
         return str(info["project"]["requires-python"])
     except (FileNotFoundError, KeyError, IndexError, TypeError):
         pass
@@ -70,8 +71,8 @@ def get_requires_python_str(package_dir: Path) -> Optional[str]:
         pass
 
     try:
-        with open(package_dir / "setup.py") as f:
-            return setup_py_python_requires(f.read())
+        with (package_dir / "setup.py").open() as f2:
+            return setup_py_python_requires(f2.read())
     except FileNotFoundError:
         pass
 

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -4,9 +4,9 @@ import sys
 from typing import TYPE_CHECKING, NoReturn, Set, Union
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Final, Literal, TypedDict
+    from typing_extensions import Final, Literal, Protocol, TypedDict
 else:
-    from typing import Final, Literal, TypedDict
+    from typing import Final, Literal, Protocol, TypedDict
 
 
 __all__ = (
@@ -18,6 +18,7 @@ __all__ = (
     "PopenBytes",
     "PathOrStr",
     "PlatformName",
+    "Protocol",
     "PLATFORMS",
     "assert_never",
 )

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -16,7 +16,7 @@ from typing import Dict, Iterator, List, NamedTuple, Optional, Set
 
 import bracex
 import certifi
-import toml
+import tomli
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -71,7 +71,8 @@ def get_build_verbosity_extra_flags(level: int) -> List[str]:
 
 def read_python_configs(config: PlatformName) -> List[Dict[str, str]]:
     input_file = resources_dir / "build-platforms.toml"
-    loaded_file = toml.load(input_file)
+    with input_file.open("rb") as f:
+        loaded_file = tomli.load(f)
     results: List[Dict[str, str]] = list(loaded_file[config]["python_configurations"])
     return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ module = [
     "setuptools",
     "pytest", # ignored in pre-commit to speed up check
     "bashlex",
-    "toml.encoder", # encoder missing from stub package
     "bracex",
     "importlib_resources",
     "nox",

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     bracex
     certifi
     packaging
-    toml
+    tomli
     typing_extensions;python_version < '3.8'
 python_requires = >=3.6
 include_package_data = True

--- a/unit_test/build_ids_test.py
+++ b/unit_test/build_ids_test.py
@@ -1,28 +1,32 @@
-import toml
+from typing import Dict, List
+
+import tomli
 from packaging.version import Version
 
-from cibuildwheel.extra import InlineArrayDictEncoder  # noqa: E402
+from cibuildwheel.extra import Printable, dump_python_configurations
 from cibuildwheel.util import resources_dir
 
 
 def test_compare_configs():
-    with open(resources_dir / "build-platforms.toml") as f:
-        txt = f.read()
+    with open(resources_dir / "build-platforms.toml") as f1:
+        txt = f1.read()
 
-    dict_txt = toml.loads(txt)
+    with open(resources_dir / "build-platforms.toml", "rb") as f2:
+        dict_txt = tomli.load(f2)
 
-    new_txt = toml.dumps(dict_txt, encoder=InlineArrayDictEncoder())  # type: ignore
+    new_txt = dump_python_configurations(dict_txt)
     print(new_txt)
 
     assert new_txt == txt
 
 
 def test_dump_with_Version():
-    example = {
+    # MyPy doesn't understand deeply nested dicts correctly
+    example: Dict[str, Dict[str, List[Dict[str, Printable]]]] = {
         "windows": {
             "python_configurations": [
                 {"identifier": "cp27-win32", "version": Version("2.7.18"), "arch": "32"},
-                {"identifier": "cp27-win_amd64", "version": Version("2.7.18"), "arch": "64"},
+                {"identifier": "cp27-win_amd64", "version": "2.7.18", "arch": "64"},
             ]
         }
     }
@@ -35,6 +39,6 @@ python_configurations = [
 ]
 """
 
-    output = toml.dumps(example, encoder=InlineArrayDictEncoder())  # type: ignore
+    output = dump_python_configurations(example)
     print(output)
     assert output == result


### PR DESCRIPTION
This is required to get TOML 1.0 support, and lightens our dependencies a bit. I think most other packages have already switched (pip, etc). Manually writing the output file since tomli-w doesn't support formatting, and tomlkit doesn't keep the output structure as promised. This is probably simpler/easier for us.

Closes #534.
