### PR TITLE
add cf-units to working examples docs

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -589,3 +589,10 @@
   gh: MarshalX/python-webrtc
   ci: [github]
   os: [windows, apple, linux]
+
+- name: cf-units
+  gh: SciTools/cf-units
+  ci: [github]
+  os: [apple, linux]
+  notes: Units of measure as required by the Climate and Forecast (CF) metadata conventions
+


### PR DESCRIPTION
Congratulations and thank-you so much for `cibuildwheel`! It is a truly amazing package :star_struck: 

We've recently adopted the use of `cibuildwheel` to automate building and testing binary wheels for our `cf-units` package on both `macos` and `linux`.

It's a godsend of a package and has made our lives **SO** much easier as package maintainers. There are not enough superlatives!

We'd love to be mentioned in your `Working examples` section of the documentation.