### PR TITLE
chore: simpler dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "actions/*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -147,10 +147,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Optional: Official actions have moving tags like v1;
-      # if you use those, you don't need updates.
-      - dependency-name: "actions/*"
 ```
 
 #### Option 2: Requirement files


### PR DESCRIPTION
Ignores no longer needed after April 2022. Dependabot keeps the same style pinning now.