### PR TITLE
feat: manylinux_2_28_s390x support

### DIFF
--- a/bin/update_docker.py
+++ b/bin/update_docker.py
@@ -50,6 +50,7 @@ images = [
     Image("manylinux_2_28", "x86_64", "quay.io/pypa/manylinux_2_28_x86_64", None),
     Image("manylinux_2_28", "aarch64", "quay.io/pypa/manylinux_2_28_aarch64", None),
     Image("manylinux_2_28", "ppc64le", "quay.io/pypa/manylinux_2_28_ppc64le", None),
+    Image("manylinux_2_28", "s390x", "quay.io/pypa/manylinux_2_28_s390x", None),
     Image("manylinux_2_28", "pypy_x86_64", "quay.io/pypa/manylinux_2_28_x86_64", None),
     Image("manylinux_2_28", "pypy_aarch64", "quay.io/pypa/manylinux_2_28_aarch64", None),
     # musllinux_1_1 images

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,48 +1,49 @@
 [x86_64]
-manylinux1 = quay.io/pypa/manylinux1_x86_64:2022-08-28-052a216
+manylinux1 = quay.io/pypa/manylinux1_x86_64:2022-09-04-d1c2903
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-08-29-0fd77fa
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2022-08-29-0fd77fa
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2022-09-04-870f6a2
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2022-09-04-870f6a2
 
 [i686]
-manylinux1 = quay.io/pypa/manylinux1_i686:2022-08-28-052a216
+manylinux1 = quay.io/pypa/manylinux1_i686:2022-09-04-d1c2903
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-08-29-0fd77fa
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-09-04-870f6a2
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2022-09-04-870f6a2
 
 [pypy_x86_64]
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-08-29-0fd77fa
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2022-09-04-870f6a2
 
 [pypy_i686]
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-09-04-870f6a2
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-08-29-0fd77fa
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2022-08-29-0fd77fa
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2022-09-04-870f6a2
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2022-09-04-870f6a2
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2022-08-29-0fd77fa
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2022-08-29-0fd77fa
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2022-09-04-870f6a2
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2022-09-04-870f6a2
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2022-08-29-0fd77fa
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2022-09-04-870f6a2
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2022-09-04-870f6a2
 
 [pypy_aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2022-08-29-0fd77fa
-manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-08-29-0fd77fa
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2022-08-29-0fd77fa
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2022-09-04-870f6a2
+manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-09-04-870f6a2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2022-09-04-870f6a2
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -911,7 +911,7 @@ The available options are (default value):
 Set an alternative Docker image to be used for building [manylinux / musllinux](https://github.com/pypa/manylinux) wheels.
 
 For `CIBW_MANYLINUX_*_IMAGE`, the value of this option can either be set to `manylinux1`, `manylinux2010`, `manylinux2014`, `manylinux_2_24` or `manylinux_2_28` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name. For PyPy, the `manylinux1` image is not available. For architectures other
-than x86 (x86\_64 and i686) `manylinux2014`, `manylinux_2_24` or `manylinux_2_28` must be used, because the first version of the manylinux specification that supports additional architectures is `manylinux2014`. `manylinux_2_28` is not supported for `i686` & `s390x` architectures.
+than x86 (x86\_64 and i686) `manylinux2014`, `manylinux_2_24` or `manylinux_2_28` must be used, because the first version of the manylinux specification that supports additional architectures is `manylinux2014`. `manylinux_2_28` is not supported for `i686` architecture.
 
 For `CIBW_MUSLLINUX_*_IMAGE`, the value of this option can either be set to `musllinux_1_1` to use a pinned version of the [official musllinux images](https://github.com/pypa/musllinux). Alternatively, set these options to any other valid Docker image name.
 

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -59,8 +59,6 @@ def test(manylinux_image, tmp_path):
     elif platform.machine() not in ["x86_64", "i686"]:
         if manylinux_image in ["manylinux1", "manylinux2010"]:
             pytest.skip("manylinux1 and 2010 doesn't exist for non-x86 architectures")
-        elif manylinux_image == "manylinux_2_28" and platform.machine() == "s390x":
-            pytest.skip("manylinux_2_28 doesn't exist for s390x architecture")
     elif manylinux_image == "manylinux_2_28" and platform.machine() == "i686":
         pytest.skip("manylinux_2_28 doesn't exist for i686 architecture")
 


### PR DESCRIPTION
A `manylinux_2_28` image now exists for the `s390x` architecture.