### PR TITLE
fix: don't build `universal2` as a default on macOS arm64 runners

### DIFF
--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -66,10 +66,6 @@ class Architecture(Enum):
         if platform == "windows" and native_architecture == Architecture.AMD64:
             result.add(Architecture.x86)
 
-        if platform == "macos" and native_architecture == Architecture.arm64:
-            # arm64 can build and test both archs of a universal2 wheel.
-            result.add(Architecture.universal2)
-
         return result
 
     @staticmethod

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,11 +53,11 @@ to load on Apple Silicon.
     available.
 
 Generally speaking, because Pip 20.3 is required for the `universal2` wheel,
-most packages should provide both `x86_64` and `universal2` wheels for now.
-Once Pip 20.3+ is common on macOS, then it should be possible to ship only the
-`universal2` wheel.
+most packages should provide both `x86_64` and one of `universal2`/`arm64`
+wheels for now. When Pip 20.3+ is common on macOS, then it might be possible
+to ship only the `universal2` wheel.
 
-**Apple Silicon wheels are not built by default**, but can be enabled by adding extra archs to the [`CIBW_ARCHS_MACOS` option](options.md#archs) - e.g. `x86_64 arm64 universal2`. Cross-compilation is provided by the Xcode toolchain.
+**Apple Silicon wheels are not built by default on Intel runners**, but can be enabled by adding extra archs to the [`CIBW_ARCHS_MACOS` option](options.md#archs) - e.g. `x86_64 arm64`. Cross-compilation is provided by the Xcode toolchain.
 
 !!! important
     When cross-compiling on Intel, it is not possible to test `arm64` and the `arm64` part of a `universal2` wheel.
@@ -66,8 +66,7 @@ Once Pip 20.3+ is common on macOS, then it should be possible to ship only the
 
 Hopefully, cross-compilation is a temporary situation. Once we have widely
 available Apple Silicon CI runners, we can build and test `arm64` and
-`universal2` wheels natively. That's why `universal2` wheels are not yet built
-by default, and require opt-in by setting `CIBW_ARCHS_MACOS`.
+`universal2` wheels natively. That's why `universal2`/`arm64` wheels require opt-in by setting `CIBW_ARCHS_MACOS`.
 
 !!! note
     Your runner needs Xcode Command Line Tools 12.2 or later to build `universal2` or `arm64`.

--- a/docs/options.md
+++ b/docs/options.md
@@ -351,7 +351,7 @@ Default: `auto`
 | Linux / Intel | `x86_64` | `x86_64` `i686` | `x86_64` | `i686` |
 | Windows / Intel | `AMD64` | `AMD64` `x86` | `AMD64` | `x86` |
 | macOS / Intel | `x86_64` | `x86_64` | `x86_64` |  |
-| macOS / Apple Silicon | `arm64` | `arm64` `universal2` | `arm64` `universal2`|  |
+| macOS / Apple Silicon | `arm64` | `arm64` | `arm64` |  |
 
 If not listed above, `auto` is the same as `native`.
 

--- a/examples/github-apple-silicon.yml
+++ b/examples/github-apple-silicon.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.8.1
         env:
-          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/test/test_macos_archs.py
+++ b/test/test_macos_archs.py
@@ -11,7 +11,7 @@ basic_project = test_projects.new_c_project()
 
 ALL_MACOS_WHEELS = {
     *utils.expected_wheels("spam", "0.1.0", machine_arch="x86_64"),
-    *utils.expected_wheels("spam", "0.1.0", machine_arch="arm64"),
+    *utils.expected_wheels("spam", "0.1.0", machine_arch="arm64", include_universal2=True),
 }
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -116,6 +116,7 @@ def expected_wheels(
     macosx_deployment_target="10.9",
     machine_arch=None,
     python_abi_tags=None,
+    include_universal2=False,
 ):
     """
     Returns a list of expected wheels from a run of cibuildwheel.
@@ -199,14 +200,14 @@ def expected_wheels(
                 arm64_macosx_deployment_target = _get_arm64_macosx_deployment_target(
                     macosx_deployment_target
                 )
-                platform_tags = [
-                    f'macosx_{macosx_deployment_target.replace(".", "_")}_universal2',
-                    f'macosx_{arm64_macosx_deployment_target.replace(".", "_")}_arm64',
-                ]
+                platform_tags = [f'macosx_{arm64_macosx_deployment_target.replace(".", "_")}_arm64']
             else:
-                platform_tags = [
-                    f'macosx_{macosx_deployment_target.replace(".", "_")}_x86_64',
-                ]
+                platform_tags = [f'macosx_{macosx_deployment_target.replace(".", "_")}_x86_64']
+
+            if include_universal2:
+                platform_tags.append(
+                    f'macosx_{macosx_deployment_target.replace(".", "_")}_universal2',
+                )
 
         else:
             raise Exception("unsupported platform")


### PR DESCRIPTION
Per discussion in #1204, only build `arm64` on arm64 macOS runners.

Fixes #1204
Relates to #1191