### PR TITLE
ci: move to ubuntu 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-11]
+        os: [ubuntu-20.04, windows-latest, macos-11]
         python_version: ['3.11']
     timeout-minutes: 180
     steps:


### PR DESCRIPTION
I think the old one might be getting phased out.