### PR TITLE
Tweak default mac repair cmd: use delocate-wheel verbose flag instead of extra listdeps command

### DIFF
--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -42,9 +42,9 @@ musllinux-s390x-image = "musllinux_1_1"
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-repair-wheel-command = [
-  "delocate-listdeps {wheel}",
-  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
-]
+repair-wheel-command = """\
+    delocate-wheel --require-archs {delocate_archs} \
+    -w {dest_dir} -v {wheel}\
+    """
 
 [tool.cibuildwheel.windows]

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -42,9 +42,6 @@ musllinux-s390x-image = "musllinux_1_1"
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-repair-wheel-command = """\
-    delocate-wheel --require-archs {delocate_archs} \
-    -w {dest_dir} -v {wheel}\
-    """
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -323,18 +323,17 @@ To work around this, use a different environment variable such as `REPAIR_LIBRAR
 
     ```yaml
     CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-        DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
-        DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+        DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
     ```
 
 !!! tab examples "pyproject.toml"
 
     ```toml
     [tool.cibuildwheel.macos]
-    repair-wheel-command = [
-        "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel}",
-        "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
-    ]
+    repair-wheel-command = """\
+    DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel \
+    --require-archs {delocate_archs} -w {dest_dir} -v {wheel}\
+    """
     ```
 
 See [#816](https://github.com/pypa/cibuildwheel/issues/816), thanks to @phoerious for reporting.

--- a/docs/options.md
+++ b/docs/options.md
@@ -851,7 +851,7 @@ Platform-specific environment variables are also available:<br/>
 Default:
 
 - on Linux: `'auditwheel repair -w {dest_dir} {wheel}'`
-- on macOS: `'delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}'`
+- on macOS: `'delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'`
 - on Windows: `''`
 
 A shell command to repair a built wheel by copying external library dependencies into the wheel tree and relinking them.

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -122,7 +122,7 @@ def get_default_repair_command(platform):
     if platform == "linux":
         return "auditwheel repair -w {dest_dir} {wheel}"
     elif platform == "macos":
-        return "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+        return "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
     elif platform == "windows":
         return ""
     else:


### PR DESCRIPTION
Minor PR to make a small tweak to cibuildwheels default mac wheel repair command. Instead of having to call `delocate-listdeps` separately, `delocate-wheel` can be invoked with a verbose flag, and this should print very similar information to the previous extra command.