### PR TITLE
Examples: Updated info for pillow_heif

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -401,9 +401,9 @@
 - name: pillow-heif
   gh: bigcat88/pillow_heif
   pypi: pillow-heif
-  ci: [github]
-  os: [apple, linux]
-  notes: Python CFFI binding to libheif library with third party dependencies like `libde265`, `x265`, `libaom` with test & publishing on PyPi.
+  ci: [github, cirrusci]
+  os: [apple, linux, windows]
+  notes: Bindings to libheif library with third party dependencies. Fully automated CI for tests and publishing including Apple Silicon builds.
 
 - name: clang-format
   gh: ssciwr/clang-format-wheel


### PR DESCRIPTION
Some people will be interested in additional examples for Cirrus CI and how to include third party libraries using MSYS2 for Windows.
For Cirrus, use a slightly different technique than scipy to show another way to get wheels out of it.