### PR TITLE
Use consistent spelling for "license" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Since `cibuildwheel` repairs the wheel with `delocate` or `auditwheel`, it might
 
 It helps ensure that the library can run without any dependencies outside of the pip toolchain.
 
-This is similar to static linking, so it might have some licence implications. Check the license for any code you're pulling in to make sure that's allowed.
+This is similar to static linking, so it might have some license implications. Check the license for any code you're pulling in to make sure that's allowed.
 
 Changelog
 =========


### PR DESCRIPTION
This PR is a one-word change to `README.md`. One sentence uses the en-gb spelling `licence` and the next uses the en-us spelling `license`. I've changed the first sentence to match the second.