### PR TITLE
chore: update to virtualenv<20.22.0

### DIFF
--- a/bin/update_virtualenv.py
+++ b/bin/update_virtualenv.py
@@ -53,6 +53,10 @@ def git_ls_remote_versions(url) -> list[VersionTuple]:
             if version.is_prerelease:
                 log.info("Ignoring pre-release %r", str(version))
                 continue
+            # Do not upgrade past 20.22.0 to keep python 3.6 compat
+            if version >= Version("20.22.0"):
+                log.info("Ignoring %r which is not compatible with python 3.6", str(version))
+                continue
             versions.append(VersionTuple(version, version_string))
         except InvalidVersion:
             log.warning("Ignoring ref %r", ref)


### PR DESCRIPTION
I'd like not to drop 3.6 right away (& possibly up-to centos 7 EOL or OpenSSL 1.1.1 EOL) as it is still used in around 15% of wheel builds (on linux at least).