### PR TITLE
Fix Travis deploy example

### DIFF
--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -22,8 +22,8 @@ install:
   - python3 -m pip install cibuildwheel==2.3.0
 
 script:
-  # build the wheels, put them into './wheelhouse'
-  - python3 -m cibuildwheel --output-dir wheelhouse
+  # build the wheels, put them into './dist'
+  - python3 -m cibuildwheel --output-dir dist
 
 deploy:
   provider: pypi


### PR DESCRIPTION
In https://github.com/pygeos/pygeos, I moved the aarch64 builds to Travis. It appeared that the `pypi` deploy provider uploads only wheels from the `dist` directory, not the `wheelhouse` directory.