### PR TITLE
fix: hide root pip warning on Linux

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -157,6 +157,7 @@ def build_in_container(
         env = container.get_environment()
         env["PATH"] = f'/opt/python/cp38-cp38/bin:{env["PATH"]}'
         env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+        env["PIP_ROOT_USER_ACTION"] = "ignore"
         env = before_all_options.environment.as_dictionary(
             env, executor=container.environment_executor
         )


### PR DESCRIPTION
This was included in pip a while ago (22.1, IIRC?) but we haven't added it yet.
