### PR TITLE
feature: add musllinux_1_2 support

### DIFF
--- a/bin/update_docker.py
+++ b/bin/update_docker.py
@@ -59,6 +59,12 @@ images = [
     Image("musllinux_1_1", "aarch64", "quay.io/pypa/musllinux_1_1_aarch64", None),
     Image("musllinux_1_1", "ppc64le", "quay.io/pypa/musllinux_1_1_ppc64le", None),
     Image("musllinux_1_1", "s390x", "quay.io/pypa/musllinux_1_1_s390x", None),
+    # musllinux_1_2 images
+    Image("musllinux_1_2", "x86_64", "quay.io/pypa/musllinux_1_2_x86_64", None),
+    Image("musllinux_1_2", "i686", "quay.io/pypa/musllinux_1_2_i686", None),
+    Image("musllinux_1_2", "aarch64", "quay.io/pypa/musllinux_1_2_aarch64", None),
+    Image("musllinux_1_2", "ppc64le", "quay.io/pypa/musllinux_1_2_ppc64le", None),
+    Image("musllinux_1_2", "s390x", "quay.io/pypa/musllinux_1_2_s390x", None),
 ]
 
 config = configparser.ConfigParser()

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,49 +1,54 @@
 [x86_64]
 manylinux1 = quay.io/pypa/manylinux1_x86_64:2023-06-25-d2e0575
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2023-07-14-55e4124
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2023-07-29-8793e83
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2023-07-29-8793e83
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2023-07-29-8793e83
 
 [i686]
 manylinux1 = quay.io/pypa/manylinux1_i686:2023-06-25-d2e0575
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-12-26-0d38463
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2023-07-14-55e4124
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2023-07-29-8793e83
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2023-07-29-8793e83
 
 [pypy_x86_64]
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2023-07-29-8793e83
 
 [pypy_i686]
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-12-26-0d38463
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2023-07-14-55e4124
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2023-07-29-8793e83
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2023-07-29-8793e83
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2023-07-29-8793e83
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2023-07-14-55e4124
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2023-07-29-8793e83
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2023-07-29-8793e83
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2023-07-29-8793e83
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2023-07-14-55e4124
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2023-07-29-8793e83
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2023-07-29-8793e83
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2023-07-29-8793e83
 
 [pypy_aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2023-07-14-55e4124
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2023-07-29-8793e83
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2023-07-14-55e4124
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2023-07-29-8793e83
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -981,7 +981,7 @@ Set an alternative Docker image to be used for building [manylinux / musllinux](
 For `CIBW_MANYLINUX_*_IMAGE`, the value of this option can either be set to `manylinux1`, `manylinux2010`, `manylinux2014`, `manylinux_2_24` or `manylinux_2_28` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name. For PyPy, the `manylinux1` image is not available. For architectures other
 than x86 (x86\_64 and i686) `manylinux2014`, `manylinux_2_24` or `manylinux_2_28` must be used, because the first version of the manylinux specification that supports additional architectures is `manylinux2014`. `manylinux_2_28` is not supported for `i686` architecture.
 
-For `CIBW_MUSLLINUX_*_IMAGE`, the value of this option can either be set to `musllinux_1_1` to use a pinned version of the [official musllinux images](https://github.com/pypa/musllinux). Alternatively, set these options to any other valid Docker image name.
+For `CIBW_MUSLLINUX_*_IMAGE`, the value of this option can either be set to `musllinux_1_1` or `musllinux_1_2` to use a pinned version of the [official musllinux images](https://github.com/pypa/musllinux). Alternatively, set these options to any other valid Docker image name.
 
 If this option is blank, it will fall though to the next available definition (environment variable -> pyproject.toml -> default).
 

--- a/test/test_musllinux_X_Y_only.py
+++ b/test/test_musllinux_X_Y_only.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import platform
+import textwrap
+
+import pytest
+
+from . import test_projects, utils
+
+project_with_manylinux_symbols = test_projects.new_c_project(
+    spam_c_top_level_add=textwrap.dedent(
+        r"""
+        #include <stdlib.h>
+
+        #if defined(__GLIBC_PREREQ)
+        #error "Must not run on a glibc linux environment"
+        #endif
+        """
+    ),
+    spam_c_function_add=textwrap.dedent(
+        r"""
+        sts = 0;
+        """
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "musllinux_image",
+    ["musllinux_1_1", "musllinux_1_2"],
+)
+def test(musllinux_image, tmp_path):
+    if utils.platform != "linux":
+        pytest.skip("the container image test is only relevant to the linux build")
+
+    project_dir = tmp_path / "project"
+    project_with_manylinux_symbols.generate(project_dir)
+
+    # build the wheels
+    add_env = {
+        "CIBW_BUILD": "*-musllinux*",
+        "CIBW_MUSLLINUX_X86_64_IMAGE": musllinux_image,
+        "CIBW_MUSLLINUX_I686_IMAGE": musllinux_image,
+        "CIBW_MUSLLINUX_AARCH64_IMAGE": musllinux_image,
+        "CIBW_MUSLLINUX_PPC64LE_IMAGE": musllinux_image,
+        "CIBW_MUSLLINUX_S390X_IMAGE": musllinux_image,
+    }
+
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env=add_env)
+    expected_wheels = utils.expected_wheels(
+        "spam",
+        "0.1.0",
+        manylinux_versions=[],
+        musllinux_versions=[musllinux_image],
+    )
+    assert set(actual_wheels) == set(expected_wheels)

--- a/test/utils.py
+++ b/test/utils.py
@@ -205,13 +205,14 @@ def expected_wheels(
             if machine_arch == "x86_64":
                 architectures.append("i686")
 
-            platform_tags = [
-                ".".join(
-                    f"{manylinux_version}_{architecture}"
-                    for manylinux_version in manylinux_versions
-                )
-                for architecture in architectures
-            ]
+            if len(manylinux_versions) > 0:
+                platform_tags = [
+                    ".".join(
+                        f"{manylinux_version}_{architecture}"
+                        for manylinux_version in manylinux_versions
+                    )
+                    for architecture in architectures
+                ]
             if len(musllinux_versions) > 0 and not python_abi_tag.startswith("pp"):
                 platform_tags.extend(
                     [


### PR DESCRIPTION
musllinux_1_2 support has been merged in the manylinux repo.
Now adding this to cibuildwheel.