### PR TITLE
Fix Travis Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ jobs:
       language: shell
       before_install:
         - choco upgrade python3 -y --version 3.7.9 --limit-output
-        # Update root certificates to fix SSL error; see http://www.chawn.com/RootCerts.htm
-        - powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"
       env:
         - PYTHON=C:\\Python37\\python
 


### PR DESCRIPTION
Travis for windows has been failing for a few days with this error:

```
$ powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"
    Directory: C:\temp
Mode                LastWriteTime         Length Name                                                                  
----                -------------         ------ ----                                                                  
d-----         6/6/2023   9:53 AM                certs                                                                 
The data is invalid. 0x8007000d (WIN32: 13 ERROR_INVALID_DATA) -- authrootstl.cab
CertUtil: -generateSSTFromWU command FAILED: 0x8007000d (WIN32: 13 ERROR_INVALID_DATA)
CertUtil: The data is invalid.
The command "powershell "md C:\temp\certs; CertUtil -generateSSTFromWU C:\temp\certs\RootStore.sst; Get-ChildItem -Path C:\\temp\certs\Rootstore.sst | Import-Certificate -CertStoreLocation Cert:\\LocalMachine\\Root\\ | out-null"" failed and exited with 1 during .
Your build has been stopped.
Get-ChildItem : Cannot find path 'C:\temp\certs\Rootstore.sst' because it does not exist.
At line:1 char:76
+ ... ootStore.sst; Get-ChildItem -Path C:\temp\certs\Rootstore.sst | Impor ...
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\temp\certs\Rootstore.sst:String) [Get-ChildItem], ItemNotFoundExcept 
   ion
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand
```

This is an attempt to fix it
