### PR TITLE
Provide alternative to actions/setup-python for self-hosted runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,16 +21,28 @@ runs:
   using: composite
   steps:
     # Set up a non-EOL, cibuildwheel & pipx supported Python version
+    # setup-python@v4 does not support ARM runners (e.g., self-hosted runners).
+    # These runners must ensure cibuildwheel and provided on their own before
+    # cibuildwheel.
+    # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
     - uses: actions/setup-python@v4
       id: python
       with:
         python-version: "3.7 - 3.10"
         update-environment: false
+      if: ${{ env.CIBW_GITHUB_ACTIONS_PYTHON == '' }}
+
+    # Set CIBW_GITHUB_ACTIONS_PYTHON to the Python installed in the step above, unless
+    # the user already set it.
+    - run: >
+        echo "CIBW_GITHUB_ACTIONS_PYTHON=${{ steps.python.outputs.python-path }}" >> $GITHUB_ENV
+      shell: bash
+      if: ${{ env.CIBW_GITHUB_ACTIONS_PYTHON == '' }}
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
         pipx run
-        --python '${{ steps.python.outputs.python-path }}'
+        --python '${{ env.CIBW_GITHUB_ACTIONS_PYTHON }}'
         --spec '${{ github.action_path }}'
         cibuildwheel
         ${{ inputs.package-dir }}


### PR DESCRIPTION
Since commit 25c1bf53d079d1fa52a5144b63bca3e66d8e21d4 (v2.8.1),
cibuildwheel uses actions/setup-python to ensure that a reasonable
Python is installed on the GitHub Actions runner. This is a reason
solution for standard runners, but unfortunately, actions/setup-python
is not capable of furnishing some self-hosted runners with a working
Python. In particular, it only provides x64 and x86 Pythons, so breaks
anyone using an ARM self-hosted runner.

This change fixes the issue by allowing self-hosted runners by
introducing a new environment variable, CIBW_GITHUB_ACTIONS_PYTHON,
allowing one to specify the host Python without calling
actions/setup-python. The user is responsible for ensuring that
Python and pipx are installed on the self-hosted runner.

Here is the list of Pythons that actions/setup-python can install:
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json