### PR TITLE
fix: A type alias cannot be final

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -45,7 +45,7 @@ resources_dir: Final = Path(__file__).parent / "resources"
 
 install_certifi_script: Final = resources_dir / "install_certifi.py"
 
-BuildFrontend: Final = Literal["pip", "build"]
+BuildFrontend = Literal["pip", "build"]
 
 MANYLINUX_ARCHS: Final = (
     "x86_64",


### PR DESCRIPTION
Addition of Python 3.10 to the checks exposed this.