### PR TITLE
fix: action using powershell on Windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,8 @@ runs:
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"
-        --output-dir "${{ inputs.output-dir }}"
-        --config-file "${{ inputs.config-file }}"
-        --only "${{ inputs.only }}"
+        --output-dir '"${{ inputs.output-dir }}"'
+        --config-file '"${{ inputs.config-file }}"'
+        --only '"${{ inputs.only }}"'
       shell: pwsh
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,23 @@ runs:
         --python '${{ steps.python.outputs.python-path }}'
         --spec '${{ github.action_path }}'
         cibuildwheel
-        ${{ inputs.package-dir }}
-        --output-dir ${{ inputs.output-dir }}
+        "${{ inputs.package-dir }}"
+        --output-dir "${{ inputs.output-dir }}"
         --config-file "${{ inputs.config-file }}"
         --only "${{ inputs.only }}"
         2>&1
       shell: bash
+      if: runner.os != 'Windows'
+
+    # Windows needs powershell to interact nicely with Meson
+    - run: >
+        pipx run
+        --python "${{ steps.python.outputs.python-path }}"
+        --spec "${{ github.action_path }}"
+        cibuildwheel
+        "${{ inputs.package-dir }}"
+        --output-dir "${{ inputs.output-dir }}"
+        --config-file "${{ inputs.config-file }}"
+        --only "${{ inputs.only }}"
+      shell: pwsh
+      if: runner.os == 'Windows'


### PR DESCRIPTION
Fixes #1338 by using the native GHA shell (powershell) on Windows. Using bash changes the path unexpectedly.

You can see it working for existing projects at https://github.com/pybind/scikit_build_example/actions/runs/3524040183/jobs/5908931400. "pipx run cibuildwheel" was verified to work with meson-python independently.