### PR TITLE
test macos-x86_64 and arm64 in different venv dir

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -543,7 +543,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     # there are no dependencies that were pulled in at build time.
                     call("pip", "install", "virtualenv", *dependency_constraint_flags, env=env)
 
-                    venv_dir = identifier_tmp_dir / "venv-test"
+                    venv_dir = identifier_tmp_dir / f"venv-test-{testing_arch}"
 
                     arch_prefix = []
                     if testing_arch != machine_arch:


### PR DESCRIPTION
pip cannot install wheels with different architecture into the same venv directory. (See https://github.com/pypa/cibuildwheel/issues/1746#issuecomment-1920164503)

Downstream test:
Before this PR: failed [log](https://github.com/tongzhugroup/mddatasetbuilder/actions/runs/7733603508/job/21086015132)
After this PR: pass [log](https://github.com/tongzhugroup/mddatasetbuilder/actions/runs/7748040866/job/21129838429)