### PR TITLE
Add python3.exe symlink on windows builds.

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -97,8 +97,9 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
     nuget_args = get_nuget_args(version, arch)
     installation_path = Path(nuget_args[-1]) / (nuget_args[0] + "." + version) / "tools"
     call([nuget, "install", *nuget_args])
+    # "python3" is not included in the vanilla nuget package,
+    # though it can be present if modified (like on Azure).
     if not (installation_path / "python3.exe").exists():
-        # create python3.exe symlink, if not exists
         (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
     return installation_path
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -109,6 +109,7 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
                 if os.path.isfile(os.path.join(installation_path, f))
             ]
         )
+        raise RuntimeError(f"{(installation_path / 'python3.exe')} already exists!")
     return installation_path
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -102,7 +102,13 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
         (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
     else:
         print(f'{(installation_path / "python3.exe")} already exists:')
-        print([f for f in os.listdir(installation_path) if os.path.isfile(os.path.join(installation_path, f))])
+        print(
+            [
+                f
+                for f in os.listdir(installation_path)
+                if os.path.isfile(os.path.join(installation_path, f))
+            ]
+        )
     return installation_path
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -100,16 +100,6 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
     if not (installation_path / "python3.exe").exists():
         # create python3.exe symlink, if not exists
         (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
-    else:
-        print(f'{(installation_path / "python3.exe")} already exists:')
-        print(
-            [
-                f
-                for f in os.listdir(installation_path)
-                if os.path.isfile(os.path.join(installation_path, f))
-            ]
-        )
-        raise RuntimeError(f"{(installation_path / 'python3.exe')} already exists!")
     return installation_path
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -97,7 +97,12 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
     nuget_args = get_nuget_args(version, arch)
     installation_path = Path(nuget_args[-1]) / (nuget_args[0] + "." + version) / "tools"
     call([nuget, "install", *nuget_args])
-    (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
+    if not (installation_path / "python3.exe").exists():
+        # create python3.exe symlink, if not exists
+        (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
+    else:
+        print(f'{(installation_path / "python3.exe")} already exists:')
+        print([f for f in os.listdir(installation_path) if os.path.isfile(os.path.join(installation_path, f))])
     return installation_path
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -97,6 +97,7 @@ def install_cpython(version: str, arch: str, nuget: Path) -> Path:
     nuget_args = get_nuget_args(version, arch)
     installation_path = Path(nuget_args[-1]) / (nuget_args[0] + "." + version) / "tools"
     call([nuget, "install", *nuget_args])
+    (installation_path / "python3.exe").symlink_to(installation_path / "python.exe")
     return installation_path
 
 


### PR DESCRIPTION
This PR adds a `python3.exe` link pointing to `python.exe` on windows, closes #915.