### PR TITLE
Update projects.yml to add new repo for working examples

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -638,4 +638,4 @@
   os: [windows, linux, apple]
   pypi: werpy
   notes: An ultra-fast python package using optimized dynamic programming to compute the Word Error Rate (WER).
-  
+

--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -638,4 +638,3 @@
   os: [windows, linux, apple]
   pypi: werpy
   notes: An ultra-fast python package using optimized dynamic programming to compute the Word Error Rate (WER).
-

--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -631,3 +631,11 @@
   os: [windows, apple, linux]
   pypi: aalink
   notes: Async Python interface for Ableton Link.
+
+- name: werpy
+  gh: analyticsinmotion/werpy
+  ci: [github]
+  os: [windows, linux, apple]
+  pypi: werpy
+  notes: An ultra-fast python package using optimized dynamic programming to compute the Word Error Rate (WER).
+  


### PR DESCRIPTION
This pull request proposes the addition of our package, werpy, to the list of working examples in the cibuildwheel documentation. 

Werpy is a fast, lightweight Python package for calculating and analyzing Word Error Rate (WER) between two sets of text. 

This package demonstrates a successful use case of cibuildwheel for building and distributing Python packages with C extensions and provides a good use case for others to view.
