### PR TITLE
fix(schema): small bug + prepare for SchemaStore

### DIFF
--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -13,7 +13,7 @@ args = parser.parse_args()
 
 starter = """
 $id: https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json
-$schema: http://json-schema.org/draft-07/schema
+$schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 description: cibuildwheel's settings.
 type: object

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -13,7 +13,7 @@ args = parser.parse_args()
 
 starter = """
 $id: https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json
-$schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-07/schema
 additionalProperties: false
 description: cibuildwheel's settings.
 type: object
@@ -150,6 +150,9 @@ properties:
 """
 
 schema = yaml.safe_load(starter)
+
+if args.schemastore:
+    schema["$id"] += "#"
 
 string_array = yaml.safe_load(
     """

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -218,11 +218,9 @@
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            ".+": [
-              {
-                "type": "string"
-              }
-            ]
+            ".+": {
+              "type": "string"
+            }
           }
         }
       ],

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "description": "cibuildwheel's settings.",
   "type": "object",

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "cibuildwheel's settings.",
   "type": "object",

--- a/noxfile.py
+++ b/noxfile.py
@@ -115,6 +115,9 @@ def update_proj(session: nox.Session) -> None:
 
 @nox.session(reuse_venv=True)
 def generate_schema(session: nox.Session) -> None:
+    """
+    Generate the cibuildwheel.schema.json file.
+    """
     session.install("pyyaml")
     output = session.run("python", "bin/generate_schema.py", silent=True)
     assert isinstance(output, str)


### PR DESCRIPTION
Fixing a small bug discovered when running this via SchemaStore's tests that fastjsonschema apparently doesn't care about (extra list). Also have a way to specify the full schema (with tool.cibuildwheel) so that cibuildwheel.toml/.cibuildwheel.toml can be checked. (Currently not sure how to have a subschema that doesn't have a file also, but this will at least move cibuildwheel forward, because we do).

https://github.com/SchemaStore/schemastore/pull/3287
