### PR TITLE
Set the default build_frontend to be "default" (which is still "pip")

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -176,7 +176,7 @@ def build_in_container(
     for config in platform_configs:
         log.build_start(config.identifier)
         build_options = options.build_options(config.identifier)
-        build_frontend = build_frontend_or_default(build_options.build_frontend, "pip")
+        build_frontend = build_frontend_or_default(build_options.build_frontend)
 
         dependency_constraint_flags: list[PathOrStr] = []
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -332,7 +332,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)
-            build_frontend = build_frontend_or_default(build_options.build_frontend, "pip")
+            build_frontend = build_frontend_or_default(build_options.build_frontend)
             log.build_start(config.identifier)
 
             identifier_tmp_dir = tmp_path / config.identifier

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -94,7 +94,7 @@ class BuildOptions:
     test_requires: list[str]
     test_extras: str
     build_verbosity: int
-    build_frontend: BuildFrontend
+    build_frontend: BuildFrontend | Literal["default"]
     config_settings: str
 
     @property
@@ -499,11 +499,13 @@ class Options:
             test_extras = self.reader.get("test-extras", sep=",")
             build_verbosity_str = self.reader.get("build-verbosity")
 
-            build_frontend: BuildFrontend
+            build_frontend: BuildFrontend | Literal["default"]
             if build_frontend_str == "build":
                 build_frontend = "build"
             elif build_frontend_str == "pip":
                 build_frontend = "pip"
+            elif build_frontend_str == "default":
+                build_frontend = "default"
             else:
                 msg = f"cibuildwheel: Unrecognised build frontend {build_frontend_str!r}, only 'pip' and 'build' are supported"
                 print(msg, file=sys.stderr)

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -4,7 +4,7 @@ skip = ""
 test-skip = ""
 
 archs = ["auto"]
-build-frontend = "pip"
+build-frontend = "default"
 config-settings = {}
 dependency-versions = "pinned"
 environment = {}

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -71,6 +71,15 @@ test_fail_cwd_file: Final[Path] = resources_dir / "testing_temp_dir_file.py"
 
 BuildFrontend = Literal["pip", "build"]
 
+
+def build_frontend_or_default(
+    setting: BuildFrontend | Literal["default"], default: BuildFrontend
+) -> BuildFrontend:
+    if setting == "default":
+        return default
+    return setting
+
+
 MANYLINUX_ARCHS: Final[tuple[str, ...]] = (
     "x86_64",
     "i686",

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -73,7 +73,7 @@ BuildFrontend = Literal["pip", "build"]
 
 
 def build_frontend_or_default(
-    setting: BuildFrontend | Literal["default"], default: BuildFrontend
+    setting: BuildFrontend | Literal["default"], default: BuildFrontend = "pip"
 ) -> BuildFrontend:
     if setting == "default":
         return default

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -368,7 +368,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)
-            build_frontend = build_frontend_or_default(build_options.build_frontend, "pip")
+            build_frontend = build_frontend_or_default(build_options.build_frontend)
             log.build_start(config.identifier)
 
             identifier_tmp_dir = tmp_path / config.identifier

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -27,6 +27,7 @@ from .util import (
     BuildFrontend,
     BuildSelector,
     NonPlatformWheelError,
+    build_frontend_or_default,
     call,
     download,
     find_compatible_wheel,
@@ -367,6 +368,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)
+            build_frontend = build_frontend_or_default(build_options.build_frontend, "pip")
             log.build_start(config.identifier)
 
             identifier_tmp_dir = tmp_path / config.identifier
@@ -387,7 +389,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 config,
                 dependency_constraint_flags,
                 build_options.environment,
-                build_options.build_frontend,
+                build_frontend,
             )
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
@@ -412,11 +414,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 built_wheel_dir.mkdir()
 
                 verbosity_flags = get_build_verbosity_extra_flags(build_options.build_verbosity)
-                extra_flags = split_config_settings(
-                    build_options.config_settings, build_options.build_frontend
-                )
+                extra_flags = split_config_settings(build_options.config_settings, build_frontend)
 
-                if build_options.build_frontend == "pip":
+                if build_frontend == "pip":
                     extra_flags += verbosity_flags
                     # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
                     # see https://github.com/pypa/cibuildwheel/pull/369
@@ -431,7 +431,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         *extra_flags,
                         env=env,
                     )
-                elif build_options.build_frontend == "build":
+                elif build_frontend == "build":
                     verbosity_setting = " ".join(verbosity_flags)
                     extra_flags += (f"--config-setting={verbosity_setting}",)
                     build_env = env.copy()
@@ -464,7 +464,7 @@ def build(options: Options, tmp_path: Path) -> None:
                             env=build_env,
                         )
                 else:
-                    assert_never(build_options.build_frontend)
+                    assert_never(build_frontend)
 
                 built_wheel = next(built_wheel_dir.glob("*.whl"))
 


### PR DESCRIPTION
Instead of using pip as the default, set it to default. This way each platform can choose independently what to do as the default behavior.

This is intended as part of adding Pyodide support #1456. Pyodide cannot use pip as the build frontend. It always uses a modified pypa/build. So if the build_frontend is explicitly set to pip we want to raise an error. But if it's unset, then we should be able to tell and just do what we want.