### PR TITLE
chore(action): update cibuildwheel arguments passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,39 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
 
+    - name: Run a sample build (GitHub Action, only)
+      uses: ./
+      with:
+        package-dir: sample_proj
+        output-dir: wheelhouse_only
+        only: cp312-${{ runner.os == 'Linux' && 'manylinux_x86_64' || (runner.os == 'Windows' && 'win_amd64' || 'macosx_x86_64') }}
+
+    - name: Create custom configuration file
+      shell: bash
+      run: |
+        cat > sample_proj/cibw.toml <<EOF
+        [tool.cibuildwheel]
+        # Only build on CPython 3.12 on native arch
+        archs = ["native"]
+        build = "cp312-*"
+        # Skip musllinux
+        skip = "*-musllinux*"
+        EOF
+
+    - name: Run a sample build (GitHub Action, config-file)
+      uses: ./
+      with:
+        package-dir: sample_proj
+        output-dir: wheelhouse_config_file
+        config-file: sample_proj/cibw.toml
+
+    - name: Check Action artefacts
+      shell: bash
+      run: |
+        test $(find wheelhouse -name '*.whl' | wc -l) -ge 1
+        test $(find wheelhouse_only -name '*.whl' | wc -l) -eq 1
+        test $(find wheelhouse_config_file -name '*.whl' | wc -l) -eq 1
+
     - uses: actions/upload-artifact@v4
       with:
         name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/action.yml
+++ b/action.yml
@@ -42,27 +42,21 @@ runs:
         --spec '${{ github.action_path }}'
         cibuildwheel
         "${{ inputs.package-dir }}"
-        --output-dir "${{ inputs.output-dir }}"
-        --config-file "${{ inputs.config-file }}"
-        --only "${{ inputs.only }}"
+        ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
+        ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
+        ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
         2>&1
       shell: bash
       if: runner.os != 'Windows'
 
     # Windows needs powershell to interact nicely with Meson
-    # $PSNativeCommandArgumentPassing was introduced in pwsh 7.3 and the
-    # legacy behaviour is needed for backwards compatibility with how this
-    # was called in the past.
     - run: >
-        if ($PSNativeCommandArgumentPassing) {
-            $PSNativeCommandArgumentPassing = 'Legacy'
-        };
         & "${{ steps.python.outputs.python-path }}" -m pipx run
         --spec "${{ github.action_path }}"
         cibuildwheel
         "${{ inputs.package-dir }}"
-        --output-dir '"${{ inputs.output-dir }}"'
-        --config-file '"${{ inputs.config-file }}"'
-        --only '"${{ inputs.only }}"'
+        ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
+        ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
+        ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
       shell: pwsh
       if: runner.os == 'Windows'


### PR DESCRIPTION
Only pass arguments that were set by the action to cibuildwheel.

Also add tests for action `only` & `config-file` arguments.

This allows to remove the workaround for `pwsh` update in https://github.com/pypa/cibuildwheel/pull/1741.

IMHO, this also brings some clarity when looking at the command-line that's being run:
e.g. https://github.com/pypa/cibuildwheel/actions/runs/7853848516/job/21433975640#step:8:64
```
Run if ($PSNativeCommandArgumentPassing) {
```
will now produce:
```
Run & "C:\hostedtoolcache\windows\Python\3.12.1\x64\python.exe" -m pipx run --spec "D:\a\cibuildwheel\cibuildwheel\./" cibuildwheel "sample_proj" --output-dir "wheelhouse"
```