### PR TITLE
feat: include size in the final printout

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -12,7 +12,7 @@ import urllib.request
 from enum import Enum
 from pathlib import Path
 from time import sleep
-from typing import Any, Dict, Iterable, Iterator, List, Optional, TextIO
+from typing import Any, Dict, Iterable, Iterator, List, NamedTuple, Optional, TextIO
 
 import bracex
 import certifi
@@ -352,11 +352,25 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     existing_contents = set(output_dir.iterdir())
     yield
     final_contents = set(output_dir.iterdir())
-    new_contents = final_contents - existing_contents
+
+    class FileReport(NamedTuple):
+        name: str
+        size: str
+
+    new_contents = [
+        FileReport(wheel.name, f"{(wheel.stat().st_size + 1023) // 1024:,d}")
+        for wheel in final_contents - existing_contents
+    ]
+    max_name_len = max(len(f.name) for f in new_contents)
+    max_size_len = max(len(f.size) for f in new_contents)
     n = len(new_contents)
     s = time.time() - start_time
     m = s / 60
-    print(msg.format(n=n, s=s, m=m), *sorted(f"  {f.name}" for f in new_contents), sep="\n")
+    print(
+        msg.format(n=n, s=s, m=m),
+        *sorted(f"  {f.name:<{max_name_len}s} {f.size:>{max_size_len}s} kB" for f in new_contents),
+        sep="\n",
+    )
 
 
 def get_pip_version(env: Dict[str, str]) -> str:

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -368,7 +368,7 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     m = s / 60
     print(
         msg.format(n=n, s=s, m=m),
-        *sorted(f"  {f.name:<{max_name_len}s} {f.size:>{max_size_len}s} kB" for f in new_contents),
+        *sorted(f"  {f.name:<{max_name_len}s}   {f.size:>{max_size_len}s} kB" for f in new_contents),
         sep="\n",
     )
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -368,7 +368,9 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     m = s / 60
     print(
         msg.format(n=n, s=s, m=m),
-        *sorted(f"  {f.name:<{max_name_len}s}   {f.size:>{max_size_len}s} kB" for f in new_contents),
+        *sorted(
+            f"  {f.name:<{max_name_len}s}   {f.size:>{max_size_len}s} kB" for f in new_contents
+        ),
         sep="\n",
     )
 

--- a/unit_test/wheel_print_test.py
+++ b/unit_test/wheel_print_test.py
@@ -6,15 +6,15 @@ from cibuildwheel.util import print_new_wheels
 def test_printout_wheels(tmp_path, capsys):
     tmp_path.joinpath("example.0").touch()
     with print_new_wheels("TEST_MSG: {n}", tmp_path):
-        tmp_path.joinpath("example.1").touch()
-        tmp_path.joinpath("example.2").touch()
+        tmp_path.joinpath("example.1").write_bytes(b"0" * 1023)
+        tmp_path.joinpath("example.2").write_bytes(b"0" * 1025)
 
     captured = capsys.readouterr()
     assert captured.err == ""
 
     assert "example.0" not in captured.out
-    assert "example.1\n" in captured.out
-    assert "example.2\n" in captured.out
+    assert "example.1 1 kB\n" in captured.out
+    assert "example.2 2 kB\n" in captured.out
     assert "TEST_MSG:" in captured.out
     assert "TEST_MSG: 2\n" in captured.out
 

--- a/unit_test/wheel_print_test.py
+++ b/unit_test/wheel_print_test.py
@@ -13,8 +13,8 @@ def test_printout_wheels(tmp_path, capsys):
     assert captured.err == ""
 
     assert "example.0" not in captured.out
-    assert "example.1 1 kB\n" in captured.out
-    assert "example.2 2 kB\n" in captured.out
+    assert "example.1   1 kB\n" in captured.out
+    assert "example.2   2 kB\n" in captured.out
     assert "TEST_MSG:" in captured.out
     assert "TEST_MSG: 2\n" in captured.out
 


### PR DESCRIPTION
Fixes #734

It uses `kB` unconditionally.

e.g.
```
13 wheels produced in 9 minutes:
  spam-0.1.0-cp310-cp310-macosx_10_9_universal2.whl  4 kB
  spam-0.1.0-cp310-cp310-macosx_10_9_x86_64.whl      3 kB
  spam-0.1.0-cp310-cp310-macosx_11_0_arm64.whl       3 kB
  spam-0.1.0-cp36-cp36m-macosx_10_9_x86_64.whl       3 kB
  spam-0.1.0-cp37-cp37m-macosx_10_9_x86_64.whl       3 kB
  spam-0.1.0-cp38-cp38-macosx_10_9_universal2.whl    4 kB
  spam-0.1.0-cp38-cp38-macosx_10_9_x86_64.whl        3 kB
  spam-0.1.0-cp38-cp38-macosx_11_0_arm64.whl         3 kB
  spam-0.1.0-cp39-cp39-macosx_10_9_universal2.whl    4 kB
  spam-0.1.0-cp39-cp39-macosx_10_9_x86_64.whl        3 kB
  spam-0.1.0-cp39-cp39-macosx_11_0_arm64.whl         3 kB
  spam-0.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl 3 kB
  spam-0.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl 4 kB
```