### PR TITLE
Add Arbor to working-examples.md

### DIFF
--- a/docs/working-examples.md
+++ b/docs/working-examples.md
@@ -93,6 +93,7 @@ title: Working examples
 | [xmlstarlet][]                    | ![github icon][] | ![windows icon][] ![apple icon][] ![linux icon][] | Python 3.6+ CFFI bindings with true MSVC build. |
 | [CorrectionLib][]                 | ![github icon][] | ![apple icon][] ![linux icon][] | Structured JSON powered correction library for HEP, designed for the CMS experiment at CERN. |
 | [SiPM][]                          | ![github icon][] | ![apple icon][] ![linux icon][] | High performance library for SiPM detectors simulation using C++17, OpenMP and AVX2 intrinsics. |
+| [Arbor][]                          | ![github icon][] | ![apple icon][] ![linux icon][] | Arbor is a multi-compartment neuron simulation library; compatible with next-generation accelerators; best-practices applied to research software; focussed on community-driven development. |
 
 [scikit-learn]: https://github.com/scikit-learn/scikit-learn
 [Tornado]: https://github.com/tornadoweb/tornado
@@ -179,6 +180,7 @@ title: Working examples
 [xmlstarlet]: https://github.com/dimitern/xmlstarlet
 [CorrectionLib]: https://github.com/cms-nanoAOD/correctionlib
 [SiPM]: https://github.com/EdoPro98/SimSiPM
+[Arbor]: https://github.com/arbor-sim/arbor
 
 [appveyor icon]: data/readme_icons/appveyor.svg
 [github icon]: data/readme_icons/github.svg


### PR DESCRIPTION
Might be interesting to mention that we have a [small script](https://github.com/arbor-sim/arbor/blob/master/scripts/patchwheel.py) to patch `rpath` in included libraries, potentially useful to others. The comment seemed to indicate an interest in such things, but there is no obvious place to add it. Maybe just append to the description?