### PR TITLE
Fix multiple version tags per release bug in release tooling

### DIFF
--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -184,7 +184,7 @@ def bump_version() -> None:
     print()
 
     release_url = "https://github.com/pypa/cibuildwheel/releases/new?" + urllib.parse.urlencode(
-        {"tag": new_version}
+        {"tag": f"v{new_version}"}
     )
     print("Then create a release at the URL:")
     print(f"    {release_url}")


### PR DESCRIPTION
> henryiii — Yesterday at 2:38 AM
> Why are there both v2.7.0 and 2.7.0 tags for the last few releases? Dependabot seems to pick different ones for different releases. I just noticed I went from 
> v2.6.0 to 2.7.0, but there's still a proper v2.7.0 that it didn't pick.
> 
> joerick — Today at 2:09 PM
> huh, that's weird. I'm not sure!
> I normally try to keep the prefix v2.7.0, not 2.7.0
> I suspect it's something to do with the github releases link

It was something to do with the Github release link in my release script!