### PR TITLE
fix(docs): pin things due to the mkdocs pin

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -92,12 +92,13 @@ def update_proj(session: nox.Session) -> None:
     )
 
 
-@nox.session
+@nox.session(python="3.9")
 def docs(session: nox.Session) -> None:
     """
     Build the docs.
     """
     session.install("-e", ".[docs]")
+    session.run("pip", "list")
 
     if session.posargs:
         if "serve" in session.posargs:

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,11 @@ from setuptools import setup
 extras = {
     "docs": [
         "mkdocs-include-markdown-plugin==2.8.0",
-        "mkdocs==1.0.4",
+        "mkdocs==1.0.4",  # Doesn't support Python 3.10+
         "jinja2==3.0.3",
         "pymdown-extensions",
         "mkdocs-macros-plugin",
+        "markdown<3.4",  # Breaks mkdocs 1.0.4
     ],
     "test": [
         "jinja2",


### PR DESCRIPTION
We really need to upgrade mkdocs! The old version we are stuck on doesn't support Python 3.10 or the latest Markdown.

Should patch the error seen in #1180 with docs.
