### PR TITLE
Fix #1161 - stdout is line-buffered during command execution

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -303,9 +303,11 @@ class OCIContainer:
                 return_code = int(return_code_str)
                 # add the last line to output, without the footer
                 output_io.write(line[0:footer_offset])
+                output_io.flush()
                 break
             else:
                 output_io.write(line)
+                output_io.flush()
 
         if isinstance(output_io, io.BytesIO):
             output = str(output_io.getvalue(), encoding="utf8", errors="surrogateescape")


### PR DESCRIPTION
Fix #1161 - making stdout line-buffered.

I can't think how to add a unit test for this because capfd keeps stdout and stderr separately. But on my machine, this-

```
python -m test.test_projects test.test_0_basic.basic_project /tmp/basic_project
(cd /tmp/basic_project && CIBW_BEFORE_BUILD="python -uc 'import sys, time; print(1, file=sys.stdout); time.sleep(0.1); print(2, file=sys.stderr)'" cibuildwheel --platform linux)
```

Prints 

```
2
1
```

before this PR and ...
```
1
2
```
after.
