### PR TITLE
action: use python 3.10 to run the GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,19 @@ jobs:
         name: sample_wheels
         path: wheelhouse
 
+    - name: Get some sample wheels (GitHub Action)
+      uses: ./
+      with:
+        package-dir: sample_proj
+        output-dir: wheelhouse_action
+      env:
+        CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: sample_wheels_action
+        path: wheelhouse_action
+
     - name: Test cibuildwheel
       run: |
         python ./bin/run_tests.py

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,15 @@ branding:
 runs:
   using: composite
   steps:
+    # Set up a non-EOL, cibuildwheel & pipx supported Python version
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
         pipx run
+        --python "$(which python)"
         --spec '${{ github.action_path }}'
         cibuildwheel
         ${{ inputs.package-dir }}


### PR DESCRIPTION
We can use setup-python in the composite GitHub Action & use that python to run cibuildwheel with pipx.
This allows to drop python 3.6 without losing support for ubuntu-18.04 runners c.f. #508.
