### PR TITLE
Add `data/images.yml` with info about OS inside

### DIFF
--- a/docs/data/images.yml
+++ b/docs/data/images.yml
@@ -1,0 +1,23 @@
+# name: image name
+# os: operating system in the image 
+# packman: package management tool
+
+- name: manylinux_2_28
+  os: AlmaLinux 8
+  packman: dnf
+
+- name: manylinux_2_24
+  os: Debian 9
+  packman: apt-get
+
+- name: manylinux2014
+  os: CentOS 7
+  packman: yum
+
+- name: manylinux2010
+  os: CentOS 6
+  packman: yum
+
+- name: manylinux1
+  os: CentOS 5
+  packman: yum


### PR DESCRIPTION
There is a missing info about which package manager should be used in which manylinux image. I am not an expert in MkDocs, but I've seen another file here, so if this YAML can be turned into some table in documentation, that would be helpful I guess. Which is missing is to how to search package names in AlmaLinux online. https://repology.org/ works somewhat, but it still not clear where the package sources and issue tracker for requests.