### PR TITLE
chore: test with Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-11]
-        python_version: ['3.10']
+        python_version: ['~3.11.0-0']
     timeout-minutes: 180
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-11]
-        python_version: ['~3.11.0-0']
+        python_version: ['3.11']
     timeout-minutes: 180
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   rev: v2.0.0
   hooks:
   - id: setup-cfg-fmt
-    args: [--include-version-classifiers, --max-py-version=3.10]
+    args: [--include-version-classifiers, --max-py-version=3.11]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.982

--- a/CI.md
+++ b/CI.md
@@ -1,10 +1,10 @@
 This is a summary of the Python versions and platforms covered by the different CI platforms:
 
-|          | 3.7                   | 3.8                       | 3.9      | 3.10                      |
-|----------|-----------------------|---------------------------|----------|---------------------------|
-| Linux    | AppVeyor¹ / Travis CI | Azure Pipelines / GitLab  | CircleCI | GitHub Actions, Cirrus CI |
-| macOS    | AppVeyor¹ / Travis CI | Azure Pipelines           | CircleCI | GitHub Actions, Cirrus CI |
-| Windows  | AppVeyor¹ / Travis CI | Azure Pipelines           |          | GitHub Actions, Cirrus CI |
+|         | 3.7                   | 3.8                      | 3.9      | 3.10      | 3.11           |
+|---------|-----------------------|--------------------------|----------|-----------|----------------|
+| Linux   | AppVeyor¹ / Travis CI | Azure Pipelines / GitLab | CircleCI | Cirrus CI | GitHub Actions |
+| macOS   | AppVeyor¹ / Travis CI | Azure Pipelines          | CircleCI | Cirrus CI | GitHub Actions |
+| Windows | AppVeyor¹ / Travis CI | Azure Pipelines          |          | Cirrus CI | GitHub Actions |
 
 > ¹ AppVeyor only runs the "basic" test to reduce load.
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - uses: actions/setup-python@v4
       id: python
       with:
-        python-version: "3.7 - 3.10"
+        python-version: "3.7 - 3.11"
         update-environment: false
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Build Tools
 keywords = ci,wheel,packaging,pypi,travis,appveyor,macos,linux,windows


### PR DESCRIPTION
With 3.11.0 available in roughly a couple weeks, let's start testing as draft.
I will update this once 3.11 reaches GA.