### PR TITLE
chore: use Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,32 +13,16 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
-  hooks:
-  - id: pyupgrade
-    args: ["--py37-plus"]
-    exclude: ^cibuildwheel/resources/.*py$
-
-# Autoremoves unused imports
-- repo: https://github.com/hadialqattan/pycln
-  rev: v2.1.2
-  hooks:
-  - id: pycln
-    args: [--all]
-    stages: [manual]
-
-- repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
-  hooks:
-  - id: isort
-    args: ["-a", "from __future__ import annotations"]
-    exclude: ^cibuildwheel/resources/.*py$
-
 - repo: https://github.com/psf/black
   rev: 22.12.0
   hooks:
   - id: black
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.237
+  hooks:
+  - id: ruff
+    args: ["--fix"]
 
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v2.2.0
@@ -73,29 +57,6 @@ repos:
     exclude: ^cibuildwheel/resources/.*py$
     args: ["--python-version=3.10"]
     additional_dependencies: *mypy-dependencies
-
-- repo: https://github.com/asottile/yesqa
-  rev: v1.4.0
-  hooks:
-  - id: yesqa
-    additional_dependencies: &flake8-dependencies
-    - flake8-bugbear
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
-  hooks:
-  - id: flake8
-    exclude: ^cibuildwheel/resources/
-    additional_dependencies: *flake8-dependencies
-
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
-  hooks:
-  - id: python-check-blanket-noqa
-    stages: [manual]
-  - id: python-no-log-warn
-  - id: python-no-eval
-  - id: python-use-type-annotations
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.9.0.2

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -68,7 +68,7 @@ def bump_version() -> None:
         sys.exit(1)
 
     # fmt: off
-    print(              'Current version:', current_version)  # noqa: E201 whitespace
+    print(              'Current version:', current_version)
     new_version = input('    New version: ').strip()
     # fmt: on
 

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -280,9 +280,8 @@ class AllVersions:
                 config_update = self.windows_64.update_version_windows(spec)
             elif identifier.startswith("pp"):
                 config_update = self.windows_pypy_64.update_version_windows(spec)
-        elif "win_arm64" in identifier:
-            if identifier.startswith("cp"):
-                config_update = self.windows_arm64.update_version_windows(spec)
+        elif "win_arm64" in identifier and identifier.startswith("cp"):
+            config_update = self.windows_arm64.update_version_windows(spec)
 
         assert config_update is not None, f"{identifier} not found!"
         config.update(**config_update)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -373,7 +373,7 @@ def build_in_container(
     log.step_end()
 
 
-def build(options: Options, tmp_path: Path) -> None:  # pylint: disable=unused-argument
+def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
     try:
         # check the container engine is installed
         subprocess.run(

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -460,7 +460,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     env=env,
                     capture_stdout=True,
                 ).strip()
-                testing_archs: list[Literal["x86_64", "arm64"]]
+                testing_archs: list[Literal["x86_64", "arm64"]]  # noqa: F821
 
                 if config_is_arm64:
                     testing_archs = ["arm64"]

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -108,7 +108,8 @@ class OCIContainer:
             stdout=subprocess.PIPE,
         )
 
-        assert self.process.stdin and self.process.stdout
+        assert self.process.stdin
+        assert self.process.stdout
         self.bash_stdin = self.process.stdin
         self.bash_stdout = self.process.stdout
 

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -44,7 +44,7 @@ from .util import (
 
 @dataclasses.dataclass
 class CommandLineArguments:
-    platform: Literal["auto", "linux", "macos", "windows"] | None
+    platform: Literal["auto", "linux", "macos", "windows"] | None  # noqa: F821
     archs: str | None
     output_dir: Path
     only: str | None

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -606,7 +606,7 @@ def virtualenv(
     else:
         paths = [str(venv_path / "bin")]
     env = os.environ.copy()
-    env["PATH"] = os.pathsep.join(paths + [env["PATH"]])
+    env["PATH"] = os.pathsep.join([*paths, env["PATH"]])
     return env
 
 
@@ -648,7 +648,7 @@ def find_compatible_wheel(wheels: Sequence[T], identifier: str) -> T | None:
                     continue
             else:
                 # Windows should exactly match
-                if not tag.platform == platform:
+                if tag.platform != platform:
                     continue
 
             # If all the filters above pass, then the wheel is a previously built compatible wheel.

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -116,7 +116,8 @@ def install_cpython(version: str, arch: str) -> Path:
 
 
 def install_pypy(tmp: Path, arch: str, url: str) -> Path:
-    assert arch == "64" and "win64" in url
+    assert arch == "64"
+    assert "win64" in url
     # Inside the PyPy zip file is a directory with the same name
     zip_filename = url.rsplit("/", 1)[-1]
     extension = ".zip"
@@ -178,12 +179,11 @@ def setup_setuptools_cross_compile(
     env["SETUPTOOLS_USE_DISTUTILS"] = "local"
 
 
-# these cross-compile setup functions have the same signature by design
-# pylint: disable=unused-argument
+# These cross-compile setup functions have the same signature by design
 def setup_rust_cross_compile(
-    tmp: Path,
+    tmp: Path,  # noqa: ARG001
     python_configuration: PythonConfiguration,
-    python_libs_base: Path,
+    python_libs_base: Path,  # noqa: ARG001
     env: dict[str, str],
 ) -> None:
     # Assume that MSVC will be used, because we already know that we are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,12 @@
 requires = [
     "setuptools>=42",
 ]
-
 build-backend = "setuptools.build_meta"
 
 
 [tool.black]
 line-length = 100
 target-version = ['py37', 'py38', 'py39', 'py310']
-
-
-[tool.isort]
-profile = "black"
 
 
 [tool.pytest.ini_options]
@@ -119,4 +114,35 @@ messages_control.disable = [
   "too-many-statements",
   "unsubscriptable-object",
   "wrong-import-position",
+  "unused-argument",  # Handled by Ruff
 ]
+
+[tool.ruff]
+select = [
+  "E", "F", "W",  # flake8
+  "B",  "B904",  # flake8-bugbear
+  "I",  # isort
+  "ARG",  # flake8-unused-arguments
+  "C4",  # flake8-comprehensions
+  "EM",  # flake8-errmsg
+  "ICN",  # flake8-import-conventions
+  "ISC",  # flake8-implicit-str-concat
+  "PGH",  # pygrep-hooks
+  "PIE",  # flake8-pie
+  "PLC", "PLE", "PLR", "PLW",  # pylint
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF",  # Ruff-specific
+  "SIM",  # flake8-simplify
+  "UP",  # pyupgrade
+  "YTT",  # flake8-2020
+]
+ignore = [
+  "PLR2004", "E501",
+  "RET504", "RET505", "RET508",  # else after control flow
+  "PT004",  # Rename suggested for returnless fixtures
+  "PT007",  # False positive (fixed upstream)
+]
+target-version = "py37"
+typing-modules = ["cibuildwheel.typing"]
+flake8-unused-arguments.ignore-variadic-names = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,18 +53,3 @@ console_scripts =
 
 [options.package_data]
 cibuildwheel = resources/*
-
-[flake8]
-extend-ignore = E203,E501,B950,B023
-extend-select = B9
-application-import-names = cibuildwheel
-exclude =
-    cibuildwheel/resources/,
-    dist/,
-    build/,
-    .git/,
-    env/,
-    env2/,
-    env??/,
-    .venv/,
-    site/

--- a/test/test_cpp_standards.py
+++ b/test/test_cpp_standards.py
@@ -70,7 +70,7 @@ def test_cpp11(tmp_path):
     cpp11_project.generate(project_dir)
 
     actual_wheels = utils.cibuildwheel_run(project_dir)
-    expected_wheels = [w for w in utils.expected_wheels("spam", "0.1.0")]
+    expected_wheels = list(utils.expected_wheels("spam", "0.1.0"))
 
     assert set(actual_wheels) == set(expected_wheels)
 
@@ -89,7 +89,7 @@ def test_cpp14(tmp_path):
     cpp14_project.generate(project_dir)
 
     actual_wheels = utils.cibuildwheel_run(project_dir)
-    expected_wheels = [w for w in utils.expected_wheels("spam", "0.1.0")]
+    expected_wheels = list(utils.expected_wheels("spam", "0.1.0"))
 
     assert set(actual_wheels) == set(expected_wheels)
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -65,8 +65,8 @@ def test_overridden_path(tmp_path, capfd):
     output_dir.mkdir()
 
     # mess up PATH, somehow
-    with pytest.raises(subprocess.CalledProcessError):
-        if utils.platform == "linux":
+    if utils.platform == "linux":
+        with pytest.raises(subprocess.CalledProcessError):
             utils.cibuildwheel_run(
                 project_dir,
                 output_dir=output_dir,
@@ -75,11 +75,12 @@ def test_overridden_path(tmp_path, capfd):
                     "CIBW_ENVIRONMENT": '''PATH="$(pwd)/new_path:$PATH"''',
                 },
             )
-        else:
-            new_path = tmp_path / "another_bin"
-            new_path.mkdir()
-            (new_path / "python").touch(mode=0o777)
+    else:
+        new_path = tmp_path / "another_bin"
+        new_path.mkdir()
+        (new_path / "python").touch(mode=0o777)
 
+        with pytest.raises(subprocess.CalledProcessError):
             utils.cibuildwheel_run(
                 project_dir,
                 output_dir=output_dir,

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -35,8 +35,7 @@ def test(tmp_path, capfd):
     pure_python_project.generate(project_dir)
 
     with pytest.raises(subprocess.CalledProcessError):
-        actual_wheels = utils.cibuildwheel_run(project_dir)
-        print("produced wheels:", actual_wheels)
+        print("produced wheels:", utils.cibuildwheel_run(project_dir))
 
     captured = capfd.readouterr()
     print("out", captured.out)

--- a/unit_test/conftest.py
+++ b/unit_test/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_package_dir(tmp_path, monkeypatch):
     """
     Monkey-patch enough for the main() function to run

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -47,7 +47,7 @@ def mock_protection(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def fake_package_dir_autouse(fake_package_dir):
+def fake_package_dir_autouse(fake_package_dir):  # noqa: ARG001
     pass
 
 
@@ -60,9 +60,9 @@ def disable_print_wheels(monkeypatch):
     monkeypatch.setattr(util, "print_new_wheels", empty_cm)
 
 
-@pytest.fixture
-def allow_empty(request, monkeypatch, fake_package_dir):
-    monkeypatch.setattr(sys, "argv", fake_package_dir + ["--allow-empty"])
+@pytest.fixture()
+def allow_empty(monkeypatch, fake_package_dir):
+    monkeypatch.setattr(sys, "argv", [*fake_package_dir, "--allow-empty"])
 
 
 @pytest.fixture(params=["linux", "macos", "windows"])
@@ -81,7 +81,7 @@ def platform(request, monkeypatch):
     return platform_value
 
 
-@pytest.fixture
+@pytest.fixture()
 def intercepted_build_args(monkeypatch):
     intercepted = ArgsInterceptor()
 

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -24,7 +24,7 @@ def test_unknown_platform_non_ci(monkeypatch, capsys):
 
     with pytest.raises(SystemExit) as exit:
         main()
-        assert exit.value.code == 2
+    assert exit.value.code == 2
     _, err = capsys.readouterr()
 
     assert "cibuildwheel: Unable to detect platform." in err
@@ -38,7 +38,7 @@ def test_unknown_platform_on_ci(monkeypatch, capsys):
 
     with pytest.raises(SystemExit) as exit:
         main()
-        assert exit.value.code == 2
+    assert exit.value.code == 2
     _, err = capsys.readouterr()
 
     assert 'cibuildwheel: Unable to detect platform from "sys.platform"' in err
@@ -57,7 +57,7 @@ def test_unknown_platform(monkeypatch, capsys):
 
 def test_platform_argument(platform, intercepted_build_args, monkeypatch):
     monkeypatch.setenv("CIBW_PLATFORM", "nonexistent")
-    monkeypatch.setattr(sys, "argv", sys.argv + ["--platform", platform])
+    monkeypatch.setattr(sys, "argv", [*sys.argv, "--platform", platform])
 
     main()
 
@@ -66,14 +66,15 @@ def test_platform_argument(platform, intercepted_build_args, monkeypatch):
     assert options.globals.package_dir == MOCK_PACKAGE_DIR.resolve()
 
 
-def test_platform_environment(platform, intercepted_build_args, monkeypatch):
+@pytest.mark.usefixtures("platform")
+def test_platform_environment(intercepted_build_args):
     main()
     options = intercepted_build_args.args[0]
 
     assert options.globals.package_dir == MOCK_PACKAGE_DIR.resolve()
 
 
-def test_archs_default(platform, intercepted_build_args, monkeypatch):
+def test_archs_default(platform, intercepted_build_args):
 
     main()
     options = intercepted_build_args.args[0]
@@ -93,7 +94,7 @@ def test_archs_argument(platform, intercepted_build_args, monkeypatch, use_env_v
         monkeypatch.setenv("CIBW_ARCHS", "ppc64le")
     else:
         monkeypatch.setenv("CIBW_ARCHS", "unused")
-        monkeypatch.setattr(sys, "argv", sys.argv + ["--archs", "ppc64le"])
+        monkeypatch.setattr(sys, "argv", [*sys.argv, "--archs", "ppc64le"])
 
     if platform in {"macos", "windows"}:
         with pytest.raises(SystemExit) as exit:
@@ -195,7 +196,7 @@ def test_archs_platform_all(platform, intercepted_build_args, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "only,plat",
+    ("only", "plat"),
     (
         ("cp311-manylinux_x86_64", "linux"),
         ("cp310-win_amd64", "windows"),
@@ -206,7 +207,7 @@ def test_archs_platform_all(platform, intercepted_build_args, monkeypatch):
 def test_only_argument(intercepted_build_args, monkeypatch, only, plat):
     monkeypatch.setenv("CIBW_BUILD", "unused")
     monkeypatch.setenv("CIBW_SKIP", "unused")
-    monkeypatch.setattr(sys, "argv", sys.argv + ["--only", only])
+    monkeypatch.setattr(sys, "argv", [*sys.argv, "--only", only])
 
     main()
 
@@ -219,7 +220,7 @@ def test_only_argument(intercepted_build_args, monkeypatch, only, plat):
 
 @pytest.mark.parametrize("only", ("cp311-manylxinux_x86_64", "some_linux_thing"))
 def test_only_failed(monkeypatch, only):
-    monkeypatch.setattr(sys, "argv", sys.argv + ["--only", only])
+    monkeypatch.setattr(sys, "argv", [*sys.argv, "--only", only])
 
     with pytest.raises(SystemExit):
         main()
@@ -227,7 +228,7 @@ def test_only_failed(monkeypatch, only):
 
 def test_only_no_platform(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", sys.argv + ["--only", "cp311-manylinux_x86_64", "--platform", "macos"]
+        sys, "argv", [*sys.argv, "--only", "cp311-manylinux_x86_64", "--platform", "macos"]
     )
 
     with pytest.raises(SystemExit):
@@ -236,7 +237,7 @@ def test_only_no_platform(monkeypatch):
 
 def test_only_no_archs(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", sys.argv + ["--only", "cp311-manylinux_x86_64", "--archs", "x86_64"]
+        sys, "argv", [*sys.argv, "--only", "cp311-manylinux_x86_64", "--archs", "x86_64"]
     )
 
     with pytest.raises(SystemExit):
@@ -244,7 +245,7 @@ def test_only_no_archs(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "envvar_name,envvar_value",
+    ("envvar_name", "envvar_value"),
     (
         ("CIBW_BUILD", "cp310-*"),
         ("CIBW_SKIP", "cp311-*"),
@@ -253,7 +254,7 @@ def test_only_no_archs(monkeypatch):
     ),
 )
 def test_only_overrides_env_vars(monkeypatch, intercepted_build_args, envvar_name, envvar_value):
-    monkeypatch.setattr(sys, "argv", sys.argv + ["--only", "cp311-manylinux_x86_64"])
+    monkeypatch.setattr(sys, "argv", [*sys.argv, "--only", "cp311-manylinux_x86_64"])
     monkeypatch.setenv(envvar_name, envvar_value)
 
     main()

--- a/unit_test/main_tests/main_requires_python_test.py
+++ b/unit_test/main_tests/main_requires_python_test.py
@@ -9,7 +9,7 @@ from packaging.specifiers import SpecifierSet
 from cibuildwheel.__main__ import main
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def fake_package_dir(monkeypatch, tmp_path):
     """
     Set up a fake project
@@ -25,7 +25,8 @@ def fake_package_dir(monkeypatch, tmp_path):
     return local_path
 
 
-def test_no_override(platform, monkeypatch, intercepted_build_args):
+@pytest.mark.usefixtures("platform")
+def test_no_override(intercepted_build_args):
 
     main()
 
@@ -38,7 +39,8 @@ def test_no_override(platform, monkeypatch, intercepted_build_args):
     assert intercepted_build_selector.requires_python is None
 
 
-def test_override_env(platform, monkeypatch, intercepted_build_args):
+@pytest.mark.usefixtures("platform")
+def test_override_env(monkeypatch, intercepted_build_args):
     monkeypatch.setenv("CIBW_PROJECT_REQUIRES_PYTHON", ">=3.8")
 
     main()
@@ -52,7 +54,8 @@ def test_override_env(platform, monkeypatch, intercepted_build_args):
     assert not intercepted_build_selector("cp36-win32")
 
 
-def test_override_setup_cfg(platform, monkeypatch, intercepted_build_args, fake_package_dir):
+@pytest.mark.usefixtures("platform")
+def test_override_setup_cfg(intercepted_build_args, fake_package_dir):
 
     fake_package_dir.joinpath("setup.cfg").write_text(
         textwrap.dedent(
@@ -74,7 +77,8 @@ def test_override_setup_cfg(platform, monkeypatch, intercepted_build_args, fake_
     assert not intercepted_build_selector("cp36-win32")
 
 
-def test_override_pyproject_toml(platform, monkeypatch, intercepted_build_args, fake_package_dir):
+@pytest.mark.usefixtures("platform")
+def test_override_pyproject_toml(intercepted_build_args, fake_package_dir):
 
     fake_package_dir.joinpath("pyproject.toml").write_text(
         textwrap.dedent(
@@ -96,7 +100,8 @@ def test_override_pyproject_toml(platform, monkeypatch, intercepted_build_args, 
     assert not intercepted_build_selector("cp36-win32")
 
 
-def test_override_setup_py_simple(platform, monkeypatch, intercepted_build_args, fake_package_dir):
+@pytest.mark.usefixtures("platform")
+def test_override_setup_py_simple(intercepted_build_args, fake_package_dir):
 
     fake_package_dir.joinpath("setup.py").write_text(
         textwrap.dedent(

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -16,7 +16,7 @@ from cibuildwheel.__main__ import main
 ALL_IDS = {"cp36", "cp37", "cp38", "cp39", "cp310", "cp311", "pp37", "pp38", "pp39"}
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_build_container(monkeypatch):
     def fail_on_call(*args, **kwargs):
         msg = "This should never be called"
@@ -46,8 +46,9 @@ def mock_build_container(monkeypatch):
     monkeypatch.setattr("cibuildwheel.util.print_new_wheels", ignore_context_call)
 
 
-def test_build_default_launches(mock_build_container, fake_package_dir, monkeypatch):
-    monkeypatch.setattr(sys, "argv", sys.argv + ["--platform=linux"])
+@pytest.mark.usefixtures("mock_build_container", "fake_package_dir")
+def test_build_default_launches(monkeypatch):
+    monkeypatch.setattr(sys, "argv", [*sys.argv, "--platform=linux"])
 
     main()
 
@@ -91,7 +92,8 @@ def test_build_default_launches(mock_build_container, fake_package_dir, monkeypa
     assert identifiers == {f"{x}-musllinux_i686" for x in ALL_IDS if "pp" not in x}
 
 
-def test_build_with_override_launches(mock_build_container, monkeypatch, tmp_path):
+@pytest.mark.usefixtures("mock_build_container")
+def test_build_with_override_launches(monkeypatch, tmp_path):
     pkg_dir = tmp_path / "cibw_package"
     pkg_dir.mkdir()
 

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -140,7 +140,7 @@ xfail_env_parse = pytest.mark.xfail(
         pytest.param("a trailing backslash \\", marks=[xfail_env_parse]),
     ],
 )
-def test_toml_environment_evil(tmp_path, monkeypatch, env_var_value):
+def test_toml_environment_evil(tmp_path, env_var_value):
     args = CommandLineArguments.defaults()
     args.package_dir = tmp_path
 
@@ -159,7 +159,7 @@ def test_toml_environment_evil(tmp_path, monkeypatch, env_var_value):
 
 
 @pytest.mark.parametrize(
-    "toml_assignment,result_value",
+    ("toml_assignment", "result_value"),
     [
         ('TEST_VAR="simple_value"', "simple_value"),
         # spaces

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -71,7 +71,7 @@ def test_simple_settings(tmp_path, platform, fname):
         options_reader.get("test-extras", table={"item": '{k}="{v}"', "sep": " "})
 
 
-def test_envvar_override(tmp_path, platform, monkeypatch):
+def test_envvar_override(tmp_path, platform):
     config_file_path: Path = tmp_path / "pyproject.toml"
     config_file_path.write_text(PYPROJECT_1)
 
@@ -112,14 +112,14 @@ repair-wheel-command = "repair-project-global"
     assert options_reader.get("repair-wheel-command") == "repair-project-global"
 
 
-def test_env_global_override_default_platform(tmp_path, platform, monkeypatch):
+def test_env_global_override_default_platform(platform):
     options_reader = OptionsReader(
         platform=platform, env={"CIBW_REPAIR_WHEEL_COMMAND": "repair-env-global"}
     )
     assert options_reader.get("repair-wheel-command") == "repair-env-global"
 
 
-def test_env_global_override_project_platform(tmp_path, platform, monkeypatch):
+def test_env_global_override_project_platform(tmp_path, platform):
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(
         """
@@ -215,7 +215,7 @@ build = ["1", "2"]
     )
     options_reader = OptionsReader(pyproject_toml, platform="linux", env={})
 
-    assert "1, 2" == options_reader.get("build", sep=", ")
+    assert options_reader.get("build", sep=", ") == "1, 2"
     with pytest.raises(ConfigOptionError):
         options_reader.get("build")
 
@@ -234,7 +234,7 @@ manylinux-x86_64-image = "manylinux1"
         OptionsReader(pyproject_toml, platform="windows", disallow=disallow, env={})
 
 
-def test_environment_override_empty(tmp_path, monkeypatch):
+def test_environment_override_empty(tmp_path):
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(
         """
@@ -262,7 +262,7 @@ manylinux-x86_64-image = ""
     assert options_reader.get("manylinux-aarch64-image", ignore_empty=True) == "manylinux1"
 
 
-@pytest.mark.parametrize("ignore_empty", (True, False))
+@pytest.mark.parametrize("ignore_empty", [True, False])
 def test_dig_first(ignore_empty):
     d1 = {"random": "thing"}
     d2 = {"this": "that", "empty": ""}

--- a/unit_test/utils_test.py
+++ b/unit_test/utils_test.py
@@ -61,8 +61,8 @@ def test_prepare_command():
 
 
 @pytest.mark.parametrize(
-    "wheel,identifier",
-    (
+    ("wheel", "identifier"),
+    [
         ("foo-0.1-cp38-abi3-win_amd64.whl", "cp310-win_amd64"),
         ("foo-0.1-cp38-abi3-macosx_11_0_x86_64.whl", "cp310-macosx_x86_64"),
         ("foo-0.1-cp38-abi3-manylinux2014_x86_64.whl", "cp310-manylinux_x86_64"),
@@ -72,7 +72,7 @@ def test_prepare_command():
         ("foo-0.1-py3-none-win_amd64.whl", "cp310-win_amd64"),
         ("foo-0.1-py38-none-win_amd64.whl", "cp310-win_amd64"),
         ("foo-0.1-py38-none-win_amd64.whl", "pp310-win_amd64"),
-    ),
+    ],
 )
 def test_find_compatible_wheel_found(wheel: str, identifier: str):
     wheel_ = PurePath(wheel)
@@ -81,8 +81,8 @@ def test_find_compatible_wheel_found(wheel: str, identifier: str):
 
 
 @pytest.mark.parametrize(
-    "wheel,identifier",
-    (
+    ("wheel", "identifier"),
+    [
         ("foo-0.1-cp38-abi3-win_amd64.whl", "cp310-win32"),
         ("foo-0.1-cp38-abi3-win_amd64.whl", "cp37-win_amd64"),
         ("foo-0.1-cp38-abi3-macosx_11_0_x86_64.whl", "cp310-macosx_universal2"),
@@ -92,7 +92,7 @@ def test_find_compatible_wheel_found(wheel: str, identifier: str):
         ("foo-0.1-py38-none-win_amd64.whl", "cp37-win_amd64"),
         ("foo-0.1-py38-none-win_amd64.whl", "pp37-win_amd64"),
         ("foo-0.1-cp38-cp38-win_amd64.whl", "cp310-win_amd64"),
-    ),
+    ],
 )
 def test_find_compatible_wheel_not_found(wheel: str, identifier: str):
     assert find_compatible_wheel([PurePath(wheel)], identifier) is None

--- a/unit_test/wheel_print_test.py
+++ b/unit_test/wheel_print_test.py
@@ -23,10 +23,9 @@ def test_printout_wheels(tmp_path, capsys):
 
 def test_no_printout_on_error(tmp_path, capsys):
     tmp_path.joinpath("example.0").touch()
-    with pytest.raises(RuntimeError):
-        with print_new_wheels("TEST_MSG: {n}", tmp_path):
-            tmp_path.joinpath("example.1").touch()
-            raise RuntimeError()
+    with pytest.raises(RuntimeError), print_new_wheels("TEST_MSG: {n}", tmp_path):  # noqa: PT012
+        tmp_path.joinpath("example.1").touch()
+        raise RuntimeError()
 
     captured = capsys.readouterr()  # type: ignore[unreachable]
     assert captured.err == ""


### PR DESCRIPTION
- chore: use ruff
- chore: use ruff (manual changes)


Is 10-100x faster (written in Rust), combines flake8 and lots of plugins, pyupgrade, isort, pygrep, yesqa, and some of flake8 (so pre-commit setup is faster - also just a simple binary, I think). And pyproject.toml configured! Also can do auto-fixes for quite a few errors.Ran into a few minor bugs that have already been fixed upstream. Used by Pandas, FastAPI, SciPy, Build, etc. More pre-commit friendly, since we don't have breakage due to plugins not being pinned (because they are all built-in, so there's only the one pre-commit ref).

Suggested in https://github.com/pypa/cibuildwheel/pull/1399#issuecomment-1397340132.