### PR TITLE
fix: ensure 2+ items in each override in schema

### DIFF
--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -200,6 +200,7 @@ description: An overrides array
 items:
   type: object
   required: ["select"]
+  minProperties: 2
   additionalProperties: false
   properties:
     select: {}

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -406,6 +406,7 @@
         "required": [
           "select"
         ],
+        "minProperties": 2,
         "additionalProperties": false,
         "properties": {
           "select": {

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -59,6 +59,19 @@ def test_overrides_no_select():
         validator(example)
 
 
+def test_overrides_only_select():
+    example = tomllib.loads(
+        """
+        [[tool.cibuildwheel.overrides]]
+        select = "somestring"
+        """
+    )
+
+    validator = validate_pyproject.api.Validator()
+    with pytest.raises(validate_pyproject.error_reporting.ValidationError):
+        validator(example)
+
+
 def test_docs_examples():
     """
     Parse out all the configuration examples, build valid TOML out of them, and


### PR DESCRIPTION
Small touchup to schema. Overrides needs select and at least one more item.
