### PR TITLE
feature: allow testing cp38-macosx_arm64 wheel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,3 +56,19 @@ macos_arm64_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   <<: *RUN_TESTS
+
+macos_arm64_cp38_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
+
+  env:
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+    PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto'
+  install_pre_requirements_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+    - curl -fsSLO https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
+    - sudo installer -pkg python-3.8.10-macos11.pkg -target /
+    - rm python-3.8.10-macos11.pkg
+    - sh "/Applications/Python 3.8/Install Certificates.command"
+  <<: *RUN_TESTS

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -425,6 +425,13 @@ def build(options: Options, tmp_path: Path) -> None:
 
             if build_options.test_command and build_options.test_selector(config.identifier):
                 machine_arch = platform.machine()
+                python_arch = call(
+                    "python",
+                    "-sSc",
+                    "import platform; print(platform.machine())",
+                    env=env,
+                    capture_stdout=True,
+                ).strip()
                 testing_archs: list[Literal["x86_64", "arm64"]]
 
                 if config_is_arm64:
@@ -473,7 +480,8 @@ def build(options: Options, tmp_path: Path) -> None:
                         # skip this test
                         continue
 
-                    if testing_arch == "arm64" and config.identifier.startswith("cp38-"):
+                    is_cp38 = config.identifier.startswith("cp38-")
+                    if testing_arch == "arm64" and is_cp38 and python_arch != "arm64":
                         log.warning(
                             unwrap(
                                 """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,12 @@ def pytest_addoption(parser) -> None:
         "--run-emulation", action="store_true", default=False, help="run emulation tests"
     )
     parser.addoption("--run-podman", action="store_true", default=False, help="run podman tests")
+    parser.addoption(
+        "--run-cp38-universal2",
+        action="store_true",
+        default=False,
+        help="macOS cp38 uses the universal2 installer",
+    )
 
 
 @pytest.fixture(

--- a/unit_test/conftest.py
+++ b/unit_test/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
         default=False,
         help="macOS cp38 uses the universal2 installer",
     )
-    
+
 
 @pytest.fixture
 def fake_package_dir(tmp_path, monkeypatch):

--- a/unit_test/conftest.py
+++ b/unit_test/conftest.py
@@ -11,7 +11,13 @@ MOCK_PACKAGE_DIR = Path("some_package_dir")
 def pytest_addoption(parser):
     parser.addoption("--run-docker", action="store_true", default=False, help="run docker tests")
     parser.addoption("--run-podman", action="store_true", default=False, help="run podman tests")
-
+    parser.addoption(
+        "--run-cp38-universal2",
+        action="store_true",
+        default=False,
+        help="macOS cp38 uses the universal2 installer",
+    )
+    
 
 @pytest.fixture
 def fake_package_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
Per discussion in https://github.com/pypa/cibuildwheel/pull/1169, the default installer used for cp38 is an Intel installer. It makes sense to skip testing arm64 wheels in this case.

However, if the user choose to manually install the universal2 CPython version (c.f. https://github.com/pypa/cibuildwheel/issues/1278#issuecomment-1256943685), then, tests shall be run on arm64.

This allows users that either target 11.0+ on intel, universal2 or only build for arm64 to get the arm64 wheel tested on AppleSilicon.

I'm not a fan of the way I added the test here but there's a test. Maybe the test suite should be updated to run fully with both installers ?