### PR TITLE
fix: artificial limiting in pycln breaks on 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
   hooks:
   - id: pycln
     args: [--config=pyproject.toml]
+    stages: [manual]  # disabled due to artificial limit on Python 3.10
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3


### PR DESCRIPTION
PyCln artificially version-caps Python to <3.10, which broke when pre-commit updated to 3.10 earlier today. I hadn't noticed this, because locally I installed with 3.9, then when brew updated pre-commit to 3.10, it just kept working, because pycln actually supports 3.10, it just follows the horrific practice of adding upper version limits as pushed by Poetry. If the version caps are not removed, I think we should remove this from our pre-commit. Otherwise, this will cause extra headaches every Python upgrade. Temporarily disabling for now. https://github.com/hadialqattan/pycln/pull/81