### PR TITLE
fix overwriting wheel on macos

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -535,6 +535,11 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if abi3_wheel is None:
+                try:
+                    os.remove(build_options.output_dir / repaired_wheel.name)
+                except OSError:
+                    pass
+
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -537,7 +537,7 @@ def build(options: Options, tmp_path: Path) -> None:
             if abi3_wheel is None:
                 try:
                     (build_options.output_dir / repaired_wheel.name).unlink()
-                except OSError:
+                except FileNotFoundError:
                     pass
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -536,7 +536,7 @@ def build(options: Options, tmp_path: Path) -> None:
             # we're all done here; move it to output (overwrite existing)
             if abi3_wheel is None:
                 try:
-                    os.remove(build_options.output_dir / repaired_wheel.name)
+                    (build_options.output_dir / repaired_wheel.name).unlink()
                 except OSError:
                     pass
 


### PR DESCRIPTION
When I run on macOS, I get the following error:

```
Traceback (most recent call last):
  File "/Users/david/.local/pipx/.cache/fd54e06d50697e7/bin/cibuildwheel", line 8, in <module>
    sys.exit(main())
  File "/Users/david/.local/pipx/.cache/fd54e06d50697e7/lib/python3.10/site-packages/cibuildwheel/__main__.py", line 128, in main
    build_in_directory(args)
  File "/Users/david/.local/pipx/.cache/fd54e06d50697e7/lib/python3.10/site-packages/cibuildwheel/__main__.py", line 252, in build_in_directory
    cibuildwheel.macos.build(options, tmp_path)
  File "/Users/david/.local/pipx/.cache/fd54e06d50697e7/lib/python3.10/site-packages/cibuildwheel/macos.py", line 538, in build
    shutil.move(str(repaired_wheel), build_options.output_dir)
  File "/opt/homebrew/Cellar/python@3.10/3.10.4/Frameworks/Python.framework/Versions/3.10/lib/python3.10/shutil.py", line 811, in move
    raise Error("Destination path '%s' already exists" % real_dst)
shutil.Error: Destination path '/Users/david/Documents/GitHub/python-mpy-cross/wheelhouse/mpy_cross_v5-1.0.0-py3-none-macosx_11_0_arm64.whl' already exists
```

The comment in the code says that it should overwrite the file, so this removes the file if it exists first before trying to move the file.