### PR TITLE
Faster Github linux CI by removing 'apt-get upgrade -y' from podman install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
         echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
         curl -sSfL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
         sudo apt-get update
-        sudo apt-get -y upgrade
         sudo apt-get -y install podman
 
     - name: Install dependencies


### PR DESCRIPTION
Just noticed that this step takes 10+ minutes - probably we can get away without it - let's try
