### PR TITLE
fix: do not use `linux32` when unnecessary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,13 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install podman
 
+    # free some space to prevent reaching GHA disk space limits
+    - name: Clean docker images
+      if: runner.os == 'Linux'
+      run: |
+        docker system prune -a -f
+        df -h
+
     - name: Install dependencies
       run: |
         python -m pip install ".[test]"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -423,7 +423,7 @@ def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
 
             with OCIContainer(
                 image=build_step.container_image,
-                simulate_32_bit=build_step.platform_tag.endswith("i686"),
+                enforce_32_bit=build_step.platform_tag.endswith("i686"),
                 cwd=container_project_path,
                 engine=options.globals.container_engine,
             ) as container:

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -110,7 +110,7 @@ class OCIContainer:
         if detect_ci_provider() == CIProvider.travis_ci and platform.machine() == "ppc64le":
             network_args = ["--network=host"]
 
-        simulate_32_bit = self.enforce_32_bit
+        simulate_32_bit = False
         if self.enforce_32_bit:
             # If the architecture running the image is already the right one
             # or the image entrypoint takes care of enforcing this, then we don't need to

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -111,13 +111,14 @@ class OCIContainer:
             network_args = ["--network=host"]
 
         simulate_32_bit = self.enforce_32_bit
-        container_machine = call(
-            self.engine.name, "run", "--rm", self.image, "uname", "-m", capture_stdout=True
-        ).strip()
-        if container_machine not in {"x86_64", "aarch64"}:
-            # either the architecture running the image is already the right one
-            # or the image entrypoint took care of this
-            simulate_32_bit = False
+        if self.enforce_32_bit:
+            # If the architecture running the image is already the right one
+            # or the image entrypoint takes care of enforcing this, then we don't need to
+            # simulate this
+            container_machine = call(
+                self.engine.name, "run", "--rm", self.image, "uname", "-m", capture_stdout=True
+            ).strip()
+            simulate_32_bit = container_machine != "i686"
 
         shell_args = ["linux32", "/bin/bash"] if simulate_32_bit else ["/bin/bash"]
 

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -85,7 +85,7 @@ class OCIContainer:
         self,
         *,
         image: str,
-        simulate_32_bit: bool = False,
+        enforce_32_bit: bool = False,
         cwd: PathOrStr | None = None,
         engine: OCIContainerEngineConfig = DEFAULT_ENGINE,
     ):
@@ -94,7 +94,7 @@ class OCIContainer:
             raise ValueError(msg)
 
         self.image = image
-        self.simulate_32_bit = simulate_32_bit
+        self.enforce_32_bit = enforce_32_bit
         self.cwd = cwd
         self.name: str | None = None
         self.engine = engine
@@ -110,7 +110,7 @@ class OCIContainer:
         if detect_ci_provider() == CIProvider.travis_ci and platform.machine() == "ppc64le":
             network_args = ["--network=host"]
 
-        simulate_32_bit = self.simulate_32_bit
+        simulate_32_bit = self.enforce_32_bit
         container_machine = call(
             self.engine.name, "run", "--rm", self.image, "uname", "-m", capture_stdout=True
         ).strip()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,6 +34,8 @@ def build_frontend_env(request) -> dict[str, str]:
 @pytest.fixture()
 def docker_cleanup() -> Generator[None, None, None]:
     def get_images() -> set[str]:
+        if detect_ci_provider() is None or platform != "linux":
+            return set()
         images = subprocess.run(
             ["docker", "image", "ls", "--format", "{{json .ID}}"],
             text=True,
@@ -42,12 +44,6 @@ def docker_cleanup() -> Generator[None, None, None]:
         ).stdout
         return {json.loads(image.strip()) for image in images.splitlines() if image.strip()}
 
-    if detect_ci_provider() is None or platform != "linux":
-        try:
-            yield
-        finally:
-            pass
-        return
     images_before = get_images()
     try:
         yield

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -72,7 +72,7 @@ def test_build_default_launches(monkeypatch):
     kwargs = build_in_container.call_args_list[0][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {f"{x}-manylinux_x86_64" for x in ALL_IDS}
@@ -80,7 +80,7 @@ def test_build_default_launches(monkeypatch):
     kwargs = build_in_container.call_args_list[1][1]
     assert "quay.io/pypa/manylinux2014_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert kwargs["container"]["simulate_32_bit"]
+    assert kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {f"{x}-manylinux_i686" for x in ALL_IDS}
@@ -88,7 +88,7 @@ def test_build_default_launches(monkeypatch):
     kwargs = build_in_container.call_args_list[2][1]
     assert "quay.io/pypa/musllinux_1_1_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
@@ -98,7 +98,7 @@ def test_build_default_launches(monkeypatch):
     kwargs = build_in_container.call_args_list[3][1]
     assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert kwargs["container"]["simulate_32_bit"]
+    assert kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {f"{x}-musllinux_i686" for x in ALL_IDS if "pp" not in x}
@@ -141,7 +141,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[0][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {"cp36-manylinux_x86_64"}
@@ -150,7 +150,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[1][1]
     assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
@@ -162,7 +162,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[2][1]
     assert "quay.io/pypa/manylinux_2_28_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
         f"{x}-manylinux_x86_64"
@@ -172,7 +172,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[3][1]
     assert "quay.io/pypa/manylinux2014_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert kwargs["container"]["simulate_32_bit"]
+    assert kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {f"{x}-manylinux_i686" for x in ALL_IDS}
@@ -180,7 +180,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[4][1]
     assert "quay.io/pypa/musllinux_1_1_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
@@ -190,7 +190,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[5][1]
     assert "quay.io/pypa/musllinux_1_2_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert not kwargs["container"]["simulate_32_bit"]
+    assert not kwargs["container"]["enforce_32_bit"]
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
         f"{x}-musllinux_x86_64" for x in ALL_IDS - {"cp36", "cp37", "cp38", "cp39"} if "pp" not in x
@@ -199,7 +199,7 @@ before-all = "true"
     kwargs = build_in_container.call_args_list[6][1]
     assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
-    assert kwargs["container"]["simulate_32_bit"]
+    assert kwargs["container"]["enforce_32_bit"]
 
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {f"{x}-musllinux_i686" for x in ALL_IDS if "pp" not in x}


### PR DESCRIPTION
The `linux32` command is always used for linux i686.
This makes cross building from macOS arm64 impossible at the moment (might depend on docker configuration).

This PR proposes to check the architecture seen inside the container before using (or not) the `linux32` command.
