### PR TITLE
ci: release to PyPI from CI on GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  pull_request:
+  release:
+    types:
+    - published
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build SDist and wheel
+      run: pipx run build
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Should avoid variance in local environments when releasing. Needs #893 to producing working SDists/wheels. Should help avoid #892 in the future. You can also download the SDist/wheel from PRs (since it's likely much, much faster than our CI, I don't think it hurts to leave this on for all PRs, we could even enable for the main branch).

Note that anyone who can make a GitHub release can make a PyPI release. Feel free to restrict as needed. Also a token needs to be generated and added to secrets with the name `pypi_password`.
