### PR TITLE
chore: move to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,12 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.10.1
-  hooks:
-  - id: black
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.2
   hooks:
   - id: ruff
     args: ["--fix", "--show-fixes"]
+  - id: ruff-format
 
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v2.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.2
+  rev: v0.1.3
   hooks:
   - id: ruff
     args: ["--fix", "--show-fixes"]

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -204,7 +204,7 @@ class CPythonVersions:
         unsorted_versions = spec.filter(self.versions_dict)
         sorted_versions = sorted(unsorted_versions, reverse=True)
 
-        macver = "10.9" if version <= Version("3.8.9999") else "11"
+        macver = "x10.9" if version <= Version("3.8.9999") else "11"
         file_ident = f"macosx{macver}.pkg"
 
         for new_version in sorted_versions:

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -205,7 +205,7 @@ class CPythonVersions:
         sorted_versions = sorted(unsorted_versions, reverse=True)
 
         macver = "x10.9" if version <= Version("3.8.9999") else "11"
-        file_ident = f"macosx{macver}.pkg"
+        file_ident = f"macos{macver}.pkg"
 
         for new_version in sorted_versions:
             # Find the first patch version that contains the requested file

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -204,10 +204,8 @@ class CPythonVersions:
         unsorted_versions = spec.filter(self.versions_dict)
         sorted_versions = sorted(unsorted_versions, reverse=True)
 
-        if version <= Version("3.8.9999"):
-            file_ident = "macosx10.9.pkg"
-        else:
-            file_ident = "macos11.pkg"
+        macver = "10.9" if version <= Version("3.8.9999") else "11"
+        file_ident = f"macosx{macver}.pkg"
 
         for new_version in sorted_versions:
             # Find the first patch version that contains the requested file

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -619,10 +619,7 @@ def virtualenv(
         python,
         venv_path,
     )
-    if IS_WIN:
-        paths = [str(venv_path), str(venv_path / "Scripts")]
-    else:
-        paths = [str(venv_path / "bin")]
+    paths = [str(venv_path), str(venv_path / "Scripts")] if IS_WIN else [str(venv_path / "bin")]
     env = os.environ.copy()
     env["PATH"] = os.pathsep.join([*paths, env["PATH"]])
     return env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ ignore = [
   "PT004",  # Rename suggested for returnless fixtures
   "PT007",  # False positive
   "PYI025", # Set as AbstractSet
-  "ISC001", # Conflicts with formatter (in 0.1.2)
+  "ISC001", # Conflicts with formatter
 ]
 typing-modules = ["cibuildwheel._compat.typing"]
 flake8-unused-arguments.ignore-variadic-names = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 
-[tool.black]
-line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
-
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
@@ -116,6 +111,8 @@ messages_control.disable = [
 
 [tool.ruff]
 target-version = "py38"
+line-length = 100
+
 
 [tool.ruff.lint]
 extend-select = [
@@ -147,6 +144,7 @@ ignore = [
   "PT004",  # Rename suggested for returnless fixtures
   "PT007",  # False positive
   "PYI025", # Set as AbstractSet
+  "ISC001", # Conflicts with formatter (in 0.1.2)
 ]
 typing-modules = ["cibuildwheel._compat.typing"]
 flake8-unused-arguments.ignore-variadic-names = true

--- a/test/test_before_test.py
+++ b/test/test_before_test.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from . import test_projects, utils
 
 before_test_project = test_projects.new_c_project()
-before_test_project.files[
-    "test/spam_test.py"
-] = r"""
+before_test_project.files["test/spam_test.py"] = r"""
 import sys
 import os
 from unittest import TestCase

--- a/test/test_cpp_standards.py
+++ b/test/test_cpp_standards.py
@@ -99,9 +99,7 @@ cpp17_project = cpp_test_project.copy()
 cpp17_project.template_context["extra_compile_args"] = [
     "/std:c++17" if utils.platform == "windows" else "-std=c++17"
 ]
-cpp17_project.template_context[
-    "spam_cpp_top_level_add"
-] = r"""
+cpp17_project.template_context["spam_cpp_top_level_add"] = r"""
 #include <utility>
 auto a = std::pair(5.0, false);
 """

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -135,9 +135,7 @@ def test_dependency_constraints_file(tmp_path, build_frontend_env):
             wheel=={wheel}
             virtualenv=={virtualenv}
             importlib-metadata<3,>=0.12; python_version < "3.8"
-            """.format(
-                **tool_versions
-            )
+            """.format(**tool_versions)
         )
     )
 

--- a/test/test_emulation.py
+++ b/test/test_emulation.py
@@ -8,9 +8,7 @@ from . import test_projects, utils
 
 project_with_a_test = test_projects.new_c_project()
 
-project_with_a_test.files[
-    "test/spam_test.py"
-] = r"""
+project_with_a_test.files["test/spam_test.py"] = r"""
 import spam
 
 def test_spam():

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -19,9 +19,7 @@ basic_project = test_projects.new_c_project(
     )
 )
 
-basic_project.files[
-    "pyproject.toml"
-] = """
+basic_project.files["pyproject.toml"] = """
 [build-system]
 requires = [
     "setuptools >= 42",

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -8,9 +8,7 @@ import pytest
 from . import utils
 
 pure_python_project = test_projects.TestProject()
-pure_python_project.files[
-    "setup.py"
-] = """
+pure_python_project.files["setup.py"] = """
 from setuptools import Extension, setup
 
 setup(
@@ -20,9 +18,7 @@ setup(
 )
 """
 
-pure_python_project.files[
-    "spam.py"
-] = """
+pure_python_project.files["spam.py"] = """
 def a_function():
     pass
 """

--- a/test/test_same_wheel.py
+++ b/test/test_same_wheel.py
@@ -8,9 +8,7 @@ import pytest
 from . import utils
 
 basic_project = test_projects.new_c_project()
-basic_project.files[
-    "repair.py"
-] = """
+basic_project.files["repair.py"] = """
 import shutil
 import sys
 from pathlib import Path

--- a/test/test_subdir_package.py
+++ b/test/test_subdir_package.py
@@ -14,9 +14,7 @@ subdir_package_project.files["src/spam/spam.c"] = jinja2.Template(SPAM_C_TEMPLAT
 subdir_package_project.template_context["spam_c_top_level_add"] = ""
 subdir_package_project.template_context["spam_c_function_add"] = ""
 
-subdir_package_project.files[
-    "src/spam/setup.py"
-] = r"""
+subdir_package_project.files["src/spam/setup.py"] = r"""
 from setuptools import Extension, setup
 
 setup(
@@ -26,15 +24,11 @@ setup(
 )
 """
 
-subdir_package_project.files[
-    "src/spam/test/run_tests.py"
-] = r"""
+subdir_package_project.files["src/spam/test/run_tests.py"] = r"""
 print('run_tests.py executed!')
 """
 
-subdir_package_project.files[
-    "bin/before_build.py"
-] = r"""
+subdir_package_project.files["bin/before_build.py"] = r"""
 print('before_build.py executed!')
 """
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,9 +18,7 @@ project_with_a_test = test_projects.new_c_project(
     )
 )
 
-project_with_a_test.files[
-    "test/spam_test.py"
-] = r'''
+project_with_a_test.files["test/spam_test.py"] = r'''
 import os
 import platform
 import sys
@@ -115,9 +113,7 @@ def test_extras_require(tmp_path):
 
 
 project_with_a_failing_test = test_projects.new_c_project()
-project_with_a_failing_test.files[
-    "test/spam_test.py"
-] = r"""
+project_with_a_failing_test.files["test/spam_test.py"] = r"""
 from unittest import TestCase
 
 class TestSpam(TestCase):


### PR DESCRIPTION
Moving to ruff-fmt. Faster, drops a dependency, less config, and formatting is a bit better.

See https://github.com/scientific-python/cookie/pull/299 and https://astral.sh/blog/the-ruff-formatter.
