### PR TITLE
Update CircleCI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Usage
 | Azure Pipelines | ✅    | ✅    | ✅      |           | ✅²       | ✅⁴         |
 | Travis CI       | ✅    |       | ✅      | ✅        |           |             |
 | AppVeyor        | ✅    | ✅    | ✅      |           | ✅²       | ✅⁴         |
-| CircleCI        | ✅    | ✅    |         | ✅        | ✅²       |             |
+| CircleCI        | ✅    | ✅    | ✅      | ✅        | ✅        |             |
 | Gitlab CI       | ✅    |       | ✅      | ✅¹       |           |             |
 | Cirrus CI       | ✅    | ✅³   | ✅      | ✅        | ✅        |             |
 


### PR DESCRIPTION
Circle CI now supports [windows](https://circleci.com/docs/using-windows/#available-resource-classes) and [MacOS-arm]( https://circleci.com/docs/using-macos/#available-resource-classes)

Have not tested to confirm cibuldwheel is compatible with it though