### PR TITLE
fix: environment variable affect initial setup macOS/win

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -192,7 +192,6 @@ def setup_python(
     # https://github.com/pypa/virtualenv/issues/620
     # Also see https://github.com/python/cpython/pull/9516
     env.pop("__PYVENV_LAUNCHER__", None)
-    env = environment.as_dictionary(prev_environment=env)
 
     # we version pip ourselves, so we don't care about pip version checking
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
@@ -245,6 +244,9 @@ def setup_python(
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Apply our environment after pip is ready
+    env = environment.as_dictionary(prev_environment=env)
 
     # Set MACOSX_DEPLOYMENT_TARGET to 10.9, if the user didn't set it.
     # PyPy defaults to 10.7, causing inconsistencies if it's left unset.

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -196,19 +196,6 @@ def setup_python(
     # we version pip ourselves, so we don't care about pip version checking
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
-    # check what version we're on
-    call(["which", "python"], env=env)
-    call(["python", "--version"], env=env)
-    which_python = subprocess.run(
-        ["which", "python"], env=env, universal_newlines=True, check=True, stdout=subprocess.PIPE
-    ).stdout.strip()
-    if which_python != "/tmp/cibw_bin/python":
-        print(
-            "cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     # Install pip
 
     requires_reinstall = not (installation_bin_path / "pip").exists()
@@ -232,6 +219,10 @@ def setup_python(
         cwd="/tmp",
     )
 
+    # Apply our environment after pip is ready
+    env = environment.as_dictionary(prev_environment=env)
+
+    # check what pip version we're on
     assert (installation_bin_path / "pip").exists()
     call(["which", "pip"], env=env)
     call(["pip", "--version"], env=env)
@@ -245,8 +236,18 @@ def setup_python(
         )
         sys.exit(1)
 
-    # Apply our environment after pip is ready
-    env = environment.as_dictionary(prev_environment=env)
+    # check what Python version we're on
+    call(["which", "python"], env=env)
+    call(["python", "--version"], env=env)
+    which_python = subprocess.run(
+        ["which", "python"], env=env, universal_newlines=True, check=True, stdout=subprocess.PIPE
+    ).stdout.strip()
+    if which_python != "/tmp/cibw_bin/python":
+        print(
+            "cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Set MACOSX_DEPLOYMENT_TARGET to 10.9, if the user didn't set it.
     # PyPy defaults to 10.7, causing inconsistencies if it's left unset.

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -157,28 +157,6 @@ def setup_python(
     )
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
-    # for the logs - check we're running the right version of python
-    call(["where", "python"], env=env)
-    call(["python", "--version"], env=env)
-    call(["python", "-c", "\"import struct; print(struct.calcsize('P') * 8)\""], env=env)
-    where_python = (
-        subprocess.run(
-            ["where", "python"],
-            env=env,
-            universal_newlines=True,
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        .stdout.splitlines()[0]
-        .strip()
-    )
-    if where_python != str(installation_path / "python.exe"):
-        print(
-            "cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     log.step("Installing build tools...")
 
     # Install pip
@@ -227,6 +205,32 @@ def setup_python(
         cwd=CIBW_INSTALL_PATH,
     )
 
+    # update env with results from CIBW_ENVIRONMENT
+    env = environment.as_dictionary(prev_environment=env)
+
+    # check what Python version we're on
+    call(["where", "python"], env=env)
+    call(["python", "--version"], env=env)
+    call(["python", "-c", "\"import struct; print(struct.calcsize('P') * 8)\""], env=env)
+    where_python = (
+        subprocess.run(
+            ["where", "python"],
+            env=env,
+            universal_newlines=True,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        .stdout.splitlines()[0]
+        .strip()
+    )
+    if where_python != str(installation_path / "python.exe"):
+        print(
+            "cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # check what pip version we're on
     assert (installation_path / "Scripts" / "pip.exe").exists()
     where_pip = (
         subprocess.run(
@@ -243,9 +247,6 @@ def setup_python(
         sys.exit(1)
 
     call(["pip", "--version"], env=env)
-
-    # update env with results from CIBW_ENVIRONMENT
-    env = environment.as_dictionary(prev_environment=env)
 
     if build_frontend == "pip":
         call(

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -157,9 +157,6 @@ def setup_python(
     )
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
-    # update env with results from CIBW_ENVIRONMENT
-    env = environment.as_dictionary(prev_environment=env)
-
     # for the logs - check we're running the right version of python
     call(["where", "python"], env=env)
     call(["python", "--version"], env=env)
@@ -246,6 +243,9 @@ def setup_python(
         sys.exit(1)
 
     call(["pip", "--version"], env=env)
+
+    # update env with results from CIBW_ENVIRONMENT
+    env = environment.as_dictionary(prev_environment=env)
 
     if build_frontend == "pip":
         call(


### PR DESCRIPTION
Closes #942. macOS and Windows currently do not support setting an environment variable that is not supported in the original pip but in the pinned pip we install.
