### PR TITLE
ensure tests run on prerelease Pythons

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -387,7 +387,7 @@ class Options:
             requires_python=requires_python,
             prerelease_pythons=prerelease_pythons,
         )
-        test_selector = TestSelector(skip_config=test_skip)
+        test_selector = TestSelector(skip_config=test_skip, prerelease_pythons=prerelease_pythons)
 
         archs_config_str = args.archs or self.reader.get("archs", sep=" ")
         architectures = Architecture.parse_config(archs_config_str, platform=self.platform)

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -387,7 +387,7 @@ class Options:
             requires_python=requires_python,
             prerelease_pythons=prerelease_pythons,
         )
-        test_selector = TestSelector(skip_config=test_skip, prerelease_pythons=prerelease_pythons)
+        test_selector = TestSelector(skip_config=test_skip)
 
         archs_config_str = args.archs or self.reader.get("archs", sep=" ")
         architectures = Architecture.parse_config(archs_config_str, platform=self.platform)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -234,21 +234,20 @@ def selector_matches(patterns: str, string: str) -> bool:
 
 # Once we require Python 3.10+, we can add kw_only=True
 @dataclasses.dataclass
-class IdentifierSelector:
+class BuildSelector:
     """
     This class holds a set of build/skip patterns. You call an instance with a
     build identifier, and it returns True if that identifier should be
     included. Only call this on valid identifiers, ones that have at least 2
-    numeric digits before the first dash. If a pre-release version X.Y is present,
-    you can filter it with prerelease="XY".
+    numeric digits before the first dash.
     """
+
+    build_config: str
+    skip_config: str
+    requires_python: Optional[SpecifierSet] = None
 
     # a pattern that skips prerelease versions, when include_prereleases is False.
     PRERELEASE_SKIP: ClassVar[str] = "cp311-*"
-
-    skip_config: str
-    build_config: str
-    requires_python: Optional[SpecifierSet] = None
     prerelease_pythons: bool = False
 
     def __call__(self, build_id: str) -> bool:
@@ -272,15 +271,16 @@ class IdentifierSelector:
 
 
 @dataclasses.dataclass
-class BuildSelector(IdentifierSelector):
-    pass
+class TestSelector:
+    """
+    A build selector that can only skip tests according to a skip pattern.
+    """
 
+    skip_config: str
 
-# Note that requires-python is not needed for TestSelector, as you can't test
-# what you can't build.
-@dataclasses.dataclass
-class TestSelector(IdentifierSelector):
-    build_config: str = "*"
+    def __call__(self, build_id: str) -> bool:
+        should_skip = selector_matches(self.skip_config, build_id)
+        return not should_skip
 
 
 # Taken from https://stackoverflow.com/a/107717

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -136,3 +136,14 @@ def test_build_limited_python_patch():
 
     assert build_selector("cp36-manylinux_x86_64")
     assert build_selector("cp37-manylinux_x86_64")
+
+
+def test_testing_selector():
+    # local import to avoid pytest trying to collect this as a test class!
+    from cibuildwheel.util import TestSelector
+
+    test_selector = TestSelector(skip_config="cp36-*")
+
+    assert not test_selector("cp36-win_amd64")
+    assert test_selector("cp37-manylinux_x86_64")
+    assert test_selector("cp311-manylinux_x86_64")


### PR DESCRIPTION
fixes #1137 

This is a pretty naive approach to the fix- not sure if maybe the Python prerelease stuff should just move to another layer in the class hierarchy instead, but this makes things work as expected at least...