### PR TITLE
Fix Linux builds on Windows

### DIFF
--- a/cibuildwheel/docker_container.py
+++ b/cibuildwheel/docker_container.py
@@ -128,7 +128,7 @@ class DockerContainer:
                 cwd=from_path,
             )
         else:
-            docker = subprocess.Popen(
+            with subprocess.Popen(
                 [
                     "docker",
                     "exec",
@@ -139,17 +139,17 @@ class DockerContainer:
                     f"cat > {shell_quote(to_path)}",
                 ],
                 stdin=subprocess.PIPE,
-            )
-            docker.stdin = cast(IO[bytes], docker.stdin)
+            ) as docker:
+                docker.stdin = cast(IO[bytes], docker.stdin)
 
-            with open(from_path, "rb") as from_file:
-                shutil.copyfileobj(from_file, docker.stdin)
+                with open(from_path, "rb") as from_file:
+                    shutil.copyfileobj(from_file, docker.stdin)
 
-            docker.stdin.close()
-            docker.wait()
+                docker.stdin.close()
+                docker.wait()
 
-            if docker.returncode:
-                raise subprocess.CalledProcessError(docker.returncode, docker.args, None, None)
+                if docker.returncode:
+                    raise subprocess.CalledProcessError(docker.returncode, docker.args, None, None)
 
     def copy_out(self, from_path: PurePath, to_path: Path) -> None:
         # note: we assume from_path is a dir

--- a/unit_test/docker_container_test.py
+++ b/unit_test/docker_container_test.py
@@ -3,7 +3,7 @@ import random
 import shutil
 import subprocess
 import textwrap
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PurePosixPath
 
 import pytest
 
@@ -178,7 +178,7 @@ def test_dir_operations(tmp_path: Path):
         test_file = test_dir / "test.dat"
         shutil.copyfile(original_test_file, test_file)
 
-        dst_dir = PurePath("/tmp/test_dir")
+        dst_dir = PurePosixPath("/tmp/test_dir")
         dst_file = dst_dir / "test.dat"
         container.copy_into(test_dir, dst_dir)
 

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -2,7 +2,7 @@ import platform as platform_module
 import subprocess
 import sys
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import cast
 from unittest import mock
 
@@ -53,7 +53,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
     # In Python 3.8+, this can be simplified to [0].kwargs
     kwargs = build_on_docker.call_args_list[0][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -61,7 +61,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
 
     kwargs = build_on_docker.call_args_list[1][1]
     assert "quay.io/pypa/manylinux2014_i686" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -69,7 +69,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
 
     kwargs = build_on_docker.call_args_list[2][1]
     assert "quay.io/pypa/musllinux_1_1_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -79,7 +79,7 @@ def test_build_default_launches(mock_build_docker, fake_package_dir, monkeypatch
 
     kwargs = build_on_docker.call_args_list[3][1]
     assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -119,7 +119,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[0][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -128,7 +128,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[1][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -139,7 +139,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[2][1]
     assert "quay.io/pypa/manylinux_2_24_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
@@ -151,7 +151,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[3][1]
     assert "quay.io/pypa/manylinux2014_i686" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -159,7 +159,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[4][1]
     assert "quay.io/pypa/musllinux_1_1_x86_64" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
@@ -169,7 +169,7 @@ before-all = "true"
 
     kwargs = build_on_docker.call_args_list[5][1]
     assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["docker"]["docker_image"]
-    assert kwargs["docker"]["cwd"] == Path("/project")
+    assert kwargs["docker"]["cwd"] == PurePosixPath("/project")
     assert kwargs["docker"]["simulate_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}


### PR DESCRIPTION
These changes fix Linux builds on Windows, which don't work in v2.5.0. Most of the changes are replacing `PurePath` with `PurePosixPath`.

As far as I can tell, none of the CI services support Linux containers on their Windows runners, so I could not add a regression test.