### PR TITLE
Edit path when building sdist package

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -160,7 +160,7 @@ def main() -> None:
         # This is now the new package dir
         args.package_dir = project_dir.resolve()
 
-        with chdir(temp_dir):
+        with chdir(project_dir):
             build_in_directory(args)
     finally:
         # avoid https://github.com/python/cpython/issues/86962 by performing

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -65,8 +65,8 @@ def test_simple(tmp_path):
         """
         import os
 
-        assert os.path.exists("setup.py")
-        assert os.path.exists("{package}/setup.py")
+        assert os.path.exists('setup.py')
+        assert os.path.exists('{package}/setup.py')
         """,
     )
     setup_py_assertion_cmd = f'python3 -c "{setup_py_assertion_snippet !s}"'

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -61,10 +61,23 @@ def test_simple(tmp_path):
     sdist_dir.mkdir()
     sdist_path = make_sdist(basic_project, sdist_dir)
 
+    setup_py_assertion_snippet = textwrap.dedent(
+        """
+        import os
+
+        assert os.path.exists("setup.py")
+        assert os.path.exists("{package}/setup.py")
+        """,
+    )
+    setup_py_assertion_cmd = f"python3 -c '{setup_py_assertion_snippet !s}'"
+
     # build the wheels from sdist
     actual_wheels = cibuildwheel_from_sdist_run(
         sdist_path,
-        add_env={"CIBW_BUILD": "cp39-*"},
+        add_env={
+            "CIBW_BEFORE_BUILD": setup_py_assertion_cmd,
+            "CIBW_BUILD": "cp39-*",
+        },
     )
 
     # check that the expected wheels are produced

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -69,7 +69,7 @@ def test_simple(tmp_path):
         assert os.path.exists("{package}/setup.py")
         """,
     )
-    setup_py_assertion_cmd = f"python3 -c '{setup_py_assertion_snippet !s}'"
+    setup_py_assertion_cmd = f'python3 -c "{setup_py_assertion_snippet !s}"'
 
     # build the wheels from sdist
     actual_wheels = cibuildwheel_from_sdist_run(


### PR DESCRIPTION
This patch changes the working directory from the temp to the project when building sdist package. This resolves issues with relative paths in configuration files.

Resolves #1683 