### PR TITLE
feat: use manylinux-interpreters tool if present

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -117,10 +117,20 @@ def check_all_python_exist(
     *, platform_configs: Iterable[PythonConfiguration], container: OCIContainer
 ) -> None:
     exist = True
+    has_manylinux_interpreters = True
     messages = []
+
+    try:
+        # use capture_output to keep quiet
+        container.call(["manylinux-interpreters", "--help"], capture_output=True)
+    except subprocess.CalledProcessError:
+        has_manylinux_interpreters = False
+
     for config in platform_configs:
         python_path = config.path / "bin" / "python"
         try:
+            if has_manylinux_interpreters:
+                container.call(["manylinux-interpreters", "ensure", config.path.name])
             container.call(["test", "-x", python_path])
         except subprocess.CalledProcessError:
             messages.append(


### PR DESCRIPTION
This will allow dropping some EOL (and maybe some none EOL) python interpreters in manylinux images which would allow to reduce its size (faster for a vast majority of user, a small slow-down for users of those interpreters).

Updates to keep tests times down are not here yet, this is just to get things started.