### PR TITLE
add warning about `cd /d` in test-command

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1172,6 +1172,14 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
+!!! tip
+
+    It's isn't recommended to `cd` to your project directory before running tests,
+    because Python might resolve `import yourpackage` relative to the working dir,
+    but we want to test the wheel you just built. However, if you're sure that's not
+    an issue for you and your workflow requires it, on Windows you should do `cd /d`,
+    because the CWD and project dir might be on different drives.
+
 #### Examples
 
 !!! tab examples "Environment variables"

--- a/docs/options.md
+++ b/docs/options.md
@@ -1172,14 +1172,6 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_COMMAND_MACOS` | `CIBW_TEST_COMMAND_WINDOWS` | `CIBW_TEST_COMMAND_LINUX`
 
-!!! tip
-
-    It's isn't recommended to `cd` to your project directory before running tests,
-    because Python might resolve `import yourpackage` relative to the working dir,
-    but we want to test the wheel you just built. However, if you're sure that's not
-    an issue for you and your workflow requires it, on Windows you should do `cd /d`,
-    because the CWD and project dir might be on different drives.
-
 #### Examples
 
 !!! tab examples "Environment variables"
@@ -1222,6 +1214,13 @@ Platform-specific environment variables are also available:<br/>
 
     In configuration files, you can use an array, and the items will be joined with `&&`.
 
+!!! note
+
+    It's isn't recommended to `cd` to your project directory before running tests,
+    because Python might resolve `import yourpackage` relative to the working dir,
+    and we want to test the wheel you just built. However, if you're sure that's not
+    an issue for you and your workflow requires it, on Windows you should do `cd /d`,
+    because the CWD and project dir might be on different drives.
 
 ### `CIBW_BEFORE_TEST` {: #before-test}
 > Execute a shell command before testing each wheel


### PR DESCRIPTION
I wouldn't normally document OS features/quirks in our documentation, but here, it wasn't the user that changed the working dir to another drive, it was cibuildwheel, so it seems fair to note some gotchas.

Fixes #1448 