### PR TITLE
chore: minor cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,16 +46,14 @@ repos:
       - tomli_w
       - types-certifi
       - types-click
-      - types-dataclasses
       - types-jinja2
       - types-pyyaml
       - types-requests
       - bracex
-      - dataclasses
   - id: mypy
-    name: mypy 3.10
+    name: mypy 3.11
     exclude: ^cibuildwheel/resources/.*py$
-    args: ["--python-version=3.10"]
+    args: ["--python-version=3.11"]
     additional_dependencies: *mypy-dependencies
 
 - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -256,6 +256,7 @@ class PlatformModule(typing.Protocol):
         ...
 
 
+# pylint: disable-next=inconsistent-return-statements
 def get_platform_module(platform: PlatformName) -> PlatformModule:
     if platform == "linux":
         return cibuildwheel.linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 
 
 [tool.pytest.ini_options]
@@ -83,10 +83,10 @@ ignore = [
 ]
 
 [tool.pylint]
-master.py-version = "3.7"
-master.jobs = "0"
-master.fail-on = ["E", "F"]
-master.fail-under = "9.8"
+py-version = "3.7"
+jobs = "0"
+fail-on = ["E", "F"]
+fail-under = "9.8"
 reports.output-format = "colorized"
 messages_control.enable = [
   "useless-suppression",

--- a/setup.py
+++ b/setup.py
@@ -27,20 +27,9 @@ extras = {
         "rich>=9.6",
         "packaging>=21.0",
     ],
-    "mypy": [
-        "mypy>=0.901",
-        "types-jinja2",
-        "types-certifi",
-        "types-toml",
-        "types-jinja2",
-        "types-pyyaml",
-        "types-click",
-        "types-requests",
-    ],
 }
 
 extras["dev"] = [
-    *extras["mypy"],
     *extras["test"],
     *extras["bin"],
 ]


### PR DESCRIPTION
Adding a bit of cleanup from looking at #1297 again. Drops the unmaintained `[mypy]` extra.


- chore: clean up mypy a little bit
- chore: clean up pylint/black a bit
