### PR TITLE
fix: Don't error if no new wheels were built

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -287,9 +287,7 @@ def build(options: Options, tmp_path: Path) -> None:
             env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
             env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
             before_all_prepared = prepare_command(
-                before_all_options.before_all,
-                project=".",
-                package=before_all_options.package_dir,
+                before_all_options.before_all, project=".", package=before_all_options.package_dir
             )
             shell(before_all_prepared, env=env)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -285,7 +285,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
                 env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
                 before_all_prepared = prepare_command(
-                    before_all_options.before_all, project=".", package=before_all_options.package_dir
+                    before_all_options.before_all,
+                    project=".",
+                    package=before_all_options.package_dir,
                 )
                 shell(before_all_prepared, env=env)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -276,17 +276,18 @@ def build(options: Options, tmp_path: Path) -> None:
     )
 
     try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+        if len(python_configurations) > 0:
+            before_all_options_identifier = python_configurations[0].identifier
+            before_all_options = options.build_options(before_all_options_identifier)
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
-            before_all_prepared = prepare_command(
-                before_all_options.before_all, project=".", package=before_all_options.package_dir
-            )
-            shell(before_all_prepared, env=env)
+            if before_all_options.before_all:
+                log.step("Running before_all...")
+                env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+                env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
+                before_all_prepared = prepare_command(
+                    before_all_options.before_all, project=".", package=before_all_options.package_dir
+                )
+                shell(before_all_prepared, env=env)
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -275,21 +275,23 @@ def build(options: Options, tmp_path: Path) -> None:
         options.globals.build_selector, options.globals.architectures
     )
 
-    try:
-        if len(python_configurations) > 0:
-            before_all_options_identifier = python_configurations[0].identifier
-            before_all_options = options.build_options(before_all_options_identifier)
+    if len(python_configurations) == 0:
+        return
 
-            if before_all_options.before_all:
-                log.step("Running before_all...")
-                env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-                env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
-                before_all_prepared = prepare_command(
-                    before_all_options.before_all,
-                    project=".",
-                    package=before_all_options.package_dir,
-                )
-                shell(before_all_prepared, env=env)
+    try:
+        before_all_options_identifier = python_configurations[0].identifier
+        before_all_options = options.build_options(before_all_options_identifier)
+
+        if before_all_options.before_all:
+            log.step("Running before_all...")
+            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+            env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
+            before_all_prepared = prepare_command(
+                before_all_options.before_all,
+                project=".",
+                package=before_all_options.package_dir,
+            )
+            shell(before_all_prepared, env=env)
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -437,7 +437,6 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     ]
 
     if len(new_contents) == 0:
-        print("No new wheels")
         return
 
     max_name_len = max(len(f.name) for f in new_contents)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -437,7 +437,7 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
     ]
 
     if len(new_contents) == 0:
-        print('No new wheels')
+        print("No new wheels")
         return
 
     max_name_len = max(len(f.name) for f in new_contents)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -435,6 +435,11 @@ def print_new_wheels(msg: str, output_dir: Path) -> Iterator[None]:
         FileReport(wheel.name, f"{(wheel.stat().st_size + 1023) // 1024:,d}")
         for wheel in final_contents - existing_contents
     ]
+
+    if len(new_contents) == 0:
+        print('No new wheels')
+        return
+
     max_name_len = max(len(f.name) for f in new_contents)
     max_size_len = max(len(f.size) for f in new_contents)
     n = len(new_contents)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -234,18 +234,20 @@ def build(options: Options, tmp_path: Path) -> None:
         options.globals.build_selector, options.globals.architectures
     )
 
-    try:
-        if len(python_configurations) > 0:
-            before_all_options_identifier = python_configurations[0].identifier
-            before_all_options = options.build_options(before_all_options_identifier)
+    if len(python_configurations) == 0:
+        return
 
-            if before_all_options.before_all:
-                log.step("Running before_all...")
-                env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-                before_all_prepared = prepare_command(
-                    before_all_options.before_all, project=".", package=options.globals.package_dir
-                )
-                shell(before_all_prepared, env=env)
+    try:
+        before_all_options_identifier = python_configurations[0].identifier
+        before_all_options = options.build_options(before_all_options_identifier)
+
+        if before_all_options.before_all:
+            log.step("Running before_all...")
+            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+            before_all_prepared = prepare_command(
+                before_all_options.before_all, project=".", package=options.globals.package_dir
+            )
+            shell(before_all_prepared, env=env)
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -235,16 +235,17 @@ def build(options: Options, tmp_path: Path) -> None:
     )
 
     try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+        if len(python_configurations) > 0:
+            before_all_options_identifier = python_configurations[0].identifier
+            before_all_options = options.build_options(before_all_options_identifier)
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            before_all_prepared = prepare_command(
-                before_all_options.before_all, project=".", package=options.globals.package_dir
-            )
-            shell(before_all_prepared, env=env)
+            if before_all_options.before_all:
+                log.step("Running before_all...")
+                env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+                before_all_prepared = prepare_command(
+                    before_all_options.before_all, project=".", package=options.globals.package_dir
+                )
+                shell(before_all_prepared, env=env)
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -74,5 +74,5 @@ def test_allow_empty(tmp_path, build_frontend_env):
         project_dir, add_env=build_frontend_env, add_args=["--allow-empty"]
     )
 
-    # check that the expected wheels are produced
-    expected_wheels = utils.expected_wheels("spam", "0.1.0")
+    # check that nothing was built
+    assert len(actual_wheels) == 0

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -61,7 +61,7 @@ def test_build_identifiers(tmp_path):
     ), f"{expected_wheels} vs {build_identifiers}"
 
 
-def test_allow_empty(tmp_path, build_frontend_env):
+def test_allow_empty(tmp_path):
     project_dir = tmp_path / "project"
     basic_project.generate(project_dir)
 
@@ -69,7 +69,7 @@ def test_allow_empty(tmp_path, build_frontend_env):
     # without error
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
-        add_env={"CIBW_BUILD": "BUILD_NOTHING_AT_ALL", **build_frontend_env},
+        add_env={"CIBW_BUILD": "BUILD_NOTHING_AT_ALL"},
         add_args=["--allow-empty"],
     )
 

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -59,3 +59,20 @@ def test_build_identifiers(tmp_path):
     assert len(expected_wheels) == len(
         build_identifiers
     ), f"{expected_wheels} vs {build_identifiers}"
+
+
+def test_allow_empty(tmp_path, build_frontend_env):
+    project_dir = tmp_path / "project"
+    basic_project.generate(project_dir)
+
+    # Sanity check - --allow-empty should cause a no-op build to complete
+    # without error
+    build_frontend_env["CIBW_BUILD"] = "BUILD_NOTHING_AT_ALL"
+
+    # build the wheels
+    actual_wheels = utils.cibuildwheel_run(
+        project_dir, add_env=build_frontend_env,
+        add_args=["--allow-empty"])
+
+    # check that the expected wheels are produced
+    expected_wheels = utils.expected_wheels("spam", "0.1.0")

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -67,11 +67,13 @@ def test_allow_empty(tmp_path, build_frontend_env):
 
     # Sanity check - --allow-empty should cause a no-op build to complete
     # without error
-    build_frontend_env["CIBW_BUILD"] = "BUILD_NOTHING_AT_ALL"
-
-    # build the wheels
     actual_wheels = utils.cibuildwheel_run(
-        project_dir, add_env=build_frontend_env, add_args=["--allow-empty"]
+        project_dir,
+        add_env={
+            "CIBW_BUILD": "BUILD_NOTHING_AT_ALL",
+            **build_frontend_env
+        },
+        add_args=["--allow-empty"]
     )
 
     # check that nothing was built

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -71,8 +71,8 @@ def test_allow_empty(tmp_path, build_frontend_env):
 
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(
-        project_dir, add_env=build_frontend_env,
-        add_args=["--allow-empty"])
+        project_dir, add_env=build_frontend_env, add_args=["--allow-empty"]
+    )
 
     # check that the expected wheels are produced
     expected_wheels = utils.expected_wheels("spam", "0.1.0")

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -69,11 +69,8 @@ def test_allow_empty(tmp_path, build_frontend_env):
     # without error
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
-        add_env={
-            "CIBW_BUILD": "BUILD_NOTHING_AT_ALL",
-            **build_frontend_env
-        },
-        add_args=["--allow-empty"]
+        add_env={"CIBW_BUILD": "BUILD_NOTHING_AT_ALL", **build_frontend_env},
+        add_args=["--allow-empty"],
     )
 
     # check that nothing was built

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ def cibuildwheel_get_build_identifiers(project_path, env=None, *, prerelease_pyt
     return cmd_output.strip().split("\n")
 
 
-def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, output_dir=None):
+def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, output_dir=None, add_args=None):
     """
     Runs cibuildwheel as a subprocess, building the project at project_path.
 
@@ -57,12 +57,16 @@ def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, outp
     :param add_env: environment used to update env
     :param output_dir: directory where wheels are saved. If None, a temporary
     directory will be used for the duration of the command.
+    :param add_args: Additional command-line arguments to pass to cibuildwheel.
     :return: list of built wheels (file names).
     """
     if env is None:
         env = os.environ.copy()
         # If present in the host environment, remove the MACOSX_DEPLOYMENT_TARGET for consistency
         env.pop("MACOSX_DEPLOYMENT_TARGET", None)
+
+    if add_args is None:
+        add_args = []
 
     if add_env is not None:
         env.update(add_env)
@@ -77,7 +81,7 @@ def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, outp
                 "--output-dir",
                 str(output_dir or tmp_output_dir),
                 str(package_dir),
-            ],
+            ] + add_args,
             env=env,
             cwd=project_path,
             check=True,

--- a/test/utils.py
+++ b/test/utils.py
@@ -83,8 +83,8 @@ def cibuildwheel_run(
                 "--output-dir",
                 str(output_dir or tmp_output_dir),
                 str(package_dir),
-            ]
-            + add_args,
+                *add_args,
+            ],
             env=env,
             cwd=project_path,
             check=True,

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,9 @@ def cibuildwheel_get_build_identifiers(project_path, env=None, *, prerelease_pyt
     return cmd_output.strip().split("\n")
 
 
-def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, output_dir=None, add_args=None):
+def cibuildwheel_run(
+    project_path, package_dir=".", env=None, add_env=None, output_dir=None, add_args=None
+):
     """
     Runs cibuildwheel as a subprocess, building the project at project_path.
 
@@ -81,7 +83,8 @@ def cibuildwheel_run(project_path, package_dir=".", env=None, add_env=None, outp
                 "--output-dir",
                 str(output_dir or tmp_output_dir),
                 str(package_dir),
-            ] + add_args,
+            ]
+            + add_args,
             env=env,
             cwd=project_path,
             check=True,


### PR DESCRIPTION
Howdy, this PR contains a simple fix for an issue which I came across when using the `--allow-empty` flag. There is some logic in `cibuildwheel.util.print_new_wheels` which is raising an error if no new wheels were built. 

```
mkdir testproj && cd testproj && touch setup.py
CIBW_BUILD="don't match anything" cibuildwheel --platform=linux --allow-empty
```

<details>

```
     _ _       _ _   _       _           _
 ___|_| |_ _ _|_| |_| |_ _ _| |_ ___ ___| |
|  _| | . | | | | | . | | | |   | -_| -_| |
|___|_|___|___|_|_|___|_____|_|_|___|___|_|

cibuildwheel version 2.4.0

Build options:
  platform: 'linux'
  architectures: {<Architecture.i686: 'i686'>, <Architecture.x86_64: 'x86_64'>}
  build_selector: BuildSelector(skip_config='', build_config="don't match anything", requires_python=None, prerelease_pythons=False)
  output_dir: PosixPath('wheelhouse')
  package_dir: PosixPath('.')
  test_selector: TestSelector(skip_config='', build_config='*', requires_python=None, prerelease_pythons=False)
  before_all: ''
  before_build: ''
  before_test: ''
  build_frontend: 'pip'
  build_verbosity: 0
  dependency_constraints: DependencyConstraints(PosixPath('/home/paulmc/Projects/cibuildwheel/cibuildwheel/resources/constraints.txt'))
  environment: ParsedEnvironment([])
  manylinux_images: {'x86_64': 'quay.io/pypa/manylinux2014_x86_64:2022-04-03-da6ecb3', 'i686': 'quay.io/pypa/manylinux2014_i686:2022-04-03-da6ecb3', 'pypy_x86_64': 'quay.io/pypa/manylinux2014_x86_64:2022-04-03-da6ecb3', 'aarch64': 'quay.io/pypa/manylinux2014_aarch64:2022-04-03-da6ecb3', 'ppc64le': 'quay.io/pypa/manylinux2014_ppc64le:2022-04-03-da6ecb3', 's390x': 'quay.io/pypa/manylinux2014_s390x:2022-04-03-da6ecb3', 'pypy_aarch64': 'quay.io/pypa/manylinux2014_aarch64:2022-04-03-da6ecb3', 'pypy_i686': 'quay.io/pypa/manylinux2014_i686:2022-04-03-da6ecb3'}
  musllinux_images: {'x86_64': 'quay.io/pypa/musllinux_1_1_x86_64:2022-04-03-da6ecb3', 'i686': 'quay.io/pypa/musllinux_1_1_i686:2022-04-03-da6ecb3', 'aarch64': 'quay.io/pypa/musllinux_1_1_aarch64:2022-04-03-da6ecb3', 'ppc64le': 'quay.io/pypa/musllinux_1_1_ppc64le:2022-04-03-da6ecb3', 's390x': 'quay.io/pypa/musllinux_1_1_s390x:2022-04-03-da6ecb3'}
  repair_command: 'auditwheel repair -w {dest_dir} {wheel}'
  test_command: ''
  test_extras: ''
  test_requires: []
Cache folder: /home/paulmc/.cache/cibuildwheel

Here we go!

cibuildwheel: No build identifiers selected: BuildSelector(skip_config='', build_config="don't match anything", requires_python=None, prerelease_pythons=False)
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/paulmc/Projects/cibuildwheel/cibuildwheel/__main__.py", line 295, in <module>
    main()
  File "/home/paulmc/Projects/cibuildwheel/cibuildwheel/__main__.py", line 213, in main
    assert_never(platform)
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/paulmc/Projects/cibuildwheel/cibuildwheel/util.py", line 433, in print_new_wheels
    max_name_len = max(len(f.name) for f in new_contents)
ValueError: max() arg is an empty sequence

✗ echo $?
1
```

</details>

With this PR:

```
CIBW_BUILD="don't match anything" cibuildwheel --platform=linux --allow-empty
```

<details>

```
     _ _       _ _   _       _           _
 ___|_| |_ _ _|_| |_| |_ _ _| |_ ___ ___| |
|  _| | . | | | | | . | | | |   | -_| -_| |
|___|_|___|___|_|_|___|_____|_|_|___|___|_|

cibuildwheel version 2.4.0

Build options:
  platform: 'linux'
  architectures: {<Architecture.x86_64: 'x86_64'>, <Architecture.i686: 'i686'>}
  build_selector: BuildSelector(skip_config='', build_config="don't match anything", requires_python=None, prerelease_pythons=False)
  output_dir: PosixPath('wheelhouse')
  package_dir: PosixPath('.')
  test_selector: TestSelector(skip_config='', build_config='*', requires_python=None, prerelease_pythons=False)
  before_all: ''
  before_build: ''
  before_test: ''
  build_frontend: 'pip'
  build_verbosity: 0
  dependency_constraints: DependencyConstraints(PosixPath('/home/paulmc/Projects/cibuildwheel/cibuildwheel/resources/constraints.txt'))
  environment: ParsedEnvironment([])
  manylinux_images: {'x86_64': 'quay.io/pypa/manylinux2014_x86_64:2022-04-03-da6ecb3', 'i686': 'quay.io/pypa/manylinux2014_i686:2022-04-03-da6ecb3', 'pypy_x86_64': 'quay.io/pypa/manylinux2014_x86_64:2022-04-03-da6ecb3', 'aarch64': 'quay.io/pypa/manylinux2014_aarch64:2022-04-03-da6ecb3', 'ppc64le': 'quay.io/pypa/manylinux2014_ppc64le:2022-04-03-da6ecb3', 's390x': 'quay.io/pypa/manylinux2014_s390x:2022-04-03-da6ecb3', 'pypy_aarch64': 'quay.io/pypa/manylinux2014_aarch64:2022-04-03-da6ecb3', 'pypy_i686': 'quay.io/pypa/manylinux2014_i686:2022-04-03-da6ecb3'}
  musllinux_images: {'x86_64': 'quay.io/pypa/musllinux_1_1_x86_64:2022-04-03-da6ecb3', 'i686': 'quay.io/pypa/musllinux_1_1_i686:2022-04-03-da6ecb3', 'aarch64': 'quay.io/pypa/musllinux_1_1_aarch64:2022-04-03-da6ecb3', 'ppc64le': 'quay.io/pypa/musllinux_1_1_ppc64le:2022-04-03-da6ecb3', 's390x': 'quay.io/pypa/musllinux_1_1_s390x:2022-04-03-da6ecb3'}
  repair_command: 'auditwheel repair -w {dest_dir} {wheel}'
  test_command: ''
  test_extras: ''
  test_requires: []
Cache folder: /home/paulmc/.cache/cibuildwheel

Here we go!

cibuildwheel: No build identifiers selected: BuildSelector(skip_config='', build_config="don't match anything", requires_python=None, prerelease_pythons=False)
No new wheels

✗ echo $?
0
```

</details>

Let me know if you'd like anything adjusted (e.g. the message that is printed). I'm also happy to add an integration test if you could point me to the right place to add it.

Thanks!