### PR TITLE
[draft] Sketched out an explicit QEMU mode

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -441,12 +441,16 @@ def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
                         this_build_platform = docker_platform
                         break
                 else:
-                    raise ValueError(f"Unexpected build platform ’{build_step.platform_tag}'.")
+                    msg = f"Unexpected build platform: {build_step.platform_tag}."
+                    raise ValueError(msg)
 
                 container_engine_config = OCIContainerEngineConfig(
                     name=options.globals.container_engine.name,
-                    create_args=tuple(options.globals.container_engine.create_args)
-                    + ("--platform", this_build_platform),
+                    create_args=(
+                        *options.globals.container_engine.create_args,
+                        "--platform",
+                        this_build_platform,
+                    ),
                     disable_host_mount=options.globals.container_engine.disable_host_mount,
                 )
             else:

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -445,8 +445,9 @@ def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
 
                 container_engine_config = OCIContainerEngineConfig(
                     name=options.globals.container_engine.name,
-                    create_args=tuple(options.globals.container_engine.create_args) + ("--platform", this_build_platform),
-                    disable_host_mount=options.globals.container_engine.disable_host_mount
+                    create_args=tuple(options.globals.container_engine.create_args)
+                    + ("--platform", this_build_platform),
+                    disable_host_mount=options.globals.container_engine.disable_host_mount,
                 )
             else:
                 container_engine_config = options.globals.container_engine

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -160,7 +160,7 @@ class OCIContainer:
             [
                 self.engine.name,
                 "create",
-                f"--platform={self.oci_platform.value}" if self.oci_platform else "",
+                *((f"--platform={self.oci_platform.value}",) if self.oci_platform else ()),
                 "--env=CIBUILDWHEEL",
                 "--env=SOURCE_DATE_EPOCH",
                 f"--name={self.name}",

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -120,7 +120,7 @@ class OCIContainer:
         enforce_32_bit: bool = False,
         cwd: PathOrStr | None = None,
         engine: OCIContainerEngineConfig = DEFAULT_ENGINE,
-        oci_platform: OCIPlatform = OCIPlatform.AMD64,
+        oci_platform: OCIPlatform | None = None,
     ):
         if not image:
             msg = "Must have a non-empty image to run."
@@ -160,7 +160,7 @@ class OCIContainer:
             [
                 self.engine.name,
                 "create",
-                f"--platform={self.oci_platform.value}",
+                f"--platform={self.oci_platform.value}" if self.oci_platform else "",
                 "--env=CIBUILDWHEEL",
                 "--env=SOURCE_DATE_EPOCH",
                 f"--name={self.name}",

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -120,7 +120,7 @@ class OCIContainer:
         enforce_32_bit: bool = False,
         cwd: PathOrStr | None = None,
         engine: OCIContainerEngineConfig = DEFAULT_ENGINE,
-        oci_platform: OCIPlatform = OCIPlatform.AMD64
+        oci_platform: OCIPlatform = OCIPlatform.AMD64,
     ):
         if not image:
             msg = "Must have a non-empty image to run."


### PR DESCRIPTION
This is a very primitive sketch of forcing `cibuildwheel` to execute a given docker build container in the platform mode that corresponds to the wanted wheel architecture. This should only have an effect when doing non-native platform wheel builds through QEMU.

Possibly interesting since I noticed that all build containers run commands are given no further platform information, even if an image could not be executed natively and *has* to be run through QEMU. This should work because of the binfmt_misc feature of the linux kernel, but for some reason I saw this crash catastrophically in this issue in a Github Action: https://github.com/pypa/cibuildwheel/issues/1771.

This would also remove these warning messages that docker prints out:
```
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
```

Note that this is just a sketch and not intended to be merged. Let me know what you think about this in general.