### PR TITLE
Ignore docs changes on Azure Pipelines and CirrusCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-skip: changesIncludeOnly('docs/*')
+skip: changesIncludeOnly('docs/*') || changesIncludeOnly('.pre-commit-config.yaml')
 
 run_tests: &RUN_TESTS
   install_cibuildwheel_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,5 @@
+skip: changesIncludeOnly('docs/*')
+
 run_tests: &RUN_TESTS
   install_cibuildwheel_script:
     - python -m pip install -e ".[dev]" pytest-custom-exit-code

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-skip: changesIncludeOnly('docs/*') || changesIncludeOnly('.pre-commit-config.yaml')
+skip: changesIncludeOnly('docs/*', '.pre-commit-config.yaml')
 
 run_tests: &RUN_TESTS
   install_cibuildwheel_script:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - .pre-commit-config.yaml
   workflow_dispatch:
     # allow manual runs on branches without a PR
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ pr:
   paths:
     exclude:
       - docs/*
+      - .pre-commit-config.yaml
 
 jobs:
 - job: linux_38

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,8 @@
+pr:
+  paths:
+    exclude:
+      - docs/*
+
 jobs:
 - job: linux_38
   timeoutInMinutes: 120


### PR DESCRIPTION
Saves a bit of pointless CI time. Jenkins and Circle don't support it.
