### PR TITLE
chore: Simplify host platform logic

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -23,6 +23,8 @@ from cibuildwheel.options import CommandLineArguments, Options, compute_options
 from cibuildwheel.typing import PLATFORMS, GenericPythonConfiguration, PlatformName
 from cibuildwheel.util import (
     CIBW_CACHE_PATH,
+    HOST_IS_WINDOWS,
+    HOST_PLATFORM,
     BuildSelector,
     CIProvider,
     Unbuffered,
@@ -164,7 +166,7 @@ def main() -> None:
     finally:
         # avoid https://github.com/python/cpython/issues/86962 by performing
         # cleanup manually
-        shutil.rmtree(temp_dir, ignore_errors=sys.platform.startswith("win"))
+        shutil.rmtree(temp_dir, ignore_errors=HOST_IS_WINDOWS)
         if temp_dir.exists():
             log.warning(f"Can't delete temporary folder '{temp_dir}'")
 
@@ -197,19 +199,15 @@ def _compute_platform_ci() -> PlatformName:
             file=sys.stderr,
         )
         sys.exit(2)
-    if sys.platform.startswith("linux"):
-        return "linux"
-    elif sys.platform == "darwin":
-        return "macos"
-    elif sys.platform == "win32":
-        return "windows"
-    else:
-        print(
-            'cibuildwheel: Unable to detect platform from "sys.platform" in a CI environment. You can run '
-            "cibuildwheel using the --platform argument. Check --help output for more information.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    if HOST_PLATFORM:
+        return HOST_PLATFORM
+
+    print(
+        'cibuildwheel: Unable to detect platform from "sys.platform" in a CI environment. You can run '
+        "cibuildwheel using the --platform argument. Check --help output for more information.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 
 def _compute_platform(args: CommandLineArguments) -> PlatformName:
@@ -328,7 +326,7 @@ def build_in_directory(args: CommandLineArguments) -> None:
     finally:
         # avoid https://github.com/python/cpython/issues/86962 by performing
         # cleanup manually
-        shutil.rmtree(tmp_path, ignore_errors=sys.platform.startswith("win"))
+        shutil.rmtree(tmp_path, ignore_errors=HOST_IS_WINDOWS)
         if tmp_path.exists():
             log.warning(f"Can't delete temporary folder '{tmp_path}'")
 

--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import functools
 import platform as platform_module
 import re
-import sys
 from collections.abc import Set
 from enum import Enum
 
 from ._compat.typing import Final, Literal, assert_never
 from .typing import PlatformName
+from .util import HOST_PLATFORM
 
 PRETTY_NAMES: Final[dict[PlatformName, str]] = {
     "linux": "Linux",
@@ -74,20 +74,14 @@ class Architecture(Enum):
     def auto_archs(platform: PlatformName) -> set[Architecture]:
         native_machine = platform_module.machine()
 
-        # Cross-platform support. Used for --print-build-identifiers or docker builds.
-        host_platform: PlatformName = (
-            "windows"
-            if sys.platform.startswith("win")
-            else ("macos" if sys.platform.startswith("darwin") else "linux")
-        )
-
+        assert HOST_PLATFORM
         native_architecture = Architecture(native_machine)
 
         # we might need to rename the native arch to the machine we're running
         # on, as the same arch can have different names on different platforms
-        if host_platform != platform:
+        if platform != HOST_PLATFORM:
             for arch_synonym in ARCH_SYNONYMS:
-                if native_machine == arch_synonym.get(host_platform):
+                if native_machine == arch_synonym.get(HOST_PLATFORM):
                     synonym = arch_synonym[platform]
 
                     if synonym is None:

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -8,7 +8,7 @@ import time
 from typing import IO, AnyStr, Tuple
 
 from ._compat.typing import Final
-from .util import CIProvider, detect_ci_provider
+from .util import HOST_IS_WIN32, CIProvider, detect_ci_provider
 
 FoldPattern = Tuple[str, str]
 DEFAULT_FOLD_PATTERN: Final[FoldPattern] = ("{name}", "")
@@ -48,7 +48,7 @@ class Logger:
     active_fold_group_name: str | None = None
 
     def __init__(self) -> None:
-        if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        if HOST_IS_WIN32 and hasattr(sys.stdout, "reconfigure"):
             # the encoding on Windows can be a 1-byte charmap, but all CIs
             # support utf8, so we hardcode that
             sys.stdout.reconfigure(encoding="utf8")
@@ -253,8 +253,7 @@ def file_supports_color(file_obj: IO[AnyStr]) -> bool:
     """
     Returns True if the running system's terminal supports color.
     """
-    plat = sys.platform
-    supported_platform = plat != "win32" or "ANSICON" in os.environ
+    supported_platform = HOST_IS_WIN32 or "ANSICON" in os.environ
 
     is_a_tty = file_is_a_tty(file_obj)
 

--- a/unit_test/architecture_test.py
+++ b/unit_test/architecture_test.py
@@ -5,7 +5,9 @@ import sys
 
 import pytest
 
+from cibuildwheel import architecture
 from cibuildwheel.architecture import Architecture
+from cibuildwheel.util import get_host_platform
 
 
 @pytest.fixture(
@@ -24,6 +26,7 @@ def platform_machine(request, monkeypatch):
     platform_name, platform_value, machine_value, machine_name = request.param
     monkeypatch.setattr(sys, "platform", platform_value)
     monkeypatch.setattr(platform_module, "machine", lambda: machine_value)
+    monkeypatch.setattr(architecture, "HOST_PLATFORM", get_host_platform())
     return platform_name, machine_name
 
 

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -6,6 +6,8 @@ import pytest
 
 from cibuildwheel.__main__ import main
 from cibuildwheel.architecture import Architecture
+from cibuildwheel.util import get_host_platform
+from cibuildwheel import __main__
 
 from ..conftest import MOCK_PACKAGE_DIR
 
@@ -35,6 +37,7 @@ def test_unknown_platform_on_ci(monkeypatch, capsys):
     monkeypatch.setenv("CI", "true")
     monkeypatch.setattr(sys, "platform", "nonexistent")
     monkeypatch.delenv("CIBW_PLATFORM", raising=False)
+    monkeypatch.setattr(__main__, "HOST_PLATFORM", get_host_platform())
 
     with pytest.raises(SystemExit) as exit:
         main()

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -4,10 +4,10 @@ import sys
 
 import pytest
 
+from cibuildwheel import __main__
 from cibuildwheel.__main__ import main
 from cibuildwheel.architecture import Architecture
 from cibuildwheel.util import get_host_platform
-from cibuildwheel import __main__
 
 from ..conftest import MOCK_PACKAGE_DIR
 


### PR DESCRIPTION
There is some duplicated code for deciding what the host platform is. This groups it together in util.py.

I was slightly confused in some places whether `startswith("win")` or `== "win32"` was desired. I added a new `HOST_IS_WIN32` variable since I think it's as explicit as possible that the intended check is specifically for win32 and not for windows in general. Since `HOST_IS_WINDOWS` is for that.