### PR TITLE
fix: --only shouldn't require prerelease pythons setting

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -450,6 +450,7 @@ class Options:
             build_config = args.only
             skip_config = ""
             architectures = Architecture.all_archs(self.platform)
+            prerelease_pythons = True
 
         build_selector = BuildSelector(
             build_config=build_config,

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -214,6 +214,7 @@ def test_only_argument(intercepted_build_args, monkeypatch, only, plat):
     assert options.globals.build_selector.skip_config == ""
     assert options.platform == plat
     assert options.globals.architectures == Architecture.all_archs(plat)
+    assert options.globals.build_selector.prerelease_pythons is True
 
 
 @pytest.mark.parametrize("only", ("cp311-manylxinux_x86_64", "some_linux_thing"))


### PR DESCRIPTION
Fix #1560.
