### PR TITLE
Enable Pycln since the artificial limit removed for all Python3 versions.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,10 @@ repos:
 
 # Autoremoves unused imports
 - repo: https://github.com/hadialqattan/pycln
-  rev: v1.0.3
+  rev: v1.1.0
   hooks:
   - id: pycln
     args: [--config=pyproject.toml]
-    stages: [manual]  # disabled due to artificial limit on Python 3.10
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.0


### PR DESCRIPTION
Re-enabling [Pycln ](https://github.com/hadialqattan/pycln) after solving the Python3.10 artificial limitation issue.
___
This is reverting [this commit](https://github.com/pypa/cibuildwheel/commit/6db52297745c0c0c212ce4cd9177bf5b1497b00b).