### PR TITLE
Add PyPy 3.8 to supported operating systems / Python versions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ What does it do?
 | CPython 3.9   | ✅ | ✅  | ✅  | ✅  | ✅² | ✅³ | ✅ | ✅ | ✅  | ✅  |
 | CPython 3.10  | ✅ | ✅  | ✅  | ✅  | ✅² | ✅ | ✅  | ✅ | ✅  | ✅  |
 | PyPy 3.7 v7.3 | ✅ | N/A | ✅  | N/A | N/A | ✅¹ | ✅¹  | ✅¹ | N/A | N/A |
+| PyPy 3.8 v7.3 | ✅ | N/A | ✅  | N/A | N/A | ✅¹ | ✅¹  | ✅¹ | N/A | N/A |
 
 <sup>¹ PyPy is only supported for manylinux wheels.</sup><br>
 <sup>² Windows arm64 support is experimental.</sup><br>


### PR DESCRIPTION
With cibuildwheel v2.3.0 came support for PyPy 3.8.
This PR simply adds it to the table under _[What does it do?](https://github.com/Zuzu-Typ/cibuildwheel/tree/patch-1#what-does-it-do)_
