### PR TITLE
tests: use uppercase envvar on Windows

### DIFF
--- a/test/test_windows.py
+++ b/test/test_windows.py
@@ -12,9 +12,9 @@ basic_project = test_projects.new_c_project()
 
 
 def skip_if_no_msvc(arm64=False):
-    programfiles = os.getenv("ProgramFiles(x86)", "") or os.getenv("ProgramFiles", "")
+    programfiles = os.getenv("PROGRAMFILES(X86)", "") or os.getenv("PROGRAMFILES", "")
     if not programfiles:
-        pytest.skip("Requires %ProgramFiles(x86)% variable to be set")
+        pytest.skip("Requires %PROGRAMFILES(X86)% variable to be set")
 
     vswhere = os.path.join(programfiles, "Microsoft Visual Studio", "Installer", "vswhere.exe")
     if not os.path.isfile(vswhere):


### PR DESCRIPTION
Quick fix for https://github.com/charliermarsh/ruff/pull/3876 - also, besides consistency, I like this a bit better, because it's easy to assume that envvar's are case sensitive when you see them in camel case. I was confused by that once on Windows (I had a nice idea that was broken by them not being case sensitive on just this one OS).
