### PR TITLE
Build wheels from sdist (separate entrypoint)

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -28,6 +28,7 @@ def main() -> None:
     platform: PlatformName
 
     parser = argparse.ArgumentParser(
+        prog="cibuildwheel",
         description="Build wheels for all the platforms.",
         epilog="""
             Most options are supplied via environment variables or in

--- a/cibuildwheel/from_sdist.py
+++ b/cibuildwheel/from_sdist.py
@@ -22,7 +22,7 @@ def main() -> None:
             the package directory.
             """,
         ),
-        epilog="""Any further arguments will be passed on to cibuildwheel.""",
+        epilog="Any further arguments will be passed on to cibuildwheel.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
@@ -65,7 +65,7 @@ def main() -> None:
 
         temp_dir_contents = list(temp_dir.iterdir())
 
-        if len(temp_dir_contents) != 1 or not temp_dir_contents[0].is_dir:
+        if len(temp_dir_contents) != 1 or not temp_dir_contents[0].is_dir():
             exit("invalid sdist: didn't contain a single dir")
 
         project_dir = temp_dir_contents[0]

--- a/cibuildwheel/from_sdist.py
+++ b/cibuildwheel/from_sdist.py
@@ -11,6 +11,7 @@ from cibuildwheel.util import format_safe
 
 def main() -> None:
     parser = argparse.ArgumentParser(
+        prog="cibuildwheel-from-sdist",
         description=textwrap.dedent(
             """
             Build wheels from an sdist archive.

--- a/cibuildwheel/from_sdist.py
+++ b/cibuildwheel/from_sdist.py
@@ -1,0 +1,102 @@
+import argparse
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+from pathlib import Path
+
+from cibuildwheel.util import format_safe
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=textwrap.dedent(
+            """
+            Build wheels from an sdist archive.
+
+            Extracts the sdist to a temp dir and calls cibuildwheel on the
+            resulting package directory. Note that cibuildwheel will be
+            invoked with its working directory as the package directory, so
+            options aside from --output-dir and --config-file are relative to
+            the package directory.
+            """,
+        ),
+        epilog="""Any further arguments will be passed on to cibuildwheel.""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        default="wheelhouse",
+        help="""
+            Destination folder for the wheels. Default: wheelhouse.
+        """,
+    )
+
+    parser.add_argument(
+        "--config-file",
+        default="",
+        help="""
+            TOML config file. To refer to a file inside the sdist, use the
+            `{project}` or `{package}` placeholder. e.g. `--config-file
+            {project}/config/cibuildwheel.toml` Default: "", meaning the
+            pyproject.toml inside the sdist, if it exists.
+        """,
+    )
+
+    parser.add_argument(
+        "package",
+        help="""
+            Path to the sdist archive that you want wheels for. Must be a
+            tar.gz archive file.
+        """,
+    )
+
+    args, passthrough_args = parser.parse_known_args()
+
+    output_dir = Path(args.output_dir).resolve()
+
+    with tempfile.TemporaryDirectory(prefix="cibw-sdist-") as temp_dir_str:
+        temp_dir = Path(temp_dir_str)
+
+        with tarfile.open(args.package) as tar:
+            tar.extractall(path=temp_dir)
+
+        temp_dir_contents = list(temp_dir.iterdir())
+
+        if len(temp_dir_contents) != 1 or not temp_dir_contents[0].is_dir:
+            exit("invalid sdist: didn't contain a single dir")
+
+        project_dir = temp_dir_contents[0]
+
+        if args.config_file:
+            # expand the placeholders if they're used
+            config_file_path = format_safe(
+                args.config_file,
+                project=project_dir,
+                package=project_dir,
+            )
+            config_file = Path(config_file_path).resolve()
+        else:
+            config_file = None
+
+        exit(
+            subprocess.call(
+                [
+                    sys.executable,
+                    "-m",
+                    "cibuildwheel",
+                    *(["--config-file", str(config_file)] if config_file else []),
+                    "--output-dir",
+                    output_dir,
+                    *passthrough_args,
+                    ".",
+                ],
+                cwd=project_dir,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ include =
 [options.entry_points]
 console_scripts =
     cibuildwheel = cibuildwheel.__main__:main
+    cibuildwheel-from-sdist = cibuildwheel.from_sdist:main
 
 [options.package_data]
 cibuildwheel = resources/*

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
         "pytest>=6",
         "pytest-timeout",
         "pytest-xdist",
+        "build",
     ],
     "bin": [
         "click",

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -8,9 +8,6 @@ from test.test_projects.base import TestProject
 
 from . import test_projects, utils
 
-basic_project = test_projects.new_c_project()
-
-
 # utilities
 
 
@@ -54,6 +51,8 @@ def cibuildwheel_from_sdist_run(sdist_path, add_env=None, config_file=None):
 
 
 def test_simple(tmp_path):
+    basic_project = test_projects.new_c_project()
+
     # make an sdist of the project
     sdist_dir = tmp_path / "sdist"
     sdist_dir.mkdir()
@@ -62,9 +61,7 @@ def test_simple(tmp_path):
     # build the wheels from sdist
     actual_wheels = cibuildwheel_from_sdist_run(
         sdist_path,
-        add_env={
-            "CIBW_BUILD": "cp39-*",
-        },
+        add_env={"CIBW_BUILD": "cp39-*"},
     )
 
     # check that the expected wheels are produced
@@ -73,6 +70,8 @@ def test_simple(tmp_path):
 
 
 def test_external_config_file_argument(tmp_path, capfd):
+    basic_project = test_projects.new_c_project()
+
     # make an sdist of the project
     sdist_dir = tmp_path / "sdist"
     sdist_dir.mkdir()
@@ -92,9 +91,7 @@ def test_external_config_file_argument(tmp_path, capfd):
     # build the wheels from sdist
     actual_wheels = cibuildwheel_from_sdist_run(
         sdist_path,
-        add_env={
-            "CIBW_BUILD": "cp39-*",
-        },
+        add_env={"CIBW_BUILD": "cp39-*"},
         config_file=config_file,
     )
 
@@ -159,12 +156,10 @@ def test_internal_config_file_argument(tmp_path, capfd):
     sdist_dir.mkdir()
     sdist_path = make_sdist(project, sdist_dir)
 
-    # build the wheels from sdist
+    # build the wheels from sdist, referencing the config file inside
     actual_wheels = cibuildwheel_from_sdist_run(
         sdist_path,
-        add_env={
-            "CIBW_BUILD": "cp39-*",
-        },
+        add_env={"CIBW_BUILD": "cp39-*"},
         config_file="{project}/wheel_build_config.toml",
     )
 

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -175,3 +175,44 @@ def test_internal_config_file_argument(tmp_path, capfd):
     # check that before-all was run
     captured = capfd.readouterr()
     assert "test log statement from before-all 1829" in captured.out
+
+
+def test_argument_passthrough(tmp_path, capfd):
+    basic_project = test_projects.new_c_project()
+
+    # make an sdist of a project
+    sdist_dir = tmp_path / "sdist"
+    sdist_dir.mkdir()
+    sdist_path = make_sdist(basic_project, sdist_dir)
+
+    # make a call that should pass some args through to cibuildwheel
+    # this asks cibuildwheel to print the ppc64le build identifiers
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cibuildwheel.from_sdist",
+            sdist_path,
+            "--platform",
+            "linux",
+            "--archs",
+            "ppc64le",
+            "--print-build-identifiers",
+        ],
+        env={
+            **os.environ,
+            "CIBW_BUILD": "cp38-*",
+        },
+        check=True,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    # fmt: off
+    assert process.stdout == textwrap.dedent(
+        """
+        cp38-manylinux_ppc64le
+        cp38-musllinux_ppc64le
+        """
+    ).lstrip()
+    # fmt: on


### PR DESCRIPTION
Alternative to #1020. Fixes #597.

This provides a separate entrypoint for building wheels from sdist, rather than from a source tree.

I'm using a different entrypoint because the way that command line arguments are parsed are different. This is because cibuildwheel is run with working dir as the root of the sdist, not the current working dir. That is because the docker 'project' is the contents of the sdist, and paths in options (e.g. options within pyproject.toml) should be relative to the sdist root.

The command line options `--output-dir` and `--config-file` are the exceptions to this - they are options of cibuildwheel-from-sdist and thus resolved relative to the working dir.

Docs are still to come, but help output is:

```
$ cibuildwheel-from-sdist --help
usage: cibuildwheel-from-sdist [-h] [--output-dir OUTPUT_DIR]
                               [--config-file CONFIG_FILE]
                               package

Build wheels from an sdist archive.

Extracts the sdist to a temp dir and calls cibuildwheel on the
resulting package directory. Note that cibuildwheel will be
invoked with its working directory as the package directory, so
options aside from --output-dir and --config-file are relative to
the package directory.

positional arguments:
  package               Path to the sdist archive that you want wheels for.
                        Must be a tar.gz archive file.

optional arguments:
  -h, --help            show this help message and exit
  --output-dir OUTPUT_DIR
                        Destination folder for the wheels. Default:
                        wheelhouse.
  --config-file CONFIG_FILE
                        TOML config file. To refer to a file inside the sdist,
                        use the `{project}` or `{package}` placeholder. e.g.
                        `--config-file {project}/config/cibuildwheel.toml`
                        Default: "", meaning the pyproject.toml inside the
                        sdist, if it exists.

Any further arguments will be passed on to cibuildwheel.
```
