### PR TITLE
Use preinstalled Python 3 for `cibuildwheel` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
-
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.7.0
+        run: python3 -m pip install cibuildwheel==2.7.0
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python3 -m cibuildwheel --output-dir wheelhouse
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -191,7 +191,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
     ```
 
 !!! tab "Generic"
-    This is the most generic form using setup-python and pip; it looks the most
+    This is the most generic form using python3 and pip; it looks the most
     like the other CI examples. If you want to avoid having setup that takes
     advantage of GitHub Actions features or pipx being preinstalled, this might
     appeal to you.
@@ -214,14 +214,11 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
         steps:
           - uses: actions/checkout@v2
 
-          # Used to host cibuildwheel
-          - uses: actions/setup-python@v2
-
           - name: Install cibuildwheel
-            run: python -m pip install cibuildwheel==2.7.0
+            run: python3 -m pip install cibuildwheel==2.7.0
 
           - name: Build wheels
-            run: python -m cibuildwheel --output-dir wheelhouse
+            run: python3 -m cibuildwheel --output-dir wheelhouse
 
           - uses: actions/upload-artifact@v2
             with:

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -8,15 +8,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'


### PR DESCRIPTION
There is at least 3.7 in every runner
https://github.com/actions/virtual-environments