### PR TITLE
Updated actions/setup-python in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.17.0

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -188,7 +188,7 @@ To build Linux, Mac, and Windows wheels using GitHub Actions, create a `.github/
           - uses: actions/checkout@v4
 
           # Used to host cibuildwheel
-          - uses: actions/setup-python@v3
+          - uses: actions/setup-python@v5
 
           - name: Install cibuildwheel
             run: python -m pip install cibuildwheel==2.17.0


### PR DESCRIPTION
The docs currently refer to actions/setup-python@v3

This updates it to the latest version, v5 - https://github.com/actions/setup-python/releases