### PR TITLE
fix: simplify action quoting on Windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,8 @@ runs:
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"
-        --output-dir '"${{ inputs.output-dir }}"'
-        --config-file '"${{ inputs.config-file }}"'
-        --only '"${{ inputs.only }}"'
+        --output-dir "${{ inputs.output-dir }}"
+        --config-file "${{ inputs.config-file }}"
+        --only "${{ inputs.only }}"
       shell: pwsh
       if: runner.os == 'Windows'


### PR DESCRIPTION
I'm not sure the quoting was necessary to make this complicated, I don't see a reason in #1346. This is option 1 to fix #1740. Would also close #1741, which is option 2 (personally, if option 1 doesn't work, option 3 seems better than option 2).

This is needed to support Powershell 7.4, which is beginning to ship on GHA.

~~The action is not exercised in tests, so we'll need someone to check it. I can later today, perhaps.~~ (It seems to be in the tests, actually)