### PR TITLE
Upgrading Pycln from v2.0.3 to v2.0.4 (a pre-commit hook)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
 
 # Autoremoves unused imports
 - repo: https://github.com/hadialqattan/pycln
-  rev: v2.0.3
+  rev: v2.0.4
   hooks:
   - id: pycln
     args: [--all]


### PR DESCRIPTION
Hi, I'm the author of Pycln...

Pycln v2.0.3 has some issues with Py3.9+ so it's highly recommended to upgrade to v2.0.4 ASAP.