### PR TITLE
Add support for PowerShell 7.3 in GHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,13 @@ runs:
       if: runner.os != 'Windows'
 
     # Windows needs powershell to interact nicely with Meson
+    # $PSNativeCommandArgumentPassing was introduced in pwsh 7.3 and the
+    # legacy behaviour is needed for backwards compatibility with how this
+    # was called in the past.
     - run: >
+        if ($PSNativeCommandArgumentPassing) {
+            $PSNativeCommandArgumentPassing = 'Legacy'
+        };
         pipx run
         --python "${{ steps.python.outputs.python-path }}"
         --spec "${{ github.action_path }}"


### PR DESCRIPTION
Fixes compatibility with PowerShell 7.3 on Windows through GitHub Actions when one of the options for cibuildwheel is empty.

I'm not sure how you want to go about this but I believe this should solve the issue with the migration of GHA to PowerShell 7.4 that is happening now.

Fixes: https://github.com/pypa/cibuildwheel/issues/1740