### PR TITLE
chore: add structurally typed GenericPythonConfiguration

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -9,6 +9,7 @@ import textwrap
 import typing
 from pathlib import Path
 from tempfile import mkdtemp
+from collections.abc import Sequence, Set
 
 import cibuildwheel
 import cibuildwheel.linux
@@ -344,9 +345,9 @@ def print_preamble(platform: str, options: Options, identifiers: list[str]) -> N
 
 
 def get_build_identifiers(
-    platform: PlatformName, build_selector: BuildSelector, architectures: set[Architecture]
+    platform: PlatformName, build_selector: BuildSelector, architectures: Set[Architecture]
 ) -> list[str]:
-    python_configurations: typing.Sequence[GenericPythonConfiguration]
+    python_configurations: Sequence[GenericPythonConfiguration]
 
     if platform == "linux":
         python_configurations = cibuildwheel.linux.get_python_configurations(

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -7,9 +7,9 @@ import sys
 import tarfile
 import textwrap
 import typing
+from collections.abc import Sequence, Set
 from pathlib import Path
 from tempfile import mkdtemp
-from collections.abc import Sequence, Set
 
 import cibuildwheel
 import cibuildwheel.linux

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -18,7 +18,12 @@ import cibuildwheel.windows
 from cibuildwheel.architecture import Architecture, allowed_architectures_check
 from cibuildwheel.logger import log
 from cibuildwheel.options import CommandLineArguments, Options, compute_options
-from cibuildwheel.typing import PLATFORMS, PlatformName, assert_never
+from cibuildwheel.typing import (
+    PLATFORMS,
+    GenericPythonConfiguration,
+    PlatformName,
+    assert_never,
+)
 from cibuildwheel.util import (
     CIBW_CACHE_PATH,
     BuildSelector,
@@ -341,11 +346,7 @@ def print_preamble(platform: str, options: Options, identifiers: list[str]) -> N
 def get_build_identifiers(
     platform: PlatformName, build_selector: BuildSelector, architectures: set[Architecture]
 ) -> list[str]:
-    python_configurations: (
-        list[cibuildwheel.linux.PythonConfiguration]
-        | list[cibuildwheel.windows.PythonConfiguration]
-        | list[cibuildwheel.macos.PythonConfiguration]
-    )
+    python_configurations: typing.Sequence[GenericPythonConfiguration]
 
     if platform == "linux":
         python_configurations = cibuildwheel.linux.get_python_configurations(

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+from collections.abc import Set
 from dataclasses import dataclass
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Iterator, Tuple
@@ -46,7 +47,7 @@ class BuildStep:
 
 def get_python_configurations(
     build_selector: BuildSelector,
-    architectures: set[Architecture],
+    architectures: Set[Architecture],
 ) -> list[PythonConfiguration]:
     full_python_configs = read_python_configs("linux")
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Set
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence, Tuple, cast
@@ -69,7 +70,7 @@ class PythonConfiguration:
 
 
 def get_python_configurations(
-    build_selector: BuildSelector, architectures: set[Architecture]
+    build_selector: BuildSelector, architectures: Set[Architecture]
 ) -> list[PythonConfiguration]:
     full_python_configs = read_python_configs("macos")
 

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -47,4 +47,4 @@ PLATFORMS: Final[set[PlatformName]] = {"linux", "macos", "windows"}
 class GenericPythonConfiguration(Protocol):
     @property
     def identifier(self) -> str:
-        pass
+        ...

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -42,3 +42,9 @@ else:
 
 PlatformName = Literal["linux", "macos", "windows"]
 PLATFORMS: Final[set[PlatformName]] = {"linux", "macos", "windows"}
+
+
+class GenericPythonConfiguration(Protocol):
+    @property
+    def identifier(self) -> str:
+        pass

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
+from collections.abc import Set
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -71,7 +72,7 @@ class PythonConfiguration:
 
 def get_python_configurations(
     build_selector: BuildSelector,
-    architectures: set[Architecture],
+    architectures: Set[Architecture],
 ) -> list[PythonConfiguration]:
     full_python_configs = read_python_configs("windows")
 


### PR DESCRIPTION
Use structural typing for the return value of get_python_configurations so that we don't have to specify a union of all possible `PythonConfiguration` types.

This makes it slightly more convenient to add a new platform.