### PR TITLE
Don't require `--platform` when running on a development machine

### DIFF
--- a/bin/dev_run_test
+++ b/bin/dev_run_test
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-CIBW_PLATFORM=linux pytest "$@"

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -192,7 +192,9 @@ def _compute_platform_auto() -> PlatformName:
         return "windows"
     else:
         print(
-            'cibuildwheel: Unable to detect platform from "sys.platform". cibuildwheel doesn\'t support building wheels for this platform. You might be able to build for a different platform using the --platform argument. Check --help output for more information.',
+            'cibuildwheel: Unable to detect platform from "sys.platform". cibuildwheel doesn\'t '
+            "support building wheels for this platform. You might be able to build for a different "
+            "platform using the --platform argument. Check --help output for more information.",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -277,7 +279,9 @@ def build_in_directory(args: CommandLineArguments) -> None:
     # Add CIBUILDWHEEL environment variable
     os.environ["CIBUILDWHEEL"] = "1"
 
-    # Python is buffering by default when running on the CI platforms, giving problems interleaving subprocess call output with unflushed calls to 'print'
+    # Python is buffering by default when running on the CI platforms, giving
+    # problems interleaving subprocess call output with unflushed calls to
+    # 'print'
     sys.stdout = Unbuffered(sys.stdout)  # type: ignore[assignment]
 
     # create the cache dir before it gets printed & builds performed

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -49,10 +49,9 @@ def main() -> None:
         default=None,
         help="""
             Platform to build for. Use this option to override the
-            auto-detected platform or to run cibuildwheel on your development
-            machine. Specifying "macos" or "windows" only works on that
-            operating system, but "linux" works on all three, as long as
-            Docker/Podman is installed. Default: auto.
+            auto-detected platform. Specifying "macos" or "windows" only works
+            on that operating system, but "linux" works on all three, as long
+            as Docker/Podman is installed. Default: auto.
         """,
     )
 
@@ -184,20 +183,7 @@ def _compute_platform_only(only: str) -> PlatformName:
     sys.exit(2)
 
 
-def _compute_platform_ci() -> PlatformName:
-    if detect_ci_provider() is None:
-        print(
-            textwrap.dedent(
-                """
-                cibuildwheel: Unable to detect platform. cibuildwheel should run on your CI server;
-                Travis CI, AppVeyor, Azure Pipelines, GitHub Actions, CircleCI, Gitlab, and Cirrus CI
-                are supported. You can run on your development machine or other CI providers
-                using the --platform argument. Check --help output for more information.
-                """
-            ),
-            file=sys.stderr,
-        )
-        sys.exit(2)
+def _compute_platform_auto() -> PlatformName:
     if sys.platform.startswith("linux"):
         return "linux"
     elif sys.platform == "darwin":
@@ -206,8 +192,7 @@ def _compute_platform_ci() -> PlatformName:
         return "windows"
     else:
         print(
-            'cibuildwheel: Unable to detect platform from "sys.platform" in a CI environment. You can run '
-            "cibuildwheel using the --platform argument. Check --help output for more information.",
+            'cibuildwheel: Unable to detect platform from "sys.platform". cibuildwheel doesn\'t support building wheels for this platform. You might be able to build for a different platform using the --platform argument. Check --help output for more information.',
             file=sys.stderr,
         )
         sys.exit(2)
@@ -238,7 +223,7 @@ def _compute_platform(args: CommandLineArguments) -> PlatformName:
     elif platform_option_value != "auto":
         return typing.cast(PlatformName, platform_option_value)
 
-    return _compute_platform_ci()
+    return _compute_platform_auto()
 
 
 class PlatformModule(Protocol):

--- a/docs/options.md
+++ b/docs/options.md
@@ -184,7 +184,7 @@ Options: `auto` `linux` `macos` `windows`
 
 Default: `auto`
 
-`auto` will auto-detect platform using environment variables, such as `TRAVIS_OS_NAME`/`APPVEYOR`/`CIRCLECI`.
+`auto` will build wheels for the current platform.
 
 - For `linux`, you need [Docker or Podman](#container-engine) running, on Linux, macOS, or Windows.
 - For `macos` and `windows`, you need to be running on the respective system, with a working compiler toolchain installed - Xcode Command Line tools for macOS, and MSVC for Windows.
@@ -192,13 +192,15 @@ Default: `auto`
 This option can also be set using the [command-line option](#command-line) `--platform`. This option is not available in the `pyproject.toml` config.
 
 !!! tip
-    You can use this option to locally debug your cibuildwheel config, instead of pushing to CI to test every change. For example:
+    You can use this option to locally debug your cibuildwheel config on Linux, instead of pushing to CI to test every change. For example:
 
     ```bash
     export CIBW_BUILD='cp37-*'
     export CIBW_TEST_COMMAND='pytest {package}/tests'
     cibuildwheel --platform linux .
     ```
+
+    Linux builds are the easiest to test locally, because all the build tools are supplied in the container, and they run exactly the same locally as in CI.
 
     This is even more convenient if you store your cibuildwheel config in [`pyproject.toml`](#configuration-file).
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,45 +11,14 @@ locally to quickly iterate and track down issues without even touching CI.
 
 Install cibuildwheel and run a build like this:
 
-!!! tab "Linux"
+```sh
+# using pipx (https://github.com/pypa/pipx)
+pipx run cibuildwheel
 
-    Using [pipx](https://github.com/pypa/pipx):
-    ```sh
-    pipx run cibuildwheel --platform linux
-    ```
-
-    Or,
-    ```sh
-    pip install cibuildwheel
-    cibuildwheel --platform linux
-    ```
-
-!!! tab "macOS"
-
-    Using [pipx](https://github.com/pypa/pipx):
-    ```sh
-    pipx run cibuildwheel --platform macos
-    ```
-
-    Or,
-    ```sh
-    pip install cibuildwheel
-    cibuildwheel --platform macos
-    ```
-
-
-!!! tab "Windows"
-
-    Using [pipx](https://github.com/pypa/pipx):
-    ```bat
-    pipx run cibuildwheel --platform windows
-    ```
-
-    Or,
-    ```bat
-    pip install cibuildwheel
-    cibuildwheel --platform windows
-    ```
+# or,
+pip install cibuildwheel
+cibuildwheel
+```
 
 You should see the builds taking place. You can experiment with options using environment variables or pyproject.toml.
 
@@ -63,7 +32,7 @@ You should see the builds taking place. You can experiment with options using en
     # run a command to set up the build system
     export CIBW_BEFORE_ALL='apt install libpng-dev'
 
-    cibuildwheel --platform linux
+    cibuildwheel
     ```
 
     > CMD (Windows)
@@ -71,7 +40,7 @@ You should see the builds taking place. You can experiment with options using en
     ```bat
     set CIBW_BEFORE_ALL='apt install libpng-dev'
 
-    cibuildwheel --platform linux
+    cibuildwheel
     ```
 
 !!! tab "pyproject.toml"
@@ -88,7 +57,7 @@ You should see the builds taking place. You can experiment with options using en
     Then invoke cibuildwheel, like:
 
     ```console
-    cibuildwheel --platform linux
+    cibuildwheel
     ```
 
 ### Linux builds


### PR DESCRIPTION
Historically, we required `--platform` when running cibuildwheel outside of CI, because cibuildwheel would attempt to globally install Python interpreters and some packages.

That was fixed in https://github.com/pypa/cibuildwheel/pull/974 a couple of years ago. As a result, there's no reason to require --platform these days, the `auto` behaviour is perfectly fine for dev machines.

It also makes running tests locally simpler, one can just do `pytest test/test_0_basic.py` (or `nox -s tests -- test/test_0_basic.py`) and not have to worry about setting CIBW_PLATFORM most of the time.