### PR TITLE
fix: extract project as current user on linux

### DIFF
--- a/cibuildwheel/docker_container.py
+++ b/cibuildwheel/docker_container.py
@@ -122,7 +122,7 @@ class DockerContainer:
         if from_path.is_dir():
             self.call(["mkdir", "-p", to_path])
             subprocess.run(
-                f"tar cf - . | docker exec -i {self.name} tar -xC {shell_quote(to_path)} -f -",
+                f"tar cf - . | docker exec -i {self.name} tar --no-same-owner -xC {shell_quote(to_path)} -f -",
                 shell=True,
                 check=True,
                 cwd=from_path,


### PR DESCRIPTION
This allows git to work properly, e.g., `versioneer`/`setuptools_scm` with latest git versions.
c.f. https://github.com/pypa/manylinux/issues/1309

e.g. for ninja which uses `versioneer` when built on `quay.io/pypa/manylinux2014_x86_64:latest`:
- `ninja-0+unknown-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` without the fix
- `ninja-1.10.2.3.post17.dev0+g3a8b005-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` with the fix