### PR TITLE
feat: add inherit to override

### DIFF
--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -17,6 +17,14 @@ $schema: http://json-schema.org/draft-07/schema
 additionalProperties: false
 description: cibuildwheel's settings.
 type: object
+defines:
+  inherit:
+    enum:
+      - none
+      - prepend
+      - append
+    default: none
+    description: How to inherit the parent's value.
 properties:
   archs:
     description: Change the architectures built on your machine by default.
@@ -212,21 +220,20 @@ items:
   properties:
     select: {}
     inherit:
-      type: array
-      items:
-        enum:
-          - before-all
-          - before-build
-          - before-test
-          - config-settings
-          - container-engine
-          - environment
-          - environment-pass
-          - repair-wheel-command
-          - test-command
-          - test-extras
-          - test-requires
-        uniqueItems: true
+      type: object
+      additionalProperties: false
+      properties:
+        before-all: {"$ref": "#/defines/inherit"}
+        before-build: {"$ref": "#/defines/inherit"}
+        before-test: {"$ref": "#/defines/inherit"}
+        config-settings: {"$ref": "#/defines/inherit"}
+        container-engine: {"$ref": "#/defines/inherit"}
+        environment: {"$ref": "#/defines/inherit"}
+        environment-pass: {"$ref": "#/defines/inherit"}
+        repair-wheel-command: {"$ref": "#/defines/inherit"}
+        test-command: {"$ref": "#/defines/inherit"}
+        test-extras: {"$ref": "#/defines/inherit"}
+        test-requires: {"$ref": "#/defines/inherit"}
 """
 )
 

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -289,7 +289,7 @@ schema["properties"] |= oses
 
 if args.schemastore:
     schema["$id"] = "https://json.schemastore.org/partial-cibuildwheel.json"
-    schema["$id"] = "http://json-schema.org/draft-07/schema#"
+    schema["$schema"] = "http://json-schema.org/draft-07/schema#"
     schema[
         "description"
     ] = "cibuildwheel's toml file, generated with ./bin/generate_schema.py --schemastore from cibuildwheel."

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -18,7 +18,7 @@ from typing import Any, Literal, Mapping, Sequence, TypedDict, Union  # noqa: TI
 from packaging.specifiers import SpecifierSet
 
 from ._compat import tomllib
-from ._compat.typing import NotRequired
+from ._compat.typing import NotRequired, assert_never
 from .architecture import Architecture
 from .environment import EnvironmentParseError, ParsedEnvironment, parse_environment
 from .logger import log
@@ -159,18 +159,21 @@ class InheritRule(enum.Enum):
 
 
 def _resolve_cascade(
-    *pairs: tuple[Setting | None, InheritRule], ignore_empty: bool = False
-) -> Setting:
+    *pairs: tuple[Setting | None, InheritRule],
+    ignore_empty: bool = False,
+    list_sep: str | None = None,
+    table_format: TableFmt | None = None,
+) -> str:
     """
     Given a cascade of values with inherit rules, resolve them into a single
     value.
 
-    'None' values mean that the option was not set at that level.
+    'None' values mean that the option was not set at that level, and are
+    ignored. If `ignore_empty` is True, empty values are ignored too.
 
-    Values start with defaults, followed by more specific rules. If rules
-    are NONE, the last non-null value is returned. If a rule is APPEND or
-    PREPEND, the value is concatenated with the previous value, according to
-    the rules in _merge_values.
+    Values start with defaults, followed by more specific rules. If rules are
+    NONE, the last non-null value is returned. If a rule is APPEND or PREPEND,
+    the value is concatenated with the previous value.
 
     The following idiom can be used to get the first matching value:
 
@@ -180,7 +183,14 @@ def _resolve_cascade(
         msg = "pairs cannot be empty"
         raise ValueError(msg)
 
-    result: Setting | None = None
+    result: str | None = None
+
+    if table_format is not None:
+        merge_sep = table_format["sep"]
+    elif list_sep is not None:
+        merge_sep = list_sep
+    else:
+        merge_sep = None
 
     for value, rule in pairs:
         if value is None:
@@ -189,10 +199,14 @@ def _resolve_cascade(
         if ignore_empty and not value:
             continue
 
-        if result is None:  # noqa: SIM108
-            result = value
-        else:
-            result = _merge_values(result, value, rule)
+        value_string = _stringify_setting(value, list_sep, table_format)
+
+        result = _merge_values(
+            result,
+            value_string,
+            rule=rule,
+            merge_sep=merge_sep,
+        )
 
     if result is None:
         msg = "a setting should at least have a default value"
@@ -201,24 +215,52 @@ def _resolve_cascade(
     return result
 
 
-def _merge_values(before: Setting, after: Setting, rule: InheritRule) -> Setting:
+def _merge_values(before: str | None, after: str, rule: InheritRule, merge_sep: str | None) -> str:
     if rule == InheritRule.NONE:
         return after
 
-    if isinstance(before, list) and isinstance(after, list):
-        if rule == InheritRule.APPEND:
-            return before + after
-        else:
-            return after + before
+    if not before:
+        # if before is None, we can just return after
+        # if before is an empty string, we shouldn't add any separator
+        return after
 
-    if isinstance(before, dict) and isinstance(after, dict):
-        if rule == InheritRule.APPEND:
-            return {**before, **after}
-        else:
-            return {**after, **before}
+    if not after:
+        # if after is an empty string, we shouldn't add any separator
+        return before
 
-    msg = f"Cannot merge {type(before)} and {type(after)} with {rule}"
-    raise TypeError(msg)
+    if not merge_sep:
+        msg = f"Don't know how to merge {before!r} and {after!r} with {rule}"
+        raise ConfigOptionError(msg)
+
+    if rule == InheritRule.APPEND:
+        return f"{before}{merge_sep}{after}"
+    elif rule == InheritRule.PREPEND:
+        return f"{after}{merge_sep}{before}"
+    else:
+        assert_never(rule)
+
+
+def _stringify_setting(
+    setting: Setting, list_sep: str | None, table_format: TableFmt | None
+) -> str:
+    if isinstance(setting, Mapping):
+        if table_format is None:
+            msg = f"Error converting {setting!r} to a string: this setting doesn't accept a table"
+            raise ConfigOptionError(msg)
+        return table_format["sep"].join(
+            item for k, v in setting.items() for item in _inner_fmt(k, v, table_format)
+        )
+
+    if not isinstance(setting, str) and isinstance(setting, Sequence):
+        if list_sep is None:
+            msg = f"Error converting {setting!r} to a string: this setting doesn't accept a list"
+            raise ConfigOptionError(msg)
+        return list_sep.join(setting)
+
+    if isinstance(setting, int):
+        return str(setting)
+
+    return setting
 
 
 class OptionsReader:
@@ -368,8 +410,8 @@ class OptionsReader:
         name: str,
         *,
         env_plat: bool = True,
-        sep: str | None = None,
-        table: TableFmt | None = None,
+        list_sep: str | None = None,
+        table_format: TableFmt | None = None,
         ignore_empty: bool = False,
     ) -> str:
         """
@@ -393,7 +435,7 @@ class OptionsReader:
 
         # get the option from the default, then the config file, then finally the environment.
         # platform-specific options are preferred, if they're allowed.
-        result = _resolve_cascade(
+        return _resolve_cascade(
             (self.default_options.get(name), InheritRule.NONE),
             (self.default_platform_options.get(name), InheritRule.NONE),
             (self.config_options.get(name), InheritRule.NONE),
@@ -405,26 +447,9 @@ class OptionsReader:
             (self.env.get(envvar), InheritRule.NONE),
             (self.env.get(plat_envvar) if env_plat else None, InheritRule.NONE),
             ignore_empty=ignore_empty,
+            list_sep=list_sep,
+            table_format=table_format,
         )
-
-        if isinstance(result, Mapping):
-            if table is None:
-                msg = f"{name!r} does not accept a table"
-                raise ConfigOptionError(msg)
-            return table["sep"].join(
-                item for k, v in result.items() for item in _inner_fmt(k, v, table)
-            )
-
-        if not isinstance(result, str) and isinstance(result, Sequence):
-            if sep is None:
-                msg = f"{name!r} does not accept a list"
-                raise ConfigOptionError(msg)
-            return sep.join(result)
-
-        if isinstance(result, int):
-            return str(result)
-
-        return result
 
 
 def _inner_fmt(k: str, v: Any, table: TableFmt) -> Iterator[str]:
@@ -486,9 +511,9 @@ class Options:
         package_dir = args.package_dir
         output_dir = args.output_dir
 
-        build_config = self.reader.get("build", env_plat=False, sep=" ") or "*"
-        skip_config = self.reader.get("skip", env_plat=False, sep=" ")
-        test_skip = self.reader.get("test-skip", env_plat=False, sep=" ")
+        build_config = self.reader.get("build", env_plat=False, list_sep=" ") or "*"
+        skip_config = self.reader.get("skip", env_plat=False, list_sep=" ")
+        test_skip = self.reader.get("test-skip", env_plat=False, list_sep=" ")
 
         prerelease_pythons = args.prerelease_pythons or strtobool(
             self.env.get("CIBW_PRERELEASE_PYTHONS", "0")
@@ -501,7 +526,7 @@ class Options:
         )
         requires_python = None if requires_python_str is None else SpecifierSet(requires_python_str)
 
-        archs_config_str = args.archs or self.reader.get("archs", sep=" ")
+        archs_config_str = args.archs or self.reader.get("archs", list_sep=" ")
         architectures = Architecture.parse_config(archs_config_str, platform=self.platform)
 
         # Process `--only`
@@ -520,7 +545,8 @@ class Options:
         test_selector = TestSelector(skip_config=test_skip)
 
         container_engine_str = self.reader.get(
-            "container-engine", table={"item": "{k}:{v}", "sep": "; ", "quote": shlex.quote}
+            "container-engine",
+            table_format={"item": "{k}:{v}", "sep": "; ", "quote": shlex.quote},
         )
 
         try:
@@ -545,29 +571,30 @@ class Options:
         """
 
         with self.reader.identifier(identifier):
-            before_all = self.reader.get("before-all", sep=" && ")
+            before_all = self.reader.get("before-all", list_sep=" && ")
 
             environment_config = self.reader.get(
-                "environment", table={"item": '{k}="{v}"', "sep": " "}
+                "environment", table_format={"item": '{k}="{v}"', "sep": " "}
             )
-            environment_pass = self.reader.get("environment-pass", sep=" ").split()
-            before_build = self.reader.get("before-build", sep=" && ")
-            repair_command = self.reader.get("repair-wheel-command", sep=" && ")
+            environment_pass = self.reader.get("environment-pass", list_sep=" ").split()
+            before_build = self.reader.get("before-build", list_sep=" && ")
+            repair_command = self.reader.get("repair-wheel-command", list_sep=" && ")
             config_settings = self.reader.get(
-                "config-settings", table={"item": "{k}={v}", "sep": " ", "quote": shlex.quote}
+                "config-settings",
+                table_format={"item": "{k}={v}", "sep": " ", "quote": shlex.quote},
             )
 
             dependency_versions = self.reader.get("dependency-versions")
-            test_command = self.reader.get("test-command", sep=" && ")
-            before_test = self.reader.get("before-test", sep=" && ")
-            test_requires = self.reader.get("test-requires", sep=" ").split()
-            test_extras = self.reader.get("test-extras", sep=",")
+            test_command = self.reader.get("test-command", list_sep=" && ")
+            before_test = self.reader.get("before-test", list_sep=" && ")
+            test_requires = self.reader.get("test-requires", list_sep=" ").split()
+            test_extras = self.reader.get("test-extras", list_sep=",")
             build_verbosity_str = self.reader.get("build-verbosity")
 
             build_frontend_str = self.reader.get(
                 "build-frontend",
                 env_plat=False,
-                table={"item": "{k}:{v}", "sep": "; ", "quote": shlex.quote},
+                table_format={"item": "{k}:{v}", "sep": "; ", "quote": shlex.quote},
             )
             build_frontend: BuildFrontendConfig | None
             if not build_frontend_str or build_frontend_str == "default":

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -423,6 +423,25 @@
               }
             ]
           },
+          "inherit": {
+            "type": "array",
+            "items": {
+              "enum": [
+                "before-all",
+                "before-build",
+                "before-test",
+                "config-settings",
+                "container-engine",
+                "environment",
+                "environment-pass",
+                "repair-wheel-command",
+                "test-command",
+                "test-extras",
+                "test-requires"
+              ],
+              "uniqueItems": true
+            }
+          },
           "before-all": {
             "$ref": "#/properties/before-all"
           },

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -4,6 +4,17 @@
   "additionalProperties": false,
   "description": "cibuildwheel's settings.",
   "type": "object",
+  "defines": {
+    "inherit": {
+      "enum": [
+        "none",
+        "prepend",
+        "append"
+      ],
+      "default": "none",
+      "description": "How to inherit the parent's value."
+    }
+  },
   "properties": {
     "archs": {
       "description": "Change the architectures built on your machine by default.",
@@ -424,22 +435,42 @@
             ]
           },
           "inherit": {
-            "type": "array",
-            "items": {
-              "enum": [
-                "before-all",
-                "before-build",
-                "before-test",
-                "config-settings",
-                "container-engine",
-                "environment",
-                "environment-pass",
-                "repair-wheel-command",
-                "test-command",
-                "test-extras",
-                "test-requires"
-              ],
-              "uniqueItems": true
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "before-all": {
+                "$ref": "#/defines/inherit"
+              },
+              "before-build": {
+                "$ref": "#/defines/inherit"
+              },
+              "before-test": {
+                "$ref": "#/defines/inherit"
+              },
+              "config-settings": {
+                "$ref": "#/defines/inherit"
+              },
+              "container-engine": {
+                "$ref": "#/defines/inherit"
+              },
+              "environment": {
+                "$ref": "#/defines/inherit"
+              },
+              "environment-pass": {
+                "$ref": "#/defines/inherit"
+              },
+              "repair-wheel-command": {
+                "$ref": "#/defines/inherit"
+              },
+              "test-command": {
+                "$ref": "#/defines/inherit"
+              },
+              "test-extras": {
+                "$ref": "#/defines/inherit"
+              },
+              "test-requires": {
+                "$ref": "#/defines/inherit"
+              }
             }
           },
           "before-all": {

--- a/docs/options.md
+++ b/docs/options.md
@@ -135,8 +135,9 @@ trigger new containers, one per image. Some commands are not supported;
 `output-dir`, build/skip/test_skip selectors, and architectures cannot be
 overridden.
 
-You can specify a list of options in `inherit=[]`, any list or table in this
-list will inherit from previous overrides or the main configuration.
+You can specify a table of overrides in `inherit={}`, any list or table in this
+list will inherit from previous overrides or the main configuration. The valid
+options are `"none"` (the default), `"append"`, and `"prepend"`.
 
 ##### Examples:
 
@@ -179,13 +180,21 @@ test-command = ["pyproject"]
 
 [[tool.cibuildwheel.overrides]]
 select = "cp311*"
-inherit = ["test-command", "environment"]
-test-command = ["pyproject-override"]
+
+inherit.test-command="prepend"
+test-command = ["pyproject-before"]
+
+inherit.environment="append"
 environment = {FOO="BAZ", "PYTHON"="MONTY"}
+
+[[tool.cibuildwheel.overrides]]
+select = "cp311*"
+inherit.test-command="append"
+test-command = ["pyproject-after"]
 ```
 
-This example will provide the command `["pyproject", "pyproject-override"]` on
-Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"="EGGS"}`.
+This example will provide the command `"pyproject-before && pyproject && pyproject-after"`
+on Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"="EGGS"}`.
 
 ## Options summary
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -181,7 +181,7 @@ test-command = ["pyproject"]
 [[tool.cibuildwheel.overrides]]
 select = "cp311*"
 
-inherit.test-command="prepend"
+inherit.test-command = "prepend"
 test-command = ["pyproject-before"]
 
 inherit.environment="append"
@@ -189,7 +189,7 @@ environment = {FOO="BAZ", "PYTHON"="MONTY"}
 
 [[tool.cibuildwheel.overrides]]
 select = "cp311*"
-inherit.test-command="append"
+inherit.test-command = "append"
 test-command = ["pyproject-after"]
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -196,6 +196,47 @@ test-command = ["pyproject-after"]
 This example will provide the command `"pyproject-before && pyproject && pyproject-after"`
 on Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"="EGGS"}`.
 
+
+### Extending existing options {: #inherit }
+
+In the TOML configuration, you can choose how tables and lists are inherited.
+By default, all values are overridden completely (`"none"`) but sometimes you'd
+rather `"append"` or `"prepend"` to an existing list or table. You can do this
+with the `inherit` table in overrides.  For example, if you want to add an environment
+variable for CPython 3.11, without `inherit` you'd have to repeat all the
+original environment variables in the override. With `inherit`, it's just:
+
+```toml
+[[tool.cibuildwheel.overrides]]
+select = "cp311*"
+inherit.environment = "append"
+environment.NEWVAR = "Added!"
+```
+
+For a table, `"append"` will replace a key if it exists, while `"prepend"` will
+only add a new key, older keys take precedence.
+
+Lists are also supported (and keep in mind that commands are lists). For
+example, you can print a message before and after a wheel is repaired:
+
+```toml
+[[tool.cibuildwheel.overrides]]
+select = "*"
+inherit.repair-wheel-command = "prepend"
+repair-wheel-command = "echo 'Before repair'"
+
+[[tool.cibuildwheel.overrides]]
+select = "*"
+inherit.repair-wheel-command = "append"
+repair-wheel-command = "echo 'After repair'"
+```
+
+As seen in this example, you can have multiple overrides match - they match top
+to bottom, with the config being accumulated. If you need platform-specific
+inheritance, you can use `select = "*-????linux_*"` for Linux, `select =
+"*-win_*"` for Windows, and `select = "*-macosx_*"` for macOS. As always,
+environment variables will completely override any TOML configuration.
+
 ## Options summary
 
 <div class="options-toc"></div>

--- a/docs/options.md
+++ b/docs/options.md
@@ -135,6 +135,9 @@ trigger new containers, one per image. Some commands are not supported;
 `output-dir`, build/skip/test_skip selectors, and architectures cannot be
 overridden.
 
+You can specify a list of options in `inherit=[]`, any list or table in this
+list will inherit from previous overrides or the main configuration.
+
 ##### Examples:
 
 ```toml
@@ -169,6 +172,20 @@ This example will build CPython 3.6 wheels on manylinux1, CPython 3.7-3.9
 wheels on manylinux2010, and manylinux2014 wheels for any newer Python
 (like 3.10).
 
+```toml
+[tool.cibuildwheel]
+environment = {FOO="BAR", "HAM"="EGGS"}
+test-command = ["pyproject"]
+
+[[tool.cibuildwheel.overrides]]
+select = "cp311*"
+inherit = ["test-command", "environment"]
+test-command = ["pyproject-override"]
+environment = {FOO="BAZ", "PYTHON"="MONTY"}
+```
+
+This example will provide the command `["pyproject", "pyproject-override"]` on
+Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"="EGGS"}`.
 
 ## Options summary
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -37,27 +37,31 @@ def test_simple_settings(tmp_path, platform, fname):
 
     options_reader = OptionsReader(config_file_path, platform=platform, env={})
 
-    assert options_reader.get("build", env_plat=False, sep=" ") == "cp39*"
+    assert options_reader.get("build", env_plat=False, list_sep=" ") == "cp39*"
 
     assert options_reader.get("test-command") == "pyproject"
-    assert options_reader.get("archs", sep=" ") == "auto"
+    assert options_reader.get("archs", list_sep=" ") == "auto"
     assert (
-        options_reader.get("test-requires", sep=" ")
+        options_reader.get("test-requires", list_sep=" ")
         == {"windows": "something", "macos": "else", "linux": "other many"}[platform]
     )
 
     # Also testing options for support for both lists and tables
     assert (
-        options_reader.get("environment", table={"item": '{k}="{v}"', "sep": " "})
+        options_reader.get("environment", table_format={"item": '{k}="{v}"', "sep": " "})
         == 'THING="OTHER" FOO="BAR"'
     )
     assert (
-        options_reader.get("environment", sep="x", table={"item": '{k}="{v}"', "sep": " "})
+        options_reader.get(
+            "environment", list_sep="x", table_format={"item": '{k}="{v}"', "sep": " "}
+        )
         == 'THING="OTHER" FOO="BAR"'
     )
-    assert options_reader.get("test-extras", sep=",") == "one,two"
+    assert options_reader.get("test-extras", list_sep=",") == "one,two"
     assert (
-        options_reader.get("test-extras", sep=",", table={"item": '{k}="{v}"', "sep": " "})
+        options_reader.get(
+            "test-extras", list_sep=",", table_format={"item": '{k}="{v}"', "sep": " "}
+        )
         == "one,two"
     )
 
@@ -65,10 +69,10 @@ def test_simple_settings(tmp_path, platform, fname):
     assert options_reader.get("manylinux-i686-image") == "manylinux2014"
 
     with pytest.raises(ConfigOptionError):
-        options_reader.get("environment", sep=" ")
+        options_reader.get("environment", list_sep=" ")
 
     with pytest.raises(ConfigOptionError):
-        options_reader.get("test-extras", table={"item": '{k}="{v}"', "sep": " "})
+        options_reader.get("test-extras", table_format={"item": '{k}="{v}"', "sep": " "})
 
 
 def test_envvar_override(tmp_path, platform):
@@ -87,14 +91,14 @@ def test_envvar_override(tmp_path, platform):
         },
     )
 
-    assert options_reader.get("archs", sep=" ") == "auto"
+    assert options_reader.get("archs", list_sep=" ") == "auto"
 
-    assert options_reader.get("build", sep=" ") == "cp38*"
+    assert options_reader.get("build", list_sep=" ") == "cp38*"
     assert options_reader.get("manylinux-x86_64-image") == "manylinux_2_24"
     assert options_reader.get("manylinux-i686-image") == "manylinux2014"
 
     assert (
-        options_reader.get("test-requires", sep=" ")
+        options_reader.get("test-requires", list_sep=" ")
         == {"windows": "docs", "macos": "docs", "linux": "scod"}[platform]
     )
     assert options_reader.get("test-command") == "mytest"
@@ -215,7 +219,7 @@ build = ["1", "2"]
     )
     options_reader = OptionsReader(pyproject_toml, platform="linux", env={})
 
-    assert options_reader.get("build", sep=", ") == "1, 2"
+    assert options_reader.get("build", list_sep=", ") == "1, 2"
     with pytest.raises(ConfigOptionError):
         options_reader.get("build")
 
@@ -301,17 +305,18 @@ def test_resolve_cascade_merge_list(ignore_empty, rule):
         (["b1", "b2"], rule),
         (None, InheritRule.NONE),
         ignore_empty=ignore_empty,
+        list_sep=" ",
     )
 
     if not ignore_empty:
-        assert answer == ["b1", "b2"]
+        assert answer == "b1 b2"
     else:
         if rule == InheritRule.PREPEND:
-            assert answer == ["b1", "b2", "a1", "a2"]
+            assert answer == "b1 b2 a1 a2"
         elif rule == InheritRule.NONE:
-            assert answer == ["b1", "b2"]
+            assert answer == "b1 b2"
         elif rule == InheritRule.APPEND:
-            assert answer == ["a1", "a2", "b1", "b2"]
+            assert answer == "a1 a2 b1 b2"
 
 
 @pytest.mark.parametrize("rule", [InheritRule.PREPEND, InheritRule.NONE, InheritRule.APPEND])
@@ -321,14 +326,24 @@ def test_resolve_cascade_merge_dict(rule):
         (None, InheritRule.NONE),
         ({"value": "override"}, rule),
         (None, InheritRule.NONE),
+        table_format={"item": "{k}={v}", "sep": " "},
     )
 
     if rule == InheritRule.PREPEND:
-        assert answer == {"value": "a1", "base": "b1"}
+        assert answer == "value=override value=a1 base=b1"
     elif rule == InheritRule.NONE:
-        assert answer == {"value": "override"}
+        assert answer == "value=override"
     elif rule == InheritRule.APPEND:
-        assert answer == {"value": "override", "base": "b1"}
+        assert answer == "value=a1 base=b1 value=override"
+
+
+def test_resolve_cascade_merge_different_types():
+    answer = _resolve_cascade(
+        ({"value": "a1", "base": "b1"}, InheritRule.NONE),
+        ({"value": "override"}, InheritRule.APPEND),
+        table_format={"item": "{k}={v}", "sep": " "},
+    )
+    assert answer == "value=a1 base=b1 value=override"
 
 
 PYPROJECT_2 = """
@@ -372,29 +387,29 @@ def test_pyproject_2(tmp_path, platform):
     pyproject_toml.write_text(PYPROJECT_2)
 
     options_reader = OptionsReader(config_file_path=pyproject_toml, platform=platform, env={})
-    assert options_reader.get("test-command", sep=" && ") == "pyproject"
+    assert options_reader.get("test-command", list_sep=" && ") == "pyproject"
 
     with options_reader.identifier("random"):
-        assert options_reader.get("test-command", sep=" && ") == "pyproject"
+        assert options_reader.get("test-command", list_sep=" && ") == "pyproject"
 
     with options_reader.identifier("cp37-something"):
         assert (
-            options_reader.get("test-command", sep=" && ")
+            options_reader.get("test-command", list_sep=" && ")
             == "pyproject-override && override2 && pyproject"
         )
         assert (
-            options_reader.get("environment", table={"item": '{k}="{v}"', "sep": " "})
-            == 'FOO="BAZ" HAM="EGGS" PYTHON="MONTY"'
+            options_reader.get("environment", table_format={"item": '{k}="{v}"', "sep": " "})
+            == 'FOO="BAR" HAM="EGGS" FOO="BAZ" PYTHON="MONTY"'
         )
 
     with options_reader.identifier("cp37-final"):
         assert (
-            options_reader.get("test-command", sep=" && ")
+            options_reader.get("test-command", list_sep=" && ")
             == "extra-prepend && pyproject-override && override2 && pyproject && pyproject-finalize && finalize2 && extra-finalize"
         )
         assert (
-            options_reader.get("environment", table={"item": '{k}="{v}"', "sep": " "})
-            == 'FOO="BAZ" HAM="EGGS" PYTHON="MONTY"'
+            options_reader.get("environment", table_format={"item": '{k}="{v}"', "sep": " "})
+            == 'FOO="BAR" HAM="EGGS" FOO="BAZ" PYTHON="MONTY"'
         )
 
 
@@ -427,7 +442,7 @@ other = ["two", "three"]
 
     options_reader = OptionsReader(config_file_path=pyproject_toml, platform="linux", env={})
     assert (
-        options_reader.get("config-settings", table={"item": '{k}="{v}"', "sep": " "})
+        options_reader.get("config-settings", table_format={"item": '{k}="{v}"', "sep": " "})
         == 'example="one" other="two" other="three"'
     )
 
@@ -444,7 +459,36 @@ def test_pip_config_settings(tmp_path):
     options_reader = OptionsReader(config_file_path=pyproject_toml, platform="linux", env={})
     assert (
         options_reader.get(
-            "config-settings", table={"item": "--config-settings='{k}=\"{v}\"'", "sep": " "}
+            "config-settings", table_format={"item": "--config-settings='{k}=\"{v}\"'", "sep": " "}
         )
         == "--config-settings='--build-option=\"--use-mypyc\"'"
     )
+
+
+def test_overrides_inherit(tmp_path):
+    pyproject_toml: Path = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        """\
+[tool.cibuildwheel]
+before-all = ["before-all"]
+
+[[tool.cibuildwheel.overrides]]
+select = "cp37*"
+inherit.before-all = "append"
+before-all = ["override1"]
+
+[[tool.cibuildwheel.overrides]]
+select = "cp37*"
+inherit.before-all = "prepend"
+before-all = ["override2"]
+"""
+    )
+
+    options_reader = OptionsReader(config_file_path=pyproject_toml, platform="linux", env={})
+    with options_reader.identifier("cp38-something"):
+        assert options_reader.get("before-all", list_sep=" && ") == "before-all"
+    with options_reader.identifier("cp37-something"):
+        assert (
+            options_reader.get("before-all", list_sep=" && ")
+            == "override2 && before-all && override1"
+        )

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -72,6 +72,35 @@ def test_overrides_only_select():
         validator(example)
 
 
+def test_overrides_valid_inherit():
+    example = tomllib.loads(
+        """
+        [[tool.cibuildwheel.overrides]]
+        inherit = ["repair-wheel-command"]
+        select = "somestring"
+        repair-wheel-command = ["something"]
+        """
+    )
+
+    validator = validate_pyproject.api.Validator()
+    assert validator(example) is not None
+
+
+def test_overrides_invalid_inherit():
+    example = tomllib.loads(
+        """
+        [[tool.cibuildwheel.overrides]]
+        inherit = ["something"]
+        select = "somestring"
+        repair-wheel-command = "something"
+        """
+    )
+
+    validator = validate_pyproject.api.Validator()
+    with pytest.raises(validate_pyproject.error_reporting.ValidationError):
+        validator(example)
+
+
 def test_docs_examples():
     """
     Parse out all the configuration examples, build valid TOML out of them, and

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -76,7 +76,7 @@ def test_overrides_valid_inherit():
     example = tomllib.loads(
         """
         [[tool.cibuildwheel.overrides]]
-        inherit = ["repair-wheel-command"]
+        inherit.repair-wheel-command = "append"
         select = "somestring"
         repair-wheel-command = ["something"]
         """
@@ -90,7 +90,22 @@ def test_overrides_invalid_inherit():
     example = tomllib.loads(
         """
         [[tool.cibuildwheel.overrides]]
-        inherit = ["something"]
+        inherit.something = "append"
+        select = "somestring"
+        repair-wheel-command = "something"
+        """
+    )
+
+    validator = validate_pyproject.api.Validator()
+    with pytest.raises(validate_pyproject.error_reporting.ValidationError):
+        validator(example)
+
+
+def test_overrides_invalid_inherit_value():
+    example = tomllib.loads(
+        """
+        [[tool.cibuildwheel.overrides]]
+        inherit.repair-wheel-command = "nothing"
         select = "somestring"
         repair-wheel-command = "something"
         """


### PR DESCRIPTION
This implements my follow-up suggestion in #1716, modified. Example:

```toml
[tool.cibuildwheel]
environment = {FOO="BAR", "HAM"="EGGS"}
test-command = ["pyproject"]

[[tool.cibuildwheel.overrides]]
select = "cp311*"
inherit.test-command = "append"
inherit.environment = "append"

test-command = ["pyproject-override"]
environment = {FOO="BAZ", "PYTHON"="MONTY"}
```

This example will provide the command `["pyproject", "pyproject-override"]` on
Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"="EGGS"}`. Both `"append"` and `"prepend"` are supported (`"none"` is the default). You can even chain them to both append and prepend in matching override blocks.
