### PR TITLE
ci: use normal AppVeyor macOS image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
       APPVEYOR_JOB_NAME: "python37-x64-ubuntu"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       APPVEYOR_JOB_NAME: "python37-x64-vs2015"
-    - APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
-      APPVEYOR_JOB_NAME: "python37-x64-macos-mojave"
+    - APPVEYOR_BUILD_WORKER_IMAGE: macos
+      APPVEYOR_JOB_NAME: "python37-x64-macos"
 
 stack: python 3.7
 

--- a/examples/appveyor-minimal.yml
+++ b/examples/appveyor-minimal.yml
@@ -4,8 +4,8 @@ environment:
       APPVEYOR_JOB_NAME: "python37-x64-ubuntu"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       APPVEYOR_JOB_NAME: "python37-x64-vs2015"
-    - APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
-      APPVEYOR_JOB_NAME: "python37-x64-macos-mojave"
+    - APPVEYOR_BUILD_WORKER_IMAGE: macos
+      APPVEYOR_JOB_NAME: "python37-x64-macos"
 
 stack: python 3.7
 


### PR DESCRIPTION
use normal AppVeyor macOS image i.e. catalina (10.15) per https://github.com/pypa/cibuildwheel/pull/1372#issuecomment-1369773672 comment.

towards #1372 & #1381 

Created a PR cherry-picking @henryiii commits (I think this might be cleaner looking at commit history depending how it would be merged).

Order for merging would be this PR then #1381 and then #1372
