### PR TITLE
docs for native arm building on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,30 @@ jobs:
           command: venv/bin/python ./bin/run_tests.py
           no_output_timeout: 30m
 
+  linux-aarch64:
+    machine:
+       image: ubuntu-2004:2022.04.1
+    resource_class: arm.medium
+    environment:
+      PYTHON: python3
+      # Temporarily restrict the tests that are run on CircleCI to prevent
+      # test timeouts.
+      PYTEST_ADDOPTS: -k "unit_test or main_tests or test_0_basic or test_docker_images"
+    steps:
+      - checkout
+
+      - run:
+          name: Prepare the environment.
+          command: bash .circleci/prepare.sh
+      - run:
+          name: Test.
+          command: venv/bin/python ./bin/run_tests.py
+          no_output_timeout: 30m
+
 workflows:
   version: 2
   all-tests:
     jobs:
       - osx-python3.9
       - linux-python3.9
+      - linux-aarch64

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Usage
 | Azure Pipelines | ✅    | ✅    | ✅      |           | ✅²       | ✅⁴         |
 | Travis CI       | ✅    |       | ✅      | ✅        |           |             |
 | AppVeyor        | ✅    | ✅    | ✅      |           | ✅²       | ✅⁴         |
-| CircleCI        | ✅    | ✅    |         |           | ✅²       |             |
+| CircleCI        | ✅    | ✅    |         | ✅        | ✅²       |             |
 | Gitlab CI       | ✅    |       |         |           |           |             |
 | Cirrus CI       | ✅    | ✅³   | ✅      | ✅        | ✅        |             |
 

--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -172,11 +172,13 @@
 
 - name: pyzmq
   gh: zeromq/pyzmq
-  ci: [github]
+  ci: [github, circleci]
   os: [windows, apple, linux]
   ci_config: .github/workflows/wheels.yml
   notes: |
-    Python bindings for zeromq, the networking library. Uses Cython and CFFI.
+    Python bindings for zeromq, the networking library.
+    Uses Cython on CPython and CFFI on PyPy.
+    ARM wheels for linux are built natively on CircleCI.
 
 - name: python-rapidjson
   gh: python-rapidjson/python-rapidjson

--- a/examples/circleci-minimal.yml
+++ b/examples/circleci-minimal.yml
@@ -16,6 +16,23 @@ jobs:
       - store_artifacts:
           path: wheelhouse/
 
+  linux-aarch64-wheels:
+    working_directory: ~/linux-aarch64-wheels
+    machine:
+      image: ubuntu-2004:2022.04.1
+    # resource_class is what tells CircleCI to use an ARM worker for native arm builds
+    # https://circleci.com/product/features/resource-classes/
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Build the Linux aarch64 wheels.
+          command: |
+            python3 -m pip install --user cibuildwheel==2.10.2
+            python3 -m cibuildwheel --output-dir wheelhouse
+      - store_artifacts:
+          path: wheelhouse/
+
   osx-wheels:
     working_directory: ~/osx-wheels
     macos:
@@ -35,4 +52,5 @@ workflows:
   all-tests:
     jobs:
       - linux-wheels
+      - linux-aarch64-wheels
       - osx-wheels


### PR DESCRIPTION
- add note in docs that pyzmq uses both github and circleci, and that it includes native linux arm builds on circle
- add linux-aarch64-wheels job to circleci-minimal example

closes #1241