### PR TITLE
Add workflow that updates a vX.Y tag on release

### DIFF
--- a/.github/workflows/update-major-minor-tag.yml
+++ b/.github/workflows/update-major-minor-tag.yml
@@ -1,0 +1,30 @@
+name: Update the vX.Y tag
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major.minor tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+
+jobs:
+  update_tag:
+    name: Update the major.minor tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update the ${{ env.TAG_NAME }} tag
+        id: update-major-minor-tag
+        uses: joerick/update-vX.Y-tag-action@v1.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
This PR will automatically push an updated vMAJOR.MINOR tag for cibuildwheel. e.g. the tag `v2.14` would point to version `v2.14.2`, until `v2.14.3` comes out.

It's implemented using a fork of https://github.com/actions/publish-action , https://github.com/joerick/update-vX.Y-tag-action

Context from discord:

@henryiii:

> I've resisted moving vX tags since cibuildwheel adds and removes platforms in minor releases, but what do you think about a moving vX.Y tag to reduce dependabot chatter on patch releases?
> Dependabot won't update to a different number of .'s since April 2022, so it would be entirely opt-in.

