### PR TITLE
Remove pytest-azurepipelines for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
       inputs:
         versionSpec: '3.8'
     - bash: |
-        python -m pip install -e ".[dev]" pytest-azurepipelines
+        python -m pip install -e ".[dev]"
         python ./bin/run_tests.py
 
 - job: macos_38
@@ -17,7 +17,7 @@ jobs:
       inputs:
         versionSpec: '3.8'
     - bash: |
-        python -m pip install -e ".[dev]" pytest-azurepipelines
+        python -m pip install -e ".[dev]"
         python ./bin/run_tests.py
 
 - job: windows_38
@@ -28,5 +28,5 @@ jobs:
       inputs:
         versionSpec: '3.8'
     - bash: |
-        python -m pip install -e ".[dev]" pytest-azurepipelines
+        python -m pip install -e ".[dev]"
         python ./bin/run_tests.py


### PR DESCRIPTION
Test errors in Azure are all printing KeyError: 'reason', it seems to be an incompatibility between pytest-azurepipelines and pytest-xdist. I've filed a bug here: https://github.com/Azure/pytest-azurepipelines/issues/71

in the meantime, I'll disable this plugin.