### PR TITLE
Use PyPI Trusted Publisher for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     needs: [dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/download-artifact@v3
@@ -35,6 +38,3 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Basically copying https://github.com/scikit-build/scikit-build-core/pull/306
And following https://docs.pypi.org/trusted-publishers/adding-a-publisher/