### PR TITLE
docs: add psycopg 3 to the projects page

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -503,3 +503,10 @@
   gh: AcademySoftwareFoundation/OpenColorIO
   ci: [github]
   os: [apple, linux, windows]
+
+- name: Psycopg 3
+  gh: psycopg/psycopg
+  pypi: psycopg_binary
+  notes: A modern implementation of a PostgreSQL adapter for Python
+  ci: [github]
+  os: [windows, apple, linux]


### PR DESCRIPTION
Psycopg uses cibuildwheel since version 3.0. Thank you very much!