### PR TITLE
DOC: Bump to non-deprecated image

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11.0]
+        os: [ubuntu-20.04, windows-2019, macOS-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macOS-11.0]
 
     steps:
       - uses: actions/checkout@v3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: macos_38
-  pool: {vmImage: 'macOS-10.15'}
+  pool: {vmImage: 'macOS-11'}
   steps:
     - task: UsePythonVersion@0
       inputs:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -176,7 +176,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
         runs-on: ${{ matrix.os }}
         strategy:
           matrix:
-            os: [ubuntu-20.04, windows-2019, macos-10.15]
+            os: [ubuntu-20.04, windows-2019, macos-11]
 
         steps:
           - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
         runs-on: ${{ matrix.os }}
         strategy:
           matrix:
-            os: [ubuntu-20.04, windows-2019, macos-10.15]
+            os: [ubuntu-20.04, windows-2019, macos-11]
 
         steps:
           - uses: actions/checkout@v3

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -14,7 +14,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 
 - job: macos
-  pool: {vmImage: 'macOS-10.15'}
+  pool: {vmImage: 'macOS-11'}
   steps:
     - task: UsePythonVersion@0
     - bash: |

--- a/examples/github-apple-silicon.yml
+++ b/examples/github-apple-silicon.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build_wheels_macos:
-    name: Build wheels on macos-10.15
-    runs-on: macos-10.15
+    name: Build wheels on macos-11
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
 

--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Bumps docs and Azure to refer to macos-11 since macos-10.15 is deprecated.

Feel free to close if this isn't the right fix and more is needed, I figured I'd get the ball rolling at least in case it isn't.