### PR TITLE
Add `pedalboard` to projects.yml.

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -645,3 +645,15 @@
   os: [linux, apple]
   pypi: keyvi
   notes: FST based key value index highly optimized for size and lookup performance, utilizes ccache action for improved runtime
+
+- name: pedalboard
+  gh: spotify/pedalboard
+  ci: [github]
+  os: [windows, linux, apple]
+  pypi: pedalboard
+  notes: >
+      A Python library for working with audio data and audio plugins
+      by wrapping the [JUCE](https://github.com/juce-framework/JUCE/
+      C++ framework. Uses cibuildwheel to deploy on as many operating
+      systems and Python versions as possible with only one dependency
+      (any NumPy).

--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -653,7 +653,7 @@
   pypi: pedalboard
   notes: >
       A Python library for working with audio data and audio plugins
-      by wrapping the [JUCE](https://github.com/juce-framework/JUCE/
+      by wrapping the [JUCE](https://github.com/juce-framework/JUCE/)
       C++ framework. Uses cibuildwheel to deploy on as many operating
       systems and Python versions as possible with only one dependency
       (any NumPy).


### PR DESCRIPTION
[`pedalboard`](https://github.com/spotify/pedalboard) is a Python library that makes it easy, fast, and intuitive to work with audio data in Python.

Under the hood, it wraps [the JUCE framework](https://github.com/juce-framework/JUCE/) to allow extremely high-speed, thread-safe audio processing - and uses `cibuildwheel` to distribute effortlessly to nearly any platform: macOS, Windows, manylinux, musllinux, arm64, x86, Python 3.6-3.12, etc; with just a `pip install`. (The project wouldn't have been possible without cibuildwheel; thanks @henryiii!)