### PR TITLE
Upgrade artifact actions in workflows to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Build SDist and wheel
       run: pipx run build
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: cibw-sdist
         path: dist/*
 
     - name: Check metadata
@@ -32,9 +33,10 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        pattern: cibw-*
         path: dist
+        merge-multiple: true
 
     - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,10 +85,10 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: sample_wheels_action
-        path: wheelhouse
+        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        path: wheelhouse/*.whl
 
     - name: Test cibuildwheel
       run: |


### PR DESCRIPTION
Supersedes (and closes https://github.com/pypa/cibuildwheel/pull/1709)