### PR TITLE
Stop suggesting adding `wheel` to `pyproject.toml`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -216,7 +216,6 @@ to build, your pyproject.toml might include a section like this:
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
     "Cython",
 ]
 


### PR DESCRIPTION
This was a historic mistake in the `setuptools`' docs that many projects copied. But `wheel` is already a dependency injected by `setuptools` when needed. So let's not suggest people to depend on it when producing sdists.