### PR TITLE
Ignore rmtree errors on Windows during cleanup

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -449,7 +449,9 @@ def build(options: Options) -> None:
                 shell(test_command_prepared, cwd="c:\\", env=virtualenv_env)
 
                 # clean up
-                shutil.rmtree(venv_dir)
+                # (we ignore errors because occasionally Windows fails to unlink a file and we
+                # don't want to abort a build because of that)
+                shutil.rmtree(venv_dir, ignore_errors=True)
 
             # we're all done here; move it to output (remove if already exists)
             shutil.move(str(repaired_wheel), build_options.output_dir)


### PR DESCRIPTION
This [fails our CI occasionally](https://app.travis-ci.com/github/pypa/cibuildwheel/jobs/550840205), but we don't really care about the
occasional file escaping deletion - this is more about hygene than
anything else, so ignore errors on this step.

