### PR TITLE
Revert to previous quoting behaviour for environment values in TOML

### DIFF
--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -4,6 +4,7 @@ import dataclasses
 from typing import Any, Mapping, Sequence
 
 import bashlex
+import bashlex.errors
 
 from cibuildwheel.typing import Protocol
 
@@ -33,7 +34,11 @@ def split_env_items(env_string: str) -> list[str]:
     if not env_string:
         return []
 
-    command_node = bashlex.parsesingle(env_string)
+    try:
+        command_node = bashlex.parsesingle(env_string)
+    except bashlex.errors.ParsingError as e:
+        raise EnvironmentParseError(env_string) from e
+
     result = []
 
     for word_node in command_node.parts:

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -10,6 +10,10 @@ if sys.version_info < (3, 8):
 else:
     from typing import Final, Literal, OrderedDict, Protocol, TypedDict
 
+if sys.version_info < (3, 11):
+    from typing_extensions import NotRequired
+else:
+    from typing import NotRequired
 
 __all__ = (
     "Final",
@@ -26,6 +30,7 @@ __all__ = (
     "OrderedDict",
     "Union",
     "assert_never",
+    "NotRequired",
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ module = [
     "setuptools",
     "pytest", # ignored in pre-commit to speed up check
     "bashlex",
+    "bashlex.*",
     "importlib_resources",
     "ghapi.*",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     packaging>=20.9
     platformdirs
     tomli;python_version < '3.11'
-    typing-extensions>=3.10.0.0;python_version < '3.8'
+    typing-extensions>=4.1.0;python_version < '3.11'
 python_requires = >=3.7
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Fix #1271.

A (perhaps) temporary fix for #1271, reverting to the previous behaviour of wrapping environment variables with double-quotes, which seems to work in 95% of use cases.

There might be a better approach that handles the last 5% of strange/evil inputs. But for now, this should restore the ability to use single-quotes in values and to reference $PARAMs.
