### PR TITLE
fix: include Requires-Python info in printout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,9 @@ repos:
   rev: v0.931
   hooks:
   - id: mypy
+    name: mypy 3.6 on cibuildwheel/
     exclude: ^(bin|cibuildwheel/resources|docs)/.*py$
-    args: ["--python-version=3.6", "--scripts-are-modules", "--show-error-codes"]
+    args: ["--python-version=3.6", "--show-error-codes"]
     additional_dependencies: &mypy-dependencies
       - nox
       - packaging>=21.0
@@ -66,10 +67,15 @@ repos:
       - types-pyyaml
       - types-requests
       - bracex
+      - dataclasses
   - id: mypy
     name: mypy 3.7+ on bin/
     files: ^((bin|docs)/.*py)$
-    args: ["--python-version=3.7", "--scripts-are-modules", "--show-error-codes"]
+    args: ["--python-version=3.7", "--show-error-codes"]
+    additional_dependencies: *mypy-dependencies
+  - id: mypy
+    name: mypy 3.10
+    args: ["--python-version=3.10", "--show-error-codes"]
     additional_dependencies: *mypy-dependencies
 
 - repo: https://github.com/asottile/yesqa


### PR DESCRIPTION
Closes #1015 by adding a missing field (`requires_python`) to the printout, making this issue much easier to debug in the future. Using dataclasses to simplify this, though I could not statically force `kw_only=True`/`_: KW_ONLY` (via `sys.version_info` or `TYPE_CHECKING`) into this so mypy keeps us from relying on field order (and this also forces skip to be before build, since you can't add a defaulted field before a required one). Also fixed a mistake where `PRERELEASE_SKIP` was being pulled from a not-yet-defined child, which is confusing. `self.<var>` works just fine for reading it, or `self.__class__.var` works too.
