### PR TITLE
fix: download pipx for action, allow support for M1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,12 @@ runs:
 
     # macos-14 (M1) may be missing pipx (due to it not having CPython)
     - run: |
-        '${{ steps.python.outputs.python-path }}' -m pip install pipx
+        "${{ steps.python.outputs.python-path }}" -m pip install pipx
       shell: bash
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
-        '${{ steps.python.outputs.python-path }}' -m pipx run
+        "${{ steps.python.outputs.python-path }}" -m pipx run
         --spec '${{ github.action_path }}'
         cibuildwheel
         "${{ inputs.package-dir }}"
@@ -51,7 +51,7 @@ runs:
 
     # Windows needs powershell to interact nicely with Meson
     - run: >
-        '${{ steps.python.outputs.python-path }}' -m pipx run
+        "${{ steps.python.outputs.python-path }}" -m pipx run
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,14 @@ runs:
         python-version: "3.8 - 3.12"
         update-environment: false
 
+    # macos-14 (M1) may be missing pipx (due to it not having CPython)
+    - run: |
+        '${{ steps.python.outputs.python-path }}' -m pip install pipx
+      shell: bash
+
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
-        pipx run
-        --python '${{ steps.python.outputs.python-path }}'
+        '${{ steps.python.outputs.python-path }}' -m pipx run
         --spec '${{ github.action_path }}'
         cibuildwheel
         "${{ inputs.package-dir }}"
@@ -47,8 +51,7 @@ runs:
 
     # Windows needs powershell to interact nicely with Meson
     - run: >
-        pipx run
-        --python "${{ steps.python.outputs.python-path }}"
+        '${{ steps.python.outputs.python-path }}' -m pipx run
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
 
     # Windows needs powershell to interact nicely with Meson
     - run: >
-        "${{ steps.python.outputs.python-path }}" -m pipx run
+        ${{ steps.python.outputs.python-path }} -m pipx run
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
         if ($PSNativeCommandArgumentPassing) {
             $PSNativeCommandArgumentPassing = 'Legacy'
         };
-        ${{ steps.python.outputs.python-path }} -m pipx run
+        & "${{ steps.python.outputs.python-path }}" -m pipx run
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"


### PR DESCRIPTION
Takes an extra second or two, plus it could interfere with the environment a bit if someone activates the same version of Python. But not too bad.
