### PR TITLE
feat: `CIBW_DEBUG_KEEP_CONTAINER`: debug container after build

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -17,7 +17,7 @@ from types import TracebackType
 from typing import IO, Dict, Literal
 
 from .typing import PathOrStr, PopenBytes
-from .util import CIProvider, detect_ci_provider, parse_key_value_string
+from .util import CIProvider, detect_ci_provider, parse_key_value_string, strtobool
 
 ContainerEngineName = Literal["docker", "podman"]
 
@@ -178,12 +178,14 @@ class OCIContainer:
 
         assert isinstance(self.name, str)
 
-        subprocess.run(
-            [self.engine.name, "rm", "--force", "-v", self.name],
-            stdout=subprocess.DEVNULL,
-            check=False,
-        )
-        self.name = None
+        keep_container = strtobool(os.environ.get("CIBW_DEBUG_KEEP_CONTAINER", ""))
+        if not keep_container:
+            subprocess.run(
+                [self.engine.name, "rm", "--force", "-v", self.name],
+                stdout=subprocess.DEVNULL,
+                check=False,
+            )
+            self.name = None
 
     def copy_into(self, from_path: Path, to_path: PurePath) -> None:
         # `docker cp` causes 'no space left on device' error when

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -17,7 +17,13 @@ from types import TracebackType
 from typing import IO, Dict, Literal
 
 from .typing import PathOrStr, PopenBytes
-from .util import CIProvider, call, detect_ci_provider, parse_key_value_string, strtobool
+from .util import (
+    CIProvider,
+    call,
+    detect_ci_provider,
+    parse_key_value_string,
+    strtobool,
+)
 
 ContainerEngineName = Literal["docker", "podman"]
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1426,6 +1426,38 @@ This option is not supported in the overrides section in `pyproject.toml`.
     test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
     ```
 
+## Debugging
+
+### `CIBW_DEBUG_KEEP_CONTAINER`
+
+Enable this flag to keep the container around for inspection after a build. This
+option is provided for debugging purposes only.
+
+Default: Off (0).
+
+!!! caution
+    This option can only be set as environment variable on the host machine
+
+#### Examples
+
+!!! tab examples "Linux"
+
+    ```shell
+    export CIBW_DEBUG_KEEP_CONTAINER=TRUE
+    ```
+
+!!! tab examples "Windows"
+
+    ```shell
+    set CIBW_DEBUG_KEEP_CONTAINER=TRUE
+    ```
+
+!!! tab examples "MacOS"
+
+    ```shell
+    export CIBW_DEBUG_KEEP_CONTAINER=TRUE
+    ```
+
 ## Other
 
 ### `CIBW_BUILD_VERBOSITY` {: #build-verbosity}

--- a/docs/options.md
+++ b/docs/options.md
@@ -1440,25 +1440,9 @@ Default: Off (0).
 
 #### Examples
 
-!!! tab examples "Linux"
-
-    ```shell
-    export CIBW_DEBUG_KEEP_CONTAINER=TRUE
-    ```
-
-!!! tab examples "Windows"
-
-    ```shell
-    set CIBW_DEBUG_KEEP_CONTAINER=TRUE
-    ```
-
-!!! tab examples "MacOS"
-
-    ```shell
-    export CIBW_DEBUG_KEEP_CONTAINER=TRUE
-    ```
-
-## Other
+```shell
+export CIBW_DEBUG_KEEP_CONTAINER=TRUE
+```
 
 ### `CIBW_BUILD_VERBOSITY` {: #build-verbosity}
 > Increase/decrease the output of pip wheel


### PR DESCRIPTION
closes #1320. With this flag enabled, the containers of local (failing) builds can be debugged afterwards.