### PR TITLE
Fix path construction when testing Linux wheels on Windows Hosts

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -185,7 +185,7 @@ def build_in_container(
             constraints_file = build_options.dependency_constraints.get_for_python_version(
                 config.version
             )
-            container_constraints_file = PurePath("/constraints.txt")
+            container_constraints_file = PurePosixPath("/constraints.txt")
 
             container.copy_into(constraints_file, container_constraints_file)
             dependency_constraint_flags = ["-c", container_constraints_file]


### PR DESCRIPTION
This Pull Request fixes issue #1572 by changing path construction for tests to use `PurePosixPath` instead of `PurePath`.
