### PR TITLE
Fix win32 identifiers with --only

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -173,7 +173,7 @@ def build_in_directory(args: CommandLineArguments) -> None:
             platform = "linux"
         elif "macosx_" in args.only:
             platform = "macos"
-        elif "win_" in args.only:
+        elif "win_" in args.only or "win32" in args.only:
             platform = "windows"
         else:
             print(

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -199,6 +199,7 @@ def test_archs_platform_all(platform, intercepted_build_args, monkeypatch):
     (
         ("cp311-manylinux_x86_64", "linux"),
         ("cp310-win_amd64", "windows"),
+        ("cp310-win32", "windows"),
         ("cp311-macosx_x86_64", "macos"),
     ),
 )


### PR DESCRIPTION
Fix #1281.
