### PR TITLE
Add the ability to pass extra flags to a build frontend through CIBW_BUILD_FRONTEND

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -29,7 +29,9 @@ class OCIContainerEngineConfig:
 
     @staticmethod
     def from_config_string(config_string: str) -> OCIContainerEngineConfig:
-        config_dict = parse_key_value_string(config_string, ["name"])
+        config_dict = parse_key_value_string(
+            config_string, ["name"], ["create_args", "create-args"]
+        )
         name = " ".join(config_dict["name"])
         if name not in {"docker", "podman"}:
             msg = f"unknown container engine {name}"

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -505,7 +505,11 @@ class Options:
             test_extras = self.reader.get("test-extras", sep=",")
             build_verbosity_str = self.reader.get("build-verbosity")
 
-            build_frontend_str = self.reader.get("build-frontend", env_plat=False)
+            build_frontend_str = self.reader.get(
+                "build-frontend",
+                env_plat=False,
+                table={"item": "{k}:{v}", "sep": "; ", "quote": shlex.quote},
+            )
             build_frontend: BuildFrontendConfig | None
             if not build_frontend_str or build_frontend_str == "default":
                 build_frontend = None

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -57,16 +57,6 @@ install_certifi_script: Final[Path] = resources_dir / "install_certifi.py"
 
 test_fail_cwd_file: Final[Path] = resources_dir / "testing_temp_dir_file.py"
 
-BuildFrontend = Literal["pip", "build"]
-
-
-def build_frontend_or_default(
-    setting: BuildFrontend | Literal["default"], default: BuildFrontend = "pip"
-) -> BuildFrontend:
-    if setting == "default":
-        return default
-    return setting
-
 
 MANYLINUX_ARCHS: Final[tuple[str, ...]] = (
     "x86_64",
@@ -374,6 +364,34 @@ class DependencyConstraints:
             return "pinned"
         else:
             return self.base_file_path.name
+
+
+BuildFrontendName = Literal["pip", "build"]
+
+
+@dataclass(frozen=True)
+class BuildFrontendConfig:
+    name: BuildFrontendName
+    args: Sequence[str] = ()
+
+    @staticmethod
+    def from_config_string(config_string: str) -> BuildFrontendConfig:
+        config_dict = parse_key_value_string(config_string, ["name"], ["args"])
+        name = " ".join(config_dict["name"])
+        if name not in {"pip", "build"}:
+            msg = f"Unrecognised build frontend {name}, only 'pip' and 'build' are supported"
+            raise ValueError(msg)
+
+        name = typing.cast(BuildFrontendName, name)
+
+        args = config_dict.get("args") or []
+        return BuildFrontendConfig(name=name, args=args)
+
+    def options_summary(self) -> str | dict[str, str]:
+        if not self.args:
+            return self.name
+        else:
+            return {"name": self.name, "args": repr(self.args)}
 
 
 class NonPlatformWheelError(Exception):
@@ -699,13 +717,19 @@ def fix_ansi_codes_for_github_actions(text: str) -> str:
 
 
 def parse_key_value_string(
-    key_value_string: str, positional_arg_names: list[str] | None = None
+    key_value_string: str,
+    positional_arg_names: Sequence[str] | None = None,
+    kw_arg_names: Sequence[str] | None = None,
 ) -> dict[str, list[str]]:
     """
     Parses a string like "docker; create_args: --some-option=value another-option"
     """
     if positional_arg_names is None:
         positional_arg_names = []
+    if kw_arg_names is None:
+        kw_arg_names = []
+
+    all_field_names = [*positional_arg_names, *kw_arg_names]
 
     shlexer = shlex.shlex(key_value_string, posix=True, punctuation_chars=";:")
     shlexer.commenters = ""
@@ -721,6 +745,9 @@ def parse_key_value_string(
         if len(field) > 1 and field[1] == ":":
             field_name = field[0]
             values = field[2:]
+            if field_name not in all_field_names:
+                msg = f"Failed to parse {key_value_string!r}. Unknown field name {field_name!r}"
+                raise ValueError(msg)
         else:
             try:
                 field_name = positional_arg_names[field_i]

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -25,10 +25,10 @@ from .typing import PathOrStr
 from .util import (
     CIBW_CACHE_PATH,
     AlreadyBuiltWheelError,
-    BuildFrontend,
+    BuildFrontendConfig,
+    BuildFrontendName,
     BuildSelector,
     NonPlatformWheelError,
-    build_frontend_or_default,
     call,
     download,
     find_compatible_wheel,
@@ -216,7 +216,7 @@ def setup_python(
     python_configuration: PythonConfiguration,
     dependency_constraint_flags: Sequence[PathOrStr],
     environment: ParsedEnvironment,
-    build_frontend: BuildFrontend,
+    build_frontend: BuildFrontendName,
 ) -> dict[str, str]:
     tmp.mkdir()
     implementation_id = python_configuration.identifier.split("-")[0]
@@ -369,7 +369,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
         for config in python_configurations:
             build_options = options.build_options(config.identifier)
-            build_frontend = build_frontend_or_default(build_options.build_frontend)
+            build_frontend = build_options.build_frontend or BuildFrontendConfig("pip")
             log.build_start(config.identifier)
 
             identifier_tmp_dir = tmp_path / config.identifier
@@ -390,7 +390,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 config,
                 dependency_constraint_flags,
                 build_options.environment,
-                build_frontend,
+                build_frontend.name,
             )
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
@@ -414,9 +414,12 @@ def build(options: Options, tmp_path: Path) -> None:
                 log.step("Building wheel...")
                 built_wheel_dir.mkdir()
 
-                extra_flags = split_config_settings(build_options.config_settings, build_frontend)
+                extra_flags = split_config_settings(
+                    build_options.config_settings, build_frontend.name
+                )
+                extra_flags += build_frontend.args
 
-                if build_frontend == "pip":
+                if build_frontend.name == "pip":
                     extra_flags += get_build_verbosity_extra_flags(build_options.build_verbosity)
                     # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
                     # see https://github.com/pypa/cibuildwheel/pull/369
@@ -431,7 +434,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         *extra_flags,
                         env=env,
                     )
-                elif build_frontend == "build":
+                elif build_frontend.name == "build":
                     if not 0 <= build_options.build_verbosity < 2:
                         msg = f"build_verbosity {build_options.build_verbosity} is not supported for build frontend. Ignoring."
                         log.warning(msg)

--- a/docs/options.md
+++ b/docs/options.md
@@ -504,8 +504,18 @@ This option can also be set using the [command-line option](#command-line) `--pr
 ### `CIBW_BUILD_FRONTEND` {: #build-frontend}
 > Set the tool to use to build, either "pip" (default for now) or "build"
 
-Choose which build backend to use. Can either be "pip", which will run
+Options:
+
+- `pip[;args: ...]`
+- `build[;args: ...]`
+
+Default: `pip`
+
+Choose which build frontend to use. Can either be "pip", which will run
 `python -m pip wheel`, or "build", which will run `python -m build --wheel`.
+
+You can specify extra arguments to pass to `pip wheel` or `build` using the
+optional `args` option.
 
 !!! tip
     Until v2.0.0, [pip] was the only way to build wheels, and is still the
@@ -526,6 +536,9 @@ Choose which build backend to use. Can either be "pip", which will run
 
     # Ensure pip is used even if the default changes in the future
     CIBW_BUILD_FRONTEND: "pip"
+
+    # supply an extra argument to 'pip wheel'
+    CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
     ```
 
 !!! tab examples "pyproject.toml"
@@ -537,6 +550,9 @@ Choose which build backend to use. Can either be "pip", which will run
 
     # Ensure pip is used even if the default changes in the future
     build-frontend = "pip"
+
+    # supply an extra argument to 'pip wheel'
+    build-frontend = { name = "pip", args = ["--no-build-isolation"] }
     ```
 
 ### `CIBW_CONFIG_SETTINGS` {: #config-settings}

--- a/test/test_build_frontend_args.py
+++ b/test/test_build_frontend_args.py
@@ -1,0 +1,34 @@
+import subprocess
+
+import pytest
+
+from . import utils
+from .test_projects.c import new_c_project
+
+
+@pytest.mark.parametrize("frontend_name", ["pip", "build"])
+def test_build_frontend_args(tmp_path, capfd, frontend_name):
+    project = new_c_project()
+    project_dir = tmp_path / "project"
+    project.generate(project_dir)
+
+    # the build will fail because the frontend is called with '-h' - it prints the help message
+    with pytest.raises(subprocess.CalledProcessError):
+        utils.cibuildwheel_run(
+            project_dir,
+            add_env={
+                "CIBW_BUILD": "cp311-*",
+                "CIBW_BUILD_FRONTEND": f"{frontend_name}; args: -h",
+            },
+        )
+
+    captured = capfd.readouterr()
+    print(captured.out)
+
+    # check that the help message was printed
+    if frontend_name == "pip":
+        assert "Usage:" in captured.out
+        assert "Wheel Options:" in captured.out
+    else:
+        assert "usage:" in captured.out
+        assert "A simple, correct Python build frontend." in captured.out

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -365,7 +365,7 @@ def test_defaults(platform, intercepted_build_args):
     if isinstance(repair_wheel_default, list):
         repair_wheel_default = " && ".join(repair_wheel_default)
     assert build_options.repair_command == repair_wheel_default
-    assert build_options.build_frontend == defaults["build-frontend"]
+    assert build_options.build_frontend is None
 
     if platform == "linux":
         assert build_options.manylinux_images


### PR DESCRIPTION
Fixes #1580.

Adds the ability to pass extra arguments to the build frontend using an option like `CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation`. The mini-syntax is the same as CIBW_CONTAINER_ENGINE. 

I liked this approach because it adds extra flexibility to the existing CIBW_BUILD_FRONTEND option in a backward-compatible way. Also, options are always going to be different between pip and build, so it makes sense to nest those within this option - if you change the build frontend, you have to change the args too.

