### PR TITLE
Use quotes when silencing warning

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -491,7 +491,7 @@ def build(options: Options, tmp_path: Path) -> None:
                                     tested. The ability to test the arm64 wheels will be added in a
                                     future release of cibuildwheel, once Apple Silicon CI runners
                                     are widely available. To silence this warning, set
-                                    `CIBW_TEST_SKIP: *-macosx_arm64`.
+                                    `CIBW_TEST_SKIP: "*-macosx_arm64"`.
                                     """
                                 )
                             )
@@ -504,7 +504,7 @@ def build(options: Options, tmp_path: Path) -> None:
                                     arm64 part of a universal2 wheel will be added in a future
                                     release of cibuildwheel, once Apple Silicon CI runners are
                                     widely available. To silence this warning, set
-                                    `CIBW_TEST_SKIP: *-macosx_universal2:arm64`.
+                                    `CIBW_TEST_SKIP: "*-macosx_universal2:arm64"`.
                                     """
                                 )
                             )
@@ -525,7 +525,7 @@ def build(options: Options, tmp_path: Path) -> None:
                                 Silicon machine. This is because we use the x86_64 installer of
                                 CPython 3.8. See the discussion in
                                 https://github.com/pypa/cibuildwheel/pull/1169 for the details. To
-                                silence this warning, set `CIBW_TEST_SKIP: cp38-macosx_*:arm64`.
+                                silence this warning, set `CIBW_TEST_SKIP: "cp38-macosx_*:arm64"`.
                                 """
                             )
                         )

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -501,7 +501,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         """
                             While arm64 wheels can be built on other platforms, they cannot
                             be tested. An arm64 runner is required. To silence this warning,
-                            set `CIBW_TEST_SKIP: *-win_arm64`.
+                            set `CIBW_TEST_SKIP: "*-win_arm64"`.
                             """
                     )
                 )

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -75,7 +75,7 @@ With the exception of Cirrus CI, macOS CI runners are still Intel-based, and App
 !!! important
     When cross-compiling on Intel, it is not possible to test `arm64` and the `arm64` part of a `universal2` wheel.
 
-    `cibuildwheel` will raise a warning to notify you of this - these warnings be be silenced by skipping testing on these platforms: `CIBW_TEST_SKIP: *_arm64 *_universal2:arm64`.
+    `cibuildwheel` will raise a warning to notify you of this - these warnings be be silenced by skipping testing on these platforms: `CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"`.
 
 !!! note
     Your runner needs Xcode Command Line Tools 12.2 or later to build `universal2` or `arm64`.
@@ -395,7 +395,7 @@ To investigate the dependencies of a C extension (i.e., the `.pyd` file, a DLL i
 
 ### Windows ARM64 builds {: #windows-arm64}
 
-`cibuildwheel` supports cross-compiling `ARM64` wheels on all Windows runners, but a native ARM64 runner is required for testing. On non-native runners, tests for ARM64 wheels will be automatically skipped with a warning. Add `*-win_arm64` to your `CIBW_TEST_SKIP` setting to suppress the warning.
+`cibuildwheel` supports cross-compiling `ARM64` wheels on all Windows runners, but a native ARM64 runner is required for testing. On non-native runners, tests for ARM64 wheels will be automatically skipped with a warning. Add `"*-win_arm64"` to your `CIBW_TEST_SKIP` setting to suppress the warning.
 
 Cross-compilation on Windows relies on a supported build backend. Supported backends use an environment variable to specify their target platform (the one they are compiling native modules for, as opposed to the one they are running on), which is set in [cibuildwheels/windows.py](https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/windows.py) before building. Currently, `setuptools>=65.4.1` and `setuptools_rust` are the only supported backends.
 


### PR DESCRIPTION
We found (re: https://github.com/python-pillow/Pillow/pull/7552#pullrequestreview-1732529361) we needed to add quotes to `CIBW_TEST_SKIP: "*-macosx_arm64"` to silence the warnings.

And this matches the recommendation in docs: https://cibuildwheel.readthedocs.io/en/stable/options/#test-skip
