### PR TITLE
py-build-cmake cross-compile Windows arm64

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -266,14 +266,14 @@ def setup_py_build_cmake_cross_compile(
     for ver_num in os.listdir(cmake_compiler):
         test = cmake_compiler / f'{ver_num}/bin/{native_arch}/{plat_name.lower()}/cl.exe'
         if test.exists():
-            cmake_compiler = test.as_posix()
+            cmake_compiler = test
             success = True
             break
 
     if not success:
         log.warning(f'Unable to find CMake compiler for cross compiling')
 
-    log.notice(f'Found CMake compiler for cross compiling: {cmake_compiler}')
+    log.notice(f'Found CMake compiler for cross compiling: {cmake_compiler.as_posix()}')
 
     if cross_toml.is_file():
         log.notice("Skip generating py-build-cmake.cross.toml for cross-compilation as it already exists")
@@ -304,9 +304,9 @@ def setup_py_build_cmake_cross_compile(
                 set(CMAKE_SYSTEM_PROCESSOR ARM64)
                 set(CMAKE_SYSTEM_VERSION 10.0)
 
-                set(CMAKE_C_COMPILER "{cmake_compiler}")
-                set(CMAKE_CXX_COMPILER "{cmake_compiler}")
-                set(CMAKE_ASM_COMPILER "{cmake_compiler}")
+                set(CMAKE_C_COMPILER "{cmake_compiler.as_posix()}")
+                set(CMAKE_CXX_COMPILER "{cmake_compiler.as_posix()}")
+                set(CMAKE_ASM_COMPILER "{cmake_compiler.as_posix()}")
 
                 set(CMAKE_GENERATOR_PLATFORM {plat_name} CACHE INTERNAL "")
                 """

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -274,7 +274,7 @@ def setup_py_build_cmake_cross_compile(
     if not success:
         log.warning("Unable to find CMake compiler for cross compiling")
 
-    log.notice(f'Found CMake compiler for cross compiling: {cmake_compiler.as_posix()}')
+    log.notice(f"Found CMake compiler for cross compiling: {cmake_compiler.as_posix()}")
 
     if cross_toml.is_file():
         log.notice(


### PR DESCRIPTION
From https://cibuildwheel.readthedocs.io/en/stable/faq/#windows-arm64

```
Currently, setuptools>=65.4.1 and setuptools_rust are the only supported backends.
```

This PR would allow [py-build-cmake](https://github.com/tttapa/py-build-cmake) projects to cross-compile on Windows to arm64.

Before merging, please read the following:

Note that `py-build-cmake.cross.toml` has to be either present inside the project to be build, or `-C--cross=/path/to/my-cross-config.toml` flag has to be present during build. The former method is less clean, so I opted for the second option.

Unfortunately, in `cibuildhwheel/windows.py`:

```
                extra_flags = split_config_settings(build_options.config_settings, build_frontend)

                # Dirty hack for py-build-cmake cross-compiling
                if env.get('PY_BUILD_CMAKE_EXTRA_FLAGS'):
                    extra_flags.append(env['PY_BUILD_CMAKE_EXTRA_FLAGS'])

                if build_frontend == "pip":
                    extra_flags += get_build_verbosity_extra_flags(build_options.build_verbosity)
                    # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
                    # see https://github.com/pypa/cibuildwheel/pull/369
                    call(
                        "python",
                        "-m",
                        "pip",
                        "wheel",
                        options.globals.package_dir.resolve(),
                        f"--wheel-dir={built_wheel_dir}",
                        "--no-deps",
                        *extra_flags,
                        env=env,
                    )
```

The `extra_flags` comes from `build_options.config_settings`, but `setup_python()` and in turn `setup_py_build_cmake_cross_compile()` does not have access to `build_options.config_settings`. Hence I had to create the 'dirty hack'. Any advice on making it cleaner before merging?

Also, code searching for suitable `cl.exe` from Visual Studio feels a bit long and might not work in all cases. Any suggestion to improve it before merging?

Useful references:
https://tttapa.github.io/py-build-cmake/Cross-compilation.html
https://tttapa.github.io/py-build-cmake/Config.html
https://stackoverflow.com/questions/66063056/cross-compiling-for-x64-arm-with-msvc-tools-on-windows