### PR TITLE
Update Azure Windows image names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: windows_36
-  pool: {vmImage: 'vs2017-win2016'}
+  pool: {vmImage: 'windows-2019'}
   timeoutInMinutes: 180
   steps:
     - task: UsePythonVersion@0
@@ -32,7 +32,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: windows_38
-  pool: {vmImage: 'vs2017-win2016'}
+  pool: {vmImage: 'windows-2019'}
   timeoutInMinutes: 180
   steps:
     - task: UsePythonVersion@0

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -28,7 +28,7 @@ jobs:
       inputs: {pathtoPublish: wheelhouse}
 
 - job: windows
-  pool: {vmImage: 'vs2017-win2016'}
+  pool: {vmImage: 'windows-2019'}
   steps:
     - task: UsePythonVersion@0
     - bash: |


### PR DESCRIPTION
Update to the oldest non-deprecated images as vs2017-win2016 is [going away in March](https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/#windows).

Closes #1023