### PR TITLE
Replace deprecated runner in CircleCI example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   linux-aarch64:
     machine:
-       image: ubuntu-2004:2022.04.1
+       image: default
     resource_class: arm.medium
     environment:
       PYTHON: python3

--- a/examples/circleci-minimal.yml
+++ b/examples/circleci-minimal.yml
@@ -19,7 +19,7 @@ jobs:
   linux-aarch64-wheels:
     working_directory: ~/linux-aarch64-wheels
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: default
     # resource_class is what tells CircleCI to use an ARM worker for native arm builds
     # https://circleci.com/product/features/resource-classes/
     resource_class: arm.medium


### PR DESCRIPTION
As described [here](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177), the Linux image used in the example has been deprecated, and the CircleCI example will stop working soon unless it gets updated.