### PR TITLE
fix: warning when building macOS arm64 wheels

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -207,12 +207,14 @@ def setup_python(
         )
         sys.exit(1)
 
-    # Set MACOSX_DEPLOYMENT_TARGET to 10.9, if the user didn't set it.
-    # PyPy defaults to 10.7, causing inconsistencies if it's left unset.
-    env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
-
     config_is_arm64 = python_configuration.identifier.endswith("arm64")
     config_is_universal2 = python_configuration.identifier.endswith("universal2")
+
+    # Set MACOSX_DEPLOYMENT_TARGET, if the user didn't set it.
+    # For arm64, the minimal deployment target is 11.0.
+    # On x86_64 (or universal2), use 10.9 as a default.
+    # PyPy defaults to 10.7, causing inconsistencies if it's left unset.
+    env.setdefault("MACOSX_DEPLOYMENT_TARGET", "11.0" if config_is_arm64 else "10.9")
 
     if python_configuration.version not in {"3.6", "3.7"}:
         if config_is_arm64:

--- a/test/test_macos_archs.py
+++ b/test/test_macos_archs.py
@@ -66,10 +66,14 @@ def test_cross_compiled_test(tmp_path, capfd, build_universal2):
             "CIBW_BUILD": "cp39-*",
             "CIBW_TEST_COMMAND": '''python -c "import platform; print('running tests on ' + platform.machine())"''',
             "CIBW_ARCHS": "universal2" if build_universal2 else "x86_64 arm64",
+            "CIBW_BUILD_VERBOSITY": "3",
         },
     )
 
     captured = capfd.readouterr()
+
+    assert "[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value" not in captured.out
+    assert "[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value" not in captured.err
 
     if platform.machine() == "x86_64":
         # ensure that tests were run on only x86_64

--- a/test/test_macos_archs.py
+++ b/test/test_macos_archs.py
@@ -14,6 +14,8 @@ ALL_MACOS_WHEELS = {
     *utils.expected_wheels("spam", "0.1.0", machine_arch="arm64", include_universal2=True),
 }
 
+DEPLOYMENT_TARGET_TOO_LOW_WARNING = "[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value"
+
 
 def get_xcode_version() -> tuple[int, int]:
     output = subprocess.run(
@@ -72,8 +74,7 @@ def test_cross_compiled_test(tmp_path, capfd, build_universal2):
 
     captured = capfd.readouterr()
 
-    assert "[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value" not in captured.out
-    assert "[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value" not in captured.err
+    assert DEPLOYMENT_TARGET_TOO_LOW_WARNING not in captured.err
 
     if platform.machine() == "x86_64":
         # ensure that tests were run on only x86_64
@@ -99,6 +100,28 @@ def test_cross_compiled_test(tmp_path, capfd, build_universal2):
         expected_wheels = [w for w in ALL_MACOS_WHEELS if "cp39" in w and "universal2" not in w]
 
     assert set(actual_wheels) == set(expected_wheels)
+
+
+def test_deployment_target_warning_is_firing(tmp_path, capfd):
+    # force the warning to check that we can detect it if it happens
+    if utils.platform != "macos":
+        pytest.skip("this test is only relevant to macos")
+
+    project_dir = tmp_path / "project"
+    basic_project.generate(project_dir)
+
+    utils.cibuildwheel_run(
+        project_dir,
+        add_env={
+            "CIBW_BUILD": "cp39-*",
+            "CIBW_ARCHS": "x86_64",
+            "MACOSX_DEPLOYMENT_TARGET": "10.8",
+            "CIBW_BUILD_VERBOSITY": "3",
+        },
+    )
+
+    captured = capfd.readouterr()
+    assert DEPLOYMENT_TARGET_TOO_LOW_WARNING in captured.err
 
 
 @pytest.mark.parametrize("skip_arm64_test", [False, True])


### PR DESCRIPTION
When `MACOSX_DEPLOYMENT_TARGET` is not set by the user, cibuildwheel always defaults to `10.9`. This leads to a warning when building arm64 wheels.
This commit removes the warning by setting the default to `11.0` for arm64 builds.

Reported in https://github.com/pypa/cibuildwheel/pull/1300#issuecomment-1278396244