### PR TITLE
Fix Rosetta2 usage for shell commands

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -505,7 +505,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
                     # define a custom 'call' function that adds the arch prefix each time
                     call_with_arch = functools.partial(call, *arch_prefix)
-                    shell_with_arch = functools.partial(shell, *arch_prefix)
+                    shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")
 
                     # Use --no-download to ensure determinism by using seed libraries
                     # built into virtualenv


### PR DESCRIPTION
Fixes #1193 

Instead of the suggested `sh`, I used `/bin/sh` as that's how Python's subprocess does it:
https://github.com/python/cpython/blob/a566912049722386478c075b83534fa9f7a1de45/Lib/subprocess.py#L1759-L1765

Successful build log: https://cirrus-ci.com/task/5802864923639808
Link to the CI configuration: https://raw.githubusercontent.com/jack1142/cibuildwheel/macos_arch_x86_64_issue/.cirrus.yml