### PR TITLE
always default to manylinux2014

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -469,10 +469,8 @@ class Options:
                     )
 
                     if not config_value:
-                        # default to manylinux2010 if it's available, otherwise manylinux2014
-                        image = pinned_images.get("manylinux2010") or pinned_images.get(
-                            "manylinux2014"
-                        )
+                        # default to manylinux2014
+                        image = pinned_images.get("manylinux2014")
                     elif config_value in pinned_images:
                         image = pinned_images[config_value]
                     else:

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -18,13 +18,13 @@ before-test = ""
 test-requires = []
 test-extras = []
 
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
-manylinux-pypy_x86_64-image = "manylinux2010"
-manylinux-pypy_i686-image = "manylinux2010"
+manylinux-pypy_x86_64-image = "manylinux2014"
+manylinux-pypy_i686-image = "manylinux2014"
 manylinux-pypy_aarch64-image = "manylinux2014"
 
 musllinux-x86_64-image = "musllinux_1_1"

--- a/docs/cpp_standards.md
+++ b/docs/cpp_standards.md
@@ -6,7 +6,7 @@ Building Python wheels with modern C++ standards (C++11 and later) requires a fe
 
 
 ## manylinux1 and C++14
-The default `manylinux1` image (based on CentOS 5) contains a version of GCC and libstdc++ that only supports C++11 and earlier standards. There are however ways to compile wheels with the C++14 standard (and later): https://github.com/pypa/manylinux/issues/118
+The old `manylinux1` image (based on CentOS 5) contains a version of GCC and libstdc++ that only supports C++11 and earlier standards. There are however ways to compile wheels with the C++14 standard (and later): https://github.com/pypa/manylinux/issues/118
 
 `manylinux2010` and `manylinux2014` are newer and support all C++ standards (up to C++17).
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -147,6 +147,10 @@ manylinux-x86_64-image = "manylinux2014"
 [[tool.cibuildwheel.overrides]]
 select = "cp36-*"
 manylinux-x86_64-image = "manylinux1"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp3?-*"
+manylinux-x86_64-image = "manylinux2014"
 ```
 
 This example will build CPython 3.6 wheels on manylinux1, and manylinux2014

--- a/docs/options.md
+++ b/docs/options.md
@@ -888,12 +888,12 @@ Auditwheel detects the version of the manylinux / musllinux standard in the Dock
     CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014
     CIBW_MANYLINUX_PYPY_I686_IMAGE: manylinux2014
 
-    # Build using the latest manylinux2010 release, instead of the cibuildwheel
+    # Build using the latest manylinux2014 release, instead of the cibuildwheel
     # pinned version
-    CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-    CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-    CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-    CIBW_MANYLINUX_PYPY_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+    CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+    CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
+    CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+    CIBW_MANYLINUX_PYPY_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
 
     # Build using a different image from the docker registry
     CIBW_MANYLINUX_X86_64_IMAGE: dockcross/manylinux-x64

--- a/docs/options.md
+++ b/docs/options.md
@@ -149,12 +149,13 @@ select = "cp36-*"
 manylinux-x86_64-image = "manylinux1"
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3?-*"
-manylinux-x86_64-image = "manylinux2014"
+select = "cp3{7,8,9}-*"
+manylinux-x86_64-image = "manylinux2010"
 ```
 
-This example will build CPython 3.6 wheels on manylinux1, and manylinux2014
-wheels everywhere else.
+This example will build CPython 3.6 wheels on manylinux1, CPython 3.7-3.9
+wheels on manylinux2010, and manylinux2014 wheels for any newer Python
+(like 3.10).
 
 
 ## Options summary

--- a/docs/options.md
+++ b/docs/options.md
@@ -142,19 +142,15 @@ which means it can be given multiple times.
 ```toml
 [tool.cibuildwheel]
 # Normal options, etc.
-manylinux-x86_64-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp36-*"
 manylinux-x86_64-image = "manylinux1"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp310-*"
-manylinux-x86_64-image = "manylinux2014"
 ```
 
-This example will build CPython 3.6 wheels on manylinux1, CPython 3.7-3.9
-images on manylinux2010, and CPython 3.10 wheels on manylinux2014.
+This example will build CPython 3.6 wheels on manylinux1, and manylinux2014
+wheels everywhere else.
 
 
 ## Options summary
@@ -843,14 +839,14 @@ Platform-specific environment variables are also available:<br/>
 
 The available options are (default value):
 
-- `CIBW_MANYLINUX_X86_64_IMAGE` ([`quay.io/pypa/manylinux2010_x86_64`](https://quay.io/pypa/manylinux2010_x86_64))
-- `CIBW_MANYLINUX_I686_IMAGE` ([`quay.io/pypa/manylinux2010_i686`](https://quay.io/pypa/manylinux2010_i686))
-- `CIBW_MANYLINUX_PYPY_X86_64_IMAGE` ([`quay.io/pypa/manylinux2010_x86_64`](https://quay.io/pypa/manylinux2010_x86_64))
+- `CIBW_MANYLINUX_X86_64_IMAGE` ([`quay.io/pypa/manylinux2014_x86_64`](https://quay.io/pypa/manylinux2014_x86_64))
+- `CIBW_MANYLINUX_I686_IMAGE` ([`quay.io/pypa/manylinux2014_i686`](https://quay.io/pypa/manylinux2014_i686))
+- `CIBW_MANYLINUX_PYPY_X86_64_IMAGE` ([`quay.io/pypa/manylinux2014_x86_64`](https://quay.io/pypa/manylinux2014_x86_64))
 - `CIBW_MANYLINUX_AARCH64_IMAGE` ([`quay.io/pypa/manylinux2014_aarch64`](https://quay.io/pypa/manylinux2014_aarch64))
 - `CIBW_MANYLINUX_PPC64LE_IMAGE` ([`quay.io/pypa/manylinux2014_ppc64le`](https://quay.io/pypa/manylinux2014_ppc64le))
-- `CIBW_MANYLINUX_S390X_IMAGE` ([`quay.io/pypa/manylinux2014_s390x`](https://quay.io/pypa/manylinux2010_s390x))
+- `CIBW_MANYLINUX_S390X_IMAGE` ([`quay.io/pypa/manylinux2014_s390x`](https://quay.io/pypa/manylinux2014_s390x))
 - `CIBW_MANYLINUX_PYPY_AARCH64_IMAGE` ([`quay.io/pypa/manylinux2014_aarch64`](https://quay.io/pypa/manylinux2014_aarch64))
-- `CIBW_MANYLINUX_PYPY_I686_IMAGE` ([`quay.io/pypa/manylinux2010_i686`](https://quay.io/pypa/manylinux2010_i686))
+- `CIBW_MANYLINUX_PYPY_I686_IMAGE` ([`quay.io/pypa/manylinux2014_i686`](https://quay.io/pypa/manylinux2014_i686))
 - `CIBW_MUSLLINUX_X86_64_IMAGE` ([`quay.io/pypa/musllinux_1_1_x86_64`](https://quay.io/pypa/musllinux_1_1_x86_64))
 - `CIBW_MUSLLINUX_I686_IMAGE` ([`quay.io/pypa/musllinux_1_1_i686`](https://quay.io/pypa/musllinux_1_1_i686))
 - `CIBW_MUSLLINUX_AARCH64_IMAGE` ([`quay.io/pypa/musllinux_1_1_aarch64`](https://quay.io/pypa/musllinux_1_1_aarch64))

--- a/test/test_docker_images.py
+++ b/test/test_docker_images.py
@@ -35,8 +35,8 @@ def test(tmp_path):
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
         add_env={
-            "CIBW_MANYLINUX_X86_64_IMAGE": "dockcross/manylinux2010-x64",
-            "CIBW_MANYLINUX_I686_IMAGE": "dockcross/manylinux2010-x86",
+            "CIBW_MANYLINUX_X86_64_IMAGE": "dockcross/manylinux2014-x64",
+            "CIBW_MANYLINUX_I686_IMAGE": "dockcross/manylinux2014-x86",
             "CIBW_BUILD": "cp3{6,7,8,9}-manylinux*",
         },
     )

--- a/test/utils.py
+++ b/test/utils.py
@@ -123,8 +123,6 @@ def expected_wheels(
             manylinux_versions = [
                 "manylinux_2_5",
                 "manylinux1",
-                "manylinux_2_12",
-                "manylinux2010",
                 "manylinux_2_17",
                 "manylinux2014",
             ]

--- a/test/utils.py
+++ b/test/utils.py
@@ -120,7 +120,14 @@ def expected_wheels(
 
     if manylinux_versions is None:
         if machine_arch == "x86_64":
-            manylinux_versions = ["manylinux_2_5", "manylinux1", "manylinux_2_12", "manylinux2010"]
+            manylinux_versions = [
+                "manylinux_2_5",
+                "manylinux1",
+                "manylinux_2_12",
+                "manylinux2010",
+                "manylinux_2_17",
+                "manylinux2014",
+            ]
         else:
             manylinux_versions = ["manylinux_2_17", "manylinux2014"]
 

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -71,19 +71,19 @@ def test_empty_selector(platform, intercepted_build_args, monkeypatch):
 @pytest.mark.parametrize(
     "architecture, image, full_image",
     [
-        ("x86_64", None, "quay.io/pypa/manylinux2010_x86_64:*"),
+        ("x86_64", None, "quay.io/pypa/manylinux2014_x86_64:*"),
         ("x86_64", "manylinux1", "quay.io/pypa/manylinux1_x86_64:*"),
         ("x86_64", "manylinux2010", "quay.io/pypa/manylinux2010_x86_64:*"),
         ("x86_64", "manylinux2014", "quay.io/pypa/manylinux2014_x86_64:*"),
         ("x86_64", "manylinux_2_24", "quay.io/pypa/manylinux_2_24_x86_64:*"),
         ("x86_64", "custom_image", "custom_image"),
-        ("i686", None, "quay.io/pypa/manylinux2010_i686:*"),
+        ("i686", None, "quay.io/pypa/manylinux2014_i686:*"),
         ("i686", "manylinux1", "quay.io/pypa/manylinux1_i686:*"),
         ("i686", "manylinux2010", "quay.io/pypa/manylinux2010_i686:*"),
         ("i686", "manylinux2014", "quay.io/pypa/manylinux2014_i686:*"),
         ("i686", "manylinux_2_24", "quay.io/pypa/manylinux_2_24_i686:*"),
         ("i686", "custom_image", "custom_image"),
-        ("pypy_x86_64", None, "quay.io/pypa/manylinux2010_x86_64:*"),
+        ("pypy_x86_64", None, "quay.io/pypa/manylinux2014_x86_64:*"),
         ("pypy_x86_64", "manylinux1", "manylinux1"),  # Does not exist
         ("pypy_x86_64", "manylinux2010", "quay.io/pypa/manylinux2010_x86_64:*"),
         ("pypy_x86_64", "manylinux2014", "quay.io/pypa/manylinux2014_x86_64:*"),

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -52,7 +52,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
 
     # In Python 3.8+, this can be simplified to [0].kwargs
     kwargs = build_on_docker.call_args_list[0][1]
-    assert "quay.io/pypa/manylinux2010_x86_64" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
@@ -60,7 +60,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
     assert identifiers == {f"{x}-manylinux_x86_64" for x in ALL_IDS}
 
     kwargs = build_on_docker.call_args_list[1][1]
-    assert "quay.io/pypa/manylinux2010_i686" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux2014_i686" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 
@@ -94,13 +94,13 @@ def test_build_with_override_launches(mock_build_docker, monkeypatch, tmp_path):
     cibw_toml.write_text(
         """
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_24"
 
-# Before Python 3.10, manylinux2010 is the most compatible
+# Before Python 3.10, use manylinux2014
 [[tool.cibuildwheel.overrides]]
 select = "cp3?-*"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp36-manylinux_x86_64"
@@ -118,7 +118,7 @@ before-all = "true"
     assert build_on_docker.call_count == 6
 
     kwargs = build_on_docker.call_args_list[0][1]
-    assert "quay.io/pypa/manylinux2010_x86_64" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
@@ -127,7 +127,7 @@ before-all = "true"
     assert kwargs["options"].build_options("cp36-manylinux_x86_64").before_all == "true"
 
     kwargs = build_on_docker.call_args_list[1][1]
-    assert "quay.io/pypa/manylinux2010_x86_64" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
@@ -138,7 +138,7 @@ before-all = "true"
     assert kwargs["options"].build_options("cp37-manylinux_x86_64").before_all == ""
 
     kwargs = build_on_docker.call_args_list[2][1]
-    assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux_2_24_x86_64" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -149,7 +149,7 @@ before-all = "true"
     }
 
     kwargs = build_on_docker.call_args_list[3][1]
-    assert "quay.io/pypa/manylinux2010_i686" in kwargs["docker"]["docker_image"]
+    assert "quay.io/pypa/manylinux2014_i686" in kwargs["docker"]["docker_image"]
     assert kwargs["docker"]["cwd"] == Path("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -60,7 +60,7 @@ def test_simple_settings(tmp_path, platform, fname):
     )
 
     assert options_reader.get("manylinux-x86_64-image") == "manylinux1"
-    assert options_reader.get("manylinux-i686-image") == "manylinux2010"
+    assert options_reader.get("manylinux-i686-image") == "manylinux2014"
 
     with pytest.raises(ConfigOptionError):
         options_reader.get("environment", sep=" ")
@@ -71,7 +71,7 @@ def test_simple_settings(tmp_path, platform, fname):
 
 def test_envvar_override(tmp_path, platform, monkeypatch):
     monkeypatch.setenv("CIBW_BUILD", "cp38*")
-    monkeypatch.setenv("CIBW_MANYLINUX_X86_64_IMAGE", "manylinux2014")
+    monkeypatch.setenv("CIBW_MANYLINUX_X86_64_IMAGE", "manylinux_2_24")
     monkeypatch.setenv("CIBW_TEST_COMMAND", "mytest")
     monkeypatch.setenv("CIBW_TEST_REQUIRES", "docs")
     monkeypatch.setenv("CIBW_TEST_REQUIRES_LINUX", "scod")
@@ -84,8 +84,8 @@ def test_envvar_override(tmp_path, platform, monkeypatch):
     assert options_reader.get("archs", sep=" ") == "auto"
 
     assert options_reader.get("build", sep=" ") == "cp38*"
-    assert options_reader.get("manylinux-x86_64-image") == "manylinux2014"
-    assert options_reader.get("manylinux-i686-image") == "manylinux2010"
+    assert options_reader.get("manylinux-x86_64-image") == "manylinux_2_24"
+    assert options_reader.get("manylinux-i686-image") == "manylinux2014"
 
     assert (
         options_reader.get("test-requires", sep=" ")
@@ -222,7 +222,7 @@ manylinux-x86_64-image = ""
     assert options_reader.get("manylinux-i686-image") == ""
     assert options_reader.get("manylinux-aarch64-image") == "manylinux1"
 
-    assert options_reader.get("manylinux-x86_64-image", ignore_empty=True) == "manylinux2010"
+    assert options_reader.get("manylinux-x86_64-image", ignore_empty=True) == "manylinux2014"
     assert options_reader.get("manylinux-i686-image", ignore_empty=True) == "manylinux1"
     assert options_reader.get("manylinux-aarch64-image", ignore_empty=True) == "manylinux1"
 


### PR DESCRIPTION
closes #909 

Move the default for all platforms to manylinux2014. This is available for all platforms in `resources/pinned_docker_images.cfg`