### PR TITLE
fix CalledProcessError message output

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -367,7 +367,7 @@ def build(options: Options, tmp_path: Path) -> None:  # pylint: disable=unused-a
 
         except subprocess.CalledProcessError as error:
             log.step_end_with_error(
-                f"Command {error.cmd} failed with code {error.returncode}. {error.stdout}"
+                f"Command {error.cmd} failed with code {error.returncode}. {error.output}"
             )
             troubleshoot(options, error)
             sys.exit(1)


### PR DESCRIPTION
According to:

https://github.com/pypa/cibuildwheel/blob/0bf4f7abc36bd33bed60eac98c0ee2faefcc4ae6/cibuildwheel/docker_container.py#L252-L253