### PR TITLE
Fix broken links incorrectly converted to point to PyPA org

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -470,7 +470,7 @@ _26 May 2019_
 - 🌟 Add support for building on Azure pipelines! This lets you build all
   Linux, Mac and Windows wheels on one service, so it promises to be the
   easiest to set up! Check out the quickstart in the docs, or
-  [cibuildwheel-azure-example](https://github.com/pypa/cibuildwheel-azure-example)
+  [cibuildwheel-azure-example](https://github.com/joerick/cibuildwheel-azure-example)
   for an example project. (#126, #132)
 - 🛠 Internal change - the end-to-end test projects format was updated, so we
   can more precisely assert what should be produced for each one. (#136, #137).

--- a/docs/deliver-to-pypi.md
+++ b/docs/deliver-to-pypi.md
@@ -33,4 +33,4 @@ Obviously, manual steps are for chumps, so we can automate this a little by usin
 
 If you don't need much control over the release of a package, you can set up cibuildwheel to deliver the wheels straight to PyPI. This doesn't require anycloud storage to work - you just need to bump the version and tag it.
 
-[`examples/travis-ci-deploy.yml`](https://github.com/pypa/cibuildwheel/blob/main/examples/travis-ci-deploy.yml) and [`examples/github-deploy.yml`](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml) are example configurations that automatically upload wheels to PyPI. Also check out [this example repo](https://github.com/pypa/cibuildwheel-autopypi-example) for more detailed instructions on how to set this up.
+See [`examples/travis-ci-deploy.yml`](https://github.com/pypa/cibuildwheel/blob/main/examples/travis-ci-deploy.yml) and [`examples/github-deploy.yml`](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml) for example configurations that automatically upload wheels to PyPI.


### PR DESCRIPTION
Upon browsing the docs, I noticed that in the [Automatic section of the Deliver to PyPI docs](https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/#automatic-method), the link to the example repo is broken. It seems 3be2d0c indiscriminately converted all references to joerick/cibuildwheel to pypa/cibuildwheel, including those to other repositories with names starting with `cibuildwheel` that were not being moved. Upon checking that commit, I noticed at least one other link that was broken as well, and given it was a rather trivial, straightforward change, went ahead and fixed both in a PR.

NB, link breakage like this could be fixed by a `linkcheck` tool in your CIs; I'm not really familiar with the mkdocs ecosystem as opposed to Sphinx, but at least at a glance, it seems [this](https://pypi.org/project/mkdocs-linkcheck/) tool exists and is well-maintained.