### PR TITLE
docs: rust

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,14 +5,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
-mkdocs:
-  configuration: mkdocs.yml
+    python: "3.12"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv venv
+    - uv pip install .[docs]
+    - .venv/bin/python -m mkdocs build --site-dir $READTHEDOCS_OUTPUT/html

--- a/README.md
+++ b/README.md
@@ -305,4 +305,4 @@ See also
 
 Another very similar tool to consider is [matthew-brett/multibuild](http://github.com/matthew-brett/multibuild). `multibuild` is a shell script toolbox for building a wheel on various platforms. It is used as a basis to build some of the big data science tools, like SciPy.
 
-If you are building Rust wheels, you can get by without some of the tricks required to make GLIBC work via manylinux; this is especially relevant for cross-compiling, which is easy with Rust. See [maturin-action](https://github.com/messense/maturin-action) for a tool that is optimized for building Rust wheels and cross-compiling.
+If you are building Rust wheels, you can get by without some of the tricks required to make GLIBC work via manylinux; this is especially relevant for cross-compiling, which is easy with Rust. See [maturin-action](https://github.com/PyO3/maturin-action) for a tool that is optimized for building Rust wheels and cross-compiling.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -285,7 +285,7 @@ For these reasons, it's strongly recommended to not use brew for native library 
 ### Building Rust wheels
 
 If you build Rust wheels, you need to download the Rust compilers in manylinux.
-If you support 32-bit windows, you need to add this as a potential target. You
+If you support 32-bit Windows, you need to add this as a potential target. You
 can do this, for example on GitHub Actions, with:
 
 ```yaml

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -294,14 +294,14 @@ CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
 CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 ```
 
-You probably need to skip PyPy (if using PyO3, anyway), and Rust does not provide Cargo for musllinux 32-bit:
+Rust does not provide Cargo for musllinux 32-bit, so that needs to be skipped:
 
 ```toml
 [tool.cibuildwheel]
-skip = ["pp*", "*-musllinux_i686"]
+skip = ["*-musllinux_i686"]
 ```
 
-Also see [maturin-action](https://github.com/PyO3/maturin-action) which is optimized for Rust wheels and can cross-compile (and can build 32-bit musl, for example).
+Also see [maturin-action](https://github.com/PyO3/maturin-action) which is optimized for Rust wheels, builds the non-Python Rust modules once, and can cross-compile (and can build 32-bit musl, for example).
 
 ### macOS: ModuleNotFoundError
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -294,7 +294,7 @@ CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
 CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 ```
 
-You probably need to skip PyPy (if using PyO3, anyway), and Rust provides cargo for musllinux 32-bit:
+You probably need to skip PyPy (if using PyO3, anyway), and Rust does not provide Cargo for musllinux 32-bit:
 
 ```toml
 [tool.cibuildwheel]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -286,7 +286,7 @@ For these reasons, it's strongly recommended to not use brew for native library 
 
 If you build Rust wheels, you need to download the Rust compilers in manylinux.
 If you support 32-bit Windows, you need to add this as a potential target. You
-can do this on GitHub Actiions, for example, with:
+can do this on GitHub Actions, for example, with:
 
 ```yaml
 CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -282,6 +282,27 @@ For these reasons, it's strongly recommended to not use brew for native library 
 [Homebrew]: https://brew.sh/
 [delocate]: https://github.com/matthew-brett/delocate
 
+### Building Rust wheels
+
+If you build Rust wheels, you need to download the Rust compilers in manylinux.
+If you support 32-bit windows, you need to add this as a potential target. You
+can do this, for example on GitHub Actions, with:
+
+```toml
+CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
+CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
+CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+```
+
+You probably need to skip PyPy (if using PyO3, anyway), and Rust doesn't support musllinux 1.1:
+
+```toml
+[tool.cibuildwheel]
+skip = ["pp*", "*musl*"]
+```
+
+Also see [maturin-action](https://github.com/PyO3/maturin-action) which is optimized for Rust wheels and can cross-compile.
+
 ### macOS: ModuleNotFoundError
 
 Calling cibuildwheel from a python3 script and getting a `ModuleNotFoundError`? Due to a (fixed) [bug](https://bugs.python.org/issue22490) in CPython, you'll need to [unset the `__PYVENV_LAUNCHER__` variable](https://github.com/pypa/cibuildwheel/issues/133#issuecomment-478288597) before activating a venv.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -286,7 +286,7 @@ For these reasons, it's strongly recommended to not use brew for native library 
 
 If you build Rust wheels, you need to download the Rust compilers in manylinux.
 If you support 32-bit Windows, you need to add this as a potential target. You
-can do this, for example on GitHub Actions, with:
+can do this on GitHub Actiions, for example, with:
 
 ```yaml
 CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
@@ -294,14 +294,14 @@ CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
 CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 ```
 
-You probably need to skip PyPy (if using PyO3, anyway), and Rust doesn't support musllinux 1.1:
+You probably need to skip PyPy (if using PyO3, anyway), and Rust provides cargo for musllinux 32-bit:
 
 ```toml
 [tool.cibuildwheel]
-skip = ["pp*", "*musl*"]
+skip = ["pp*", "*-musllinux_i686"]
 ```
 
-Also see [maturin-action](https://github.com/PyO3/maturin-action) which is optimized for Rust wheels and can cross-compile.
+Also see [maturin-action](https://github.com/PyO3/maturin-action) which is optimized for Rust wheels and can cross-compile (and can build 32-bit musl, for example).
 
 ### macOS: ModuleNotFoundError
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -288,7 +288,7 @@ If you build Rust wheels, you need to download the Rust compilers in manylinux.
 If you support 32-bit windows, you need to add this as a potential target. You
 can do this, for example on GitHub Actions, with:
 
-```toml
+```yaml
 CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
 CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
 CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
Two related changes:

- **docs: add FAQ entry on Rust**
- **ci: make readthedocs faster**

Before, on readthedocs:

![Screenshot 2024-05-10 at 1 12 09 AM](https://github.com/pypa/cibuildwheel/assets/4616906/b26cd27c-811b-4f1a-8710-54c5062b6662)

After:

![Screenshot 2024-05-10 at 1 13 01 AM](https://github.com/pypa/cibuildwheel/assets/4616906/30a2cd31-ff71-4d2a-85e4-9c9cb1413569)

