### PR TITLE
feature: Automatically pass SOURCE_DATE_EPOCH to Linux containers

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -115,6 +115,7 @@ class OCIContainer:
                 self.engine.name,
                 "create",
                 "--env=CIBUILDWHEEL",
+                "--env=SOURCE_DATE_EPOCH",
                 f"--name={self.name}",
                 "--interactive",
                 "--volume=/:/host",  # ignored on CircleCI

--- a/docs/options.md
+++ b/docs/options.md
@@ -664,6 +664,9 @@ A list of environment variables to pass into the linux container during the buil
 
 To specify more than one environment variable, separate the variable names by spaces.
 
+!!! note
+    cibuildwheel automatically passes the environment variable [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) if defined.
+
 #### Examples
 
 !!! tab examples "Environment passthrough"

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -72,6 +72,17 @@ def test_environment(container_engine):
         )
 
 
+def test_environment_pass(container_engine, monkeypatch):
+    monkeypatch.setenv("CIBUILDWHEEL", "1")
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1489957071")
+    with OCIContainer(engine=container_engine, image=DEFAULT_IMAGE) as container:
+        assert container.call(["sh", "-c", "echo $CIBUILDWHEEL"], capture_output=True) == "1\n"
+        assert (
+            container.call(["sh", "-c", "echo $SOURCE_DATE_EPOCH"], capture_output=True)
+            == "1489957071\n"
+        )
+
+
 def test_cwd(container_engine):
     with OCIContainer(
         engine=container_engine, image=DEFAULT_IMAGE, cwd="/cibuildwheel/working_directory"


### PR DESCRIPTION
Support for reproducible builds: https://reproducible-builds.org/docs/source-date-epoch/