### PR TITLE
fix: minor fixes to get pycharm not to complain too much

### DIFF
--- a/cibuildwheel/docker_container.py
+++ b/cibuildwheel/docker_container.py
@@ -131,7 +131,7 @@ class DockerContainer:
     def glob(self, path: PurePath, pattern: str) -> List[PurePath]:
         glob_pattern = os.path.join(str(path), pattern)
 
-        path_strs = json.loads(
+        path_strings = json.loads(
             self.call(
                 [
                     self.UTILITY_PYTHON,
@@ -142,7 +142,7 @@ class DockerContainer:
             )
         )
 
-        return [PurePath(p) for p in path_strs]
+        return [PurePath(p) for p in path_strings]
 
     def call(
         self,
@@ -170,7 +170,7 @@ class DockerContainer:
         # can cope with spaces and strange characters in the name or value.
         # Finally, the remote shell is told to write a footer - this will show
         # up in the output so we know when to stop reading, and will include
-        # the returncode of `command`.
+        # the return code of `command`.
         self.bash_stdin.write(
             bytes(
                 f"""(
@@ -199,11 +199,11 @@ class DockerContainer:
                     len(line)
                     - 1  # newline character
                     - len(end_of_message)  # delimiter
-                    - 4  # 4 returncode decimals
+                    - 4  # 4 return code decimals
                 )
                 # fmt: on
-                returncode_str = line[footer_offset : footer_offset + 4]
-                returncode = int(returncode_str)
+                return_code_str = line[footer_offset : footer_offset + 4]
+                return_code = int(return_code_str)
                 # add the last line to output, without the footer
                 output_io.write(line[0:footer_offset])
                 break
@@ -215,8 +215,8 @@ class DockerContainer:
         else:
             output = ""
 
-        if returncode != 0:
-            raise subprocess.CalledProcessError(returncode, args, output)
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, args, output)
 
         return output
 

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -14,7 +14,7 @@ FOLD_PATTERNS = {
     "github": ("::group::{name}", "::endgroup::{name}"),
 }
 
-PLATFORM_IDENTIFIER_DESCIPTIONS = {
+PLATFORM_IDENTIFIER_DESCRIPTIONS = {
     "manylinux_x86_64": "manylinux x86_64",
     "manylinux_i686": "manylinux i686",
     "manylinux_aarch64": "manylinux aarch64",
@@ -204,7 +204,7 @@ def build_description_from_identifier(identifier: str) -> str:
     build_description += f" {python_version[0]}.{python_version[1:]} "
 
     try:
-        build_description += PLATFORM_IDENTIFIER_DESCIPTIONS[platform_identifier]
+        build_description += PLATFORM_IDENTIFIER_DESCRIPTIONS[platform_identifier]
     except KeyError as e:
         raise Exception("unknown platform") from e
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -402,10 +402,10 @@ def build(options: Options) -> None:
                 config_setting = " ".join(verbosity_flags)
                 build_env = env.copy()
                 if build_options.dependency_constraints:
-                    constr = build_options.dependency_constraints.get_for_python_version(
+                    constraint_path = build_options.dependency_constraints.get_for_python_version(
                         config.version
                     )
-                    build_env["PIP_CONSTRAINT"] = constr.as_uri()
+                    build_env["PIP_CONSTRAINT"] = constraint_path.as_uri()
                 build_env["VIRTUALENV_PIP"] = get_pip_version(env)
                 call(
                     [
@@ -457,7 +457,7 @@ def build(options: Options) -> None:
 
             if build_options.test_command and build_options.test_selector(config.identifier):
                 machine_arch = platform.machine()
-                testing_archs: List[Literal["x86_64", "arm64"]] = []
+                testing_archs: List[Literal["x86_64", "arm64"]]
 
                 if config_is_arm64:
                     testing_archs = ["arm64"]

--- a/cibuildwheel/projectfiles.py
+++ b/cibuildwheel/projectfiles.py
@@ -51,7 +51,7 @@ def setup_py_python_requires(content: str) -> Optional[str]:
 
 
 def get_requires_python_str(package_dir: Path) -> Optional[str]:
-    "Return the python requires string from the most canonical source available, or None"
+    """Return the python requires string from the most canonical source available, or None"""
 
     # Read in from pyproject.toml:project.requires-python
     try:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -87,8 +87,8 @@ def get_python_configurations(
 
 
 def extract_zip(zip_src: Path, dest: Path) -> None:
-    with ZipFile(zip_src) as zip:
-        zip.extractall(dest)
+    with ZipFile(zip_src) as zip_:
+        zip_.extractall(dest)
 
 
 def install_cpython(version: str, arch: str, nuget: Path) -> Path:


### PR DESCRIPTION
minor fixes to get pycharm not to complain too much:
- spelling when deemed appropriate
- variable name shadowing builtin function
- unused assignment
- invalid doc string