### PR TITLE
DOC: Typo manylinux_2_24

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -700,9 +700,9 @@ Platform-specific environment variables also available:<br/>
 
     In configuration files, you can use a TOML array, and each line will be run sequentially - joined with `&&`.
 
-Note that manylinux2_24 builds occur inside a Debian9 docker, where
+Note that manylinux_2_24 builds occur inside a Debian9 docker, where
 manylinux2010 and manylinux2014 builds occur inside a CentOS one. So for
-`manylinux2_24` the `CIBW_BEFORE_ALL_LINUX` command must use `apt-get -y`
+`manylinux_2_24` the `CIBW_BEFORE_ALL_LINUX` command must use `apt-get -y`
 instead.
 
 ### `CIBW_BEFORE_BUILD` {: #before-build}

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -21,7 +21,7 @@ jobs:
         # with:
         #   package-dir: .
         #   output-dir: wheelhouse
-        #   config-file: {package}/pyproject.toml
+        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Just a little typo `manylinux2_24` to `manylinux_2_24`