### PR TITLE
Change github.event.ref to github.ref

### DIFF
--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
According to the [documentation](https://docs.github.com/en/actions/learn-github-actions/environment-variables), the variable `GITHUB_REF` which is accessed here via `github.ref` has the value `refs/tags/<tag_name>` for tags. `github.event.ref` just contains `<tag_name>` (as described [here](https://stackoverflow.com/a/59349906)).

An alternative edit is of course 
```yaml
if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
```