### PR TITLE
Expand the catch statement on util.download to be more robust

### DIFF
--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -316,7 +316,7 @@ def download(url: str, dest: Path) -> None:
                 dest.write_bytes(response.read())
                 return
 
-        except urllib.error.URLError:
+        except OSError:
             if i == repeat_num - 1:
                 raise
             sleep(3)


### PR DESCRIPTION
URLError and SSLError both subclass OSError. Should prevent random
network errors like this from breaking the build
https://app.circleci.com/pipelines/github/pypa/cibuildwheel/3668/workflows/6a3b6066-e892-48c4-bb6b-4c094b1c814e/jobs/9933?invite=true#step-103-623
