### PR TITLE
fix: use GNU tar on macOS for OCIContainer interactions

### DIFF
--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -20,10 +20,10 @@ from cibuildwheel.oci_container import OCIContainer
 
 # for these tests we use manylinux2014 images, because they're available on
 # multi architectures and include python3.8
-pm = platform.machine()
-if pm == "x86_64":
+pm = platform.machine().lower()
+if pm in {"x86_64", "amd64"}:
     DEFAULT_IMAGE = "quay.io/pypa/manylinux2014_x86_64:2020-05-17-2f8ac3b"
-elif pm == "aarch64" or pm == "arm64":
+elif pm in {"aarch64", "arm64"}:
     DEFAULT_IMAGE = "quay.io/pypa/manylinux2014_aarch64:2020-05-17-2f8ac3b"
 elif pm == "ppc64le":
     DEFAULT_IMAGE = "quay.io/pypa/manylinux2014_ppc64le:2020-05-17-2f8ac3b"


### PR DESCRIPTION
macOS uses BSD tar as the default `tar` command.
This can result in hard to debug issues when building linux wheels on macOS because of incompatibilities between GNU tar (used inside containers) & BSD tar (used on host).
This commit tries to use GNU tar on the host macOS and warns if it is not found.