### PR TITLE
fix: pip config options were broken

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -240,7 +240,9 @@ def build_in_container(
             container.call(["mkdir", "-p", built_wheel_dir])
 
             verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
-            extra_flags = split_config_settings(build_options.config_settings)
+            extra_flags = split_config_settings(
+                build_options.config_settings, plural=build_options.build_frontend == "pip"
+            )
 
             if build_options.build_frontend == "pip":
                 extra_flags += verbosity_flags

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -241,7 +241,7 @@ def build_in_container(
 
             verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
             extra_flags = split_config_settings(
-                build_options.config_settings, plural=build_options.build_frontend == "pip"
+                build_options.config_settings, build_options.build_frontend
             )
 
             if build_options.build_frontend == "pip":

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -375,7 +375,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
                 extra_flags = split_config_settings(
-                    build_options.config_settings, plural=build_options.build_frontend == "pip"
+                    build_options.config_settings, build_options.build_frontend
                 )
 
                 if build_options.build_frontend == "pip":

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -374,7 +374,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 built_wheel_dir.mkdir()
 
                 verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
-                extra_flags = split_config_settings(build_options.config_settings)
+                extra_flags = split_config_settings(
+                    build_options.config_settings, plural=build_options.build_frontend == "pip"
+                )
 
                 if build_options.build_frontend == "pip":
                     extra_flags += verbosity_flags

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -208,9 +208,9 @@ def get_build_verbosity_extra_flags(level: int) -> list[str]:
         return []
 
 
-def split_config_settings(config_settings: str, *, plural: bool) -> list[str]:
+def split_config_settings(config_settings: str, frontend: Literal["pip", "build"]) -> list[str]:
     config_settings_list = shlex.split(config_settings)
-    s = "s" if plural else ""
+    s = "s" if frontend == "pip" else ""
     return [f"--config-setting{s}={setting}" for setting in config_settings_list]
 
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -208,9 +208,10 @@ def get_build_verbosity_extra_flags(level: int) -> list[str]:
         return []
 
 
-def split_config_settings(config_settings: str) -> list[str]:
+def split_config_settings(config_settings: str, *, plural: bool) -> list[str]:
     config_settings_list = shlex.split(config_settings)
-    return [f"--config-setting={setting}" for setting in config_settings_list]
+    s = "s" if plural else ""
+    return [f"--config-setting{s}={setting}" for setting in config_settings_list]
 
 
 def read_python_configs(config: PlatformName) -> list[dict[str, str]]:

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -412,7 +412,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
                 extra_flags = split_config_settings(
-                    build_options.config_settings, plural=build_options.build_frontend == "pip"
+                    build_options.config_settings, build_options.build_frontend
                 )
 
                 if build_options.build_frontend == "pip":

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -411,7 +411,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 built_wheel_dir.mkdir()
 
                 verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
-                extra_flags = split_config_settings(build_options.config_settings)
+                extra_flags = split_config_settings(
+                    build_options.config_settings, plural=build_options.build_frontend == "pip"
+                )
 
                 if build_options.build_frontend == "pip":
                     extra_flags += verbosity_flags

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -283,10 +283,16 @@ def test_config_settings(platform_specific, platform, intercepted_build_args, mo
 
     assert build_options.config_settings == config_settings
 
-    assert split_config_settings(config_settings) == [
+    assert split_config_settings(config_settings, plural=False) == [
         "--config-setting=setting=value",
         "--config-setting=setting=value2",
         "--config-setting=other=something else",
+    ]
+
+    assert split_config_settings(config_settings, plural=True) == [
+        "--config-settings=setting=value",
+        "--config-settings=setting=value2",
+        "--config-settings=other=something else",
     ]
 
 

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -283,13 +283,13 @@ def test_config_settings(platform_specific, platform, intercepted_build_args, mo
 
     assert build_options.config_settings == config_settings
 
-    assert split_config_settings(config_settings, plural=False) == [
+    assert split_config_settings(config_settings, "build") == [
         "--config-setting=setting=value",
         "--config-setting=setting=value2",
         "--config-setting=other=something else",
     ]
 
-    assert split_config_settings(config_settings, plural=True) == [
+    assert split_config_settings(config_settings, "pip") == [
         "--config-settings=setting=value",
         "--config-settings=setting=value2",
         "--config-settings=other=something else",


### PR DESCRIPTION
Closes #1429. Only "build" backend supported config options, since pip uses a different name (with an s).
