### PR TITLE
Fix deprecated option in github-deploy example

### DIFF
--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -60,4 +60,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # To test: repository_url: https://test.pypi.org/legacy/
+          # To test: repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
The `github-deploy.yml` example workflow was using a deprecated argument `repository_url` which is not `repository-url` since v1.7.0 (https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0 + https://github.com/pypa/gh-action-pypi-publish/blob/b7f401de30cb6434a1e19f805ff006643653240e/action.yml#L15)

Thus fixing the warning in GitHub workflows:

> Warning: Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.