### PR TITLE
chore: minor additions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+*.py diff=python
+*.md diff=markdown
+
+*.svg -diff

--- a/cibuildwheel/_compat/tomllib.py
+++ b/cibuildwheel/_compat/tomllib.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import sys
 
 if sys.version_info >= (3, 11):
-    from tomllib import load  # noqa: TID251
+    from tomllib import load
 else:
-    from tomli import load  # noqa: TID251
+    from tomli import load
 
 __all__ = ("load",)

--- a/cibuildwheel/_compat/typing.py
+++ b/cibuildwheel/_compat/typing.py
@@ -5,7 +5,7 @@ import sys
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired, assert_never
 else:
-    from typing import NotRequired, assert_never  # noqa: TID251
+    from typing import NotRequired, assert_never
 
 __all__ = (
     "assert_never",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,3 +161,4 @@ flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.per-file-ignores]
 "unit_test/*" = ["PLC1901"]
+"cibuildwheel/_compat/**.py" = ["TID251"]


### PR DESCRIPTION
A couple of minor additions.


- chore: Ruff ignore for `_compat`
- chore: add `.gitattributes`
    - Better EoL handling if someone doesn't have git set up correctly
    - Better contextual diffs for Python and markdown
    - Ignore binary-like matches in svgs when grepping
