### PR TITLE
Add ril to projects.yml

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -606,7 +606,7 @@
   ci: [github]
   os: [linux, apple]
   note: A machine learning model serving framework powered by Rust
-  
+
 - name: ril
   gh: Cryptex-github/ril-py
   ci: [github]

--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -606,3 +606,10 @@
   ci: [github]
   os: [linux, apple]
   note: A machine learning model serving framework powered by Rust
+  
+- name: ril
+  gh: Cryptex-github/ril-py
+  ci: [github]
+  os: [windows, apple, linux]
+  pypi: pyril
+  notes: A python binding to Rust Imaging library using maturin and Pyo3, utilizes Github Action cache to improve speed. Builds abi3 wheels.


### PR DESCRIPTION
A great example on how to use cibuildwheel for Pyo3 Rust bindings that uses maturin and how to utilize Github Action caches for performance and auto release. 