### PR TITLE
Update RtD config to include mandatory build.os option

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,13 +2,17 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 
-mkdocs:
-  configuration: mkdocs.yml
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .
       extra_requirements:
         - docs
+
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
As spotted in #1617, this is now required.
