### PR TITLE
feat: move default `musllinux` build to `musllinux_1_2`

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -669,7 +669,7 @@ class Options:
                     config_value = self.reader.get(f"musllinux-{build_platform}-image")
 
                     if not config_value:
-                        image = pinned_images["musllinux_1_1"]
+                        image = pinned_images["musllinux_1_2"]
                     elif config_value in pinned_images:
                         image = pinned_images[config_value]
                     else:

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -31,11 +31,11 @@ manylinux-pypy_x86_64-image = "manylinux2014"
 manylinux-pypy_i686-image = "manylinux2014"
 manylinux-pypy_aarch64-image = "manylinux2014"
 
-musllinux-x86_64-image = "musllinux_1_1"
-musllinux-i686-image = "musllinux_1_1"
-musllinux-aarch64-image = "musllinux_1_1"
-musllinux-ppc64le-image = "musllinux_1_1"
-musllinux-s390x-image = "musllinux_1_1"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
 
 
 [tool.cibuildwheel.linux]

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,54 +1,54 @@
 [x86_64]
 manylinux1 = quay.io/pypa/manylinux1_x86_64:2024-04-29-76807b8
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2024-04-29-07d05a0
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2024-04-29-07d05a0
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2024-05-10-7415d48
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_x86_64:2024-05-10-7415d48
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2024-05-10-7415d48
 
 [i686]
 manylinux1 = quay.io/pypa/manylinux1_i686:2024-04-29-76807b8
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-12-26-0d38463
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2024-04-29-07d05a0
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2024-04-29-07d05a0
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_i686:2024-05-10-7415d48
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2024-05-10-7415d48
 
 [pypy_x86_64]
 manylinux2010 = quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2024-05-10-7415d48
 
 [pypy_i686]
 manylinux2010 = quay.io/pypa/manylinux2010_i686:2022-08-05-4535177
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_i686:2022-12-26-0d38463
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2024-04-29-07d05a0
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2024-04-29-07d05a0
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2024-05-10-7415d48
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_aarch64:2024-05-10-7415d48
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2024-05-10-7415d48
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_ppc64le:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2024-04-29-07d05a0
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2024-04-29-07d05a0
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2024-05-10-7415d48
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_ppc64le:2024-05-10-7415d48
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2024-05-10-7415d48
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_s390x:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2024-04-29-07d05a0
-musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2024-04-29-07d05a0
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2024-05-10-7415d48
+musllinux_1_1 = quay.io/pypa/musllinux_1_1_s390x:2024-05-10-7415d48
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2024-05-10-7415d48
 
 [pypy_aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2024-04-29-07d05a0
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2024-05-10-7415d48
 manylinux_2_24 = quay.io/pypa/manylinux_2_24_aarch64:2022-12-26-0d38463
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2024-04-29-07d05a0
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2024-05-10-7415d48
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ title: Tips and tricks
 
 Linux wheels are built in [`manylinux`/`musllinux` containers](https://github.com/pypa/manylinux) to provide binary compatible wheels on Linux, according to [PEP 600](https://www.python.org/dev/peps/pep-0600/) / [PEP 656](https://www.python.org/dev/peps/pep-0656/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
 
--   Programs and libraries are not installed on the CI runner host, but rather should be installed inside the container - using `yum` for `manylinux2010` or `manylinux2014`, `apt-get` for `manylinux_2_24` and `apk` for `musllinux_1_1`, or manually. The same goes for environment variables that are potentially needed to customize the wheel building.
+-   Programs and libraries are not installed on the CI runner host, but rather should be installed inside the container - using `yum` for `manylinux2010` or `manylinux2014`, `apt-get` for `manylinux_2_24`, `dnf` for `manylinux_2_28` and `apk` for `musllinux_1_1` or `musllinux_1_2`, or manually. The same goes for environment variables that are potentially needed to customize the wheel building.
 
     `cibuildwheel` supports this by providing the [`CIBW_ENVIRONMENT`](options.md#environment) and [`CIBW_BEFORE_ALL`](options.md#before-all) options to setup the build environment inside the running container.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1056,11 +1056,11 @@ The available options are (default value):
 - `CIBW_MANYLINUX_S390X_IMAGE` ([`quay.io/pypa/manylinux2014_s390x`](https://quay.io/pypa/manylinux2014_s390x))
 - `CIBW_MANYLINUX_PYPY_AARCH64_IMAGE` ([`quay.io/pypa/manylinux2014_aarch64`](https://quay.io/pypa/manylinux2014_aarch64))
 - `CIBW_MANYLINUX_PYPY_I686_IMAGE` ([`quay.io/pypa/manylinux2014_i686`](https://quay.io/pypa/manylinux2014_i686))
-- `CIBW_MUSLLINUX_X86_64_IMAGE` ([`quay.io/pypa/musllinux_1_1_x86_64`](https://quay.io/pypa/musllinux_1_1_x86_64))
-- `CIBW_MUSLLINUX_I686_IMAGE` ([`quay.io/pypa/musllinux_1_1_i686`](https://quay.io/pypa/musllinux_1_1_i686))
-- `CIBW_MUSLLINUX_AARCH64_IMAGE` ([`quay.io/pypa/musllinux_1_1_aarch64`](https://quay.io/pypa/musllinux_1_1_aarch64))
-- `CIBW_MUSLLINUX_PPC64LE_IMAGE` ([`quay.io/pypa/musllinux_1_1_ppc64le`](https://quay.io/pypa/musllinux_1_1_ppc64le))
-- `CIBW_MUSLLINUX_S390X_IMAGE` ([`quay.io/pypa/musllinux_1_1_s390x`](https://quay.io/pypa/musllinux_1_1_s390x))
+- `CIBW_MUSLLINUX_X86_64_IMAGE` ([`quay.io/pypa/musllinux_1_2_x86_64`](https://quay.io/pypa/musllinux_1_2_x86_64))
+- `CIBW_MUSLLINUX_I686_IMAGE` ([`quay.io/pypa/musllinux_1_2_i686`](https://quay.io/pypa/musllinux_1_2_i686))
+- `CIBW_MUSLLINUX_AARCH64_IMAGE` ([`quay.io/pypa/musllinux_1_2_aarch64`](https://quay.io/pypa/musllinux_1_2_aarch64))
+- `CIBW_MUSLLINUX_PPC64LE_IMAGE` ([`quay.io/pypa/musllinux_1_2_ppc64le`](https://quay.io/pypa/musllinux_1_2_ppc64le))
+- `CIBW_MUSLLINUX_S390X_IMAGE` ([`quay.io/pypa/musllinux_1_2_s390x`](https://quay.io/pypa/musllinux_1_2_s390x))
 
 Set an alternative Docker image to be used for building [manylinux / musllinux](https://github.com/pypa/manylinux) wheels.
 
@@ -1071,7 +1071,7 @@ For `CIBW_MUSLLINUX_*_IMAGE`, the value of this option can either be set to `mus
 
 If this option is blank, it will fall though to the next available definition (environment variable -> pyproject.toml -> default).
 
-If setting a custom image, you'll need to make sure it can be used in the same way as the default images: all necessary Python and pip versions need to be present in `/opt/python/`, and the auditwheel tool needs to be present for cibuildwheel to work. Apart from that, the architecture and relevant shared system libraries need to be compatible to the relevant standard to produce valid manylinux1/manylinux2010/manylinux2014/manylinux_2_24/manylinux_2_28/musllinux_1_1 wheels (see [pypa/manylinux on GitHub](https://github.com/pypa/manylinux), [PEP 513](https://www.python.org/dev/peps/pep-0513/), [PEP 571](https://www.python.org/dev/peps/pep-0571/), [PEP 599](https://www.python.org/dev/peps/pep-0599/), [PEP 600](https://www.python.org/dev/peps/pep-0600/) and [PEP 656](https://www.python.org/dev/peps/pep-0656/) for more details).
+If setting a custom image, you'll need to make sure it can be used in the same way as the default images: all necessary Python and pip versions need to be present in `/opt/python/`, and the auditwheel tool needs to be present for cibuildwheel to work. Apart from that, the architecture and relevant shared system libraries need to be compatible to the relevant standard to produce valid manylinux1/manylinux2010/manylinux2014/manylinux_2_24/manylinux_2_28/musllinux_1_1/musllinux_1_2 wheels (see [pypa/manylinux on GitHub](https://github.com/pypa/manylinux), [PEP 513](https://www.python.org/dev/peps/pep-0513/), [PEP 571](https://www.python.org/dev/peps/pep-0571/), [PEP 599](https://www.python.org/dev/peps/pep-0599/), [PEP 600](https://www.python.org/dev/peps/pep-0600/) and [PEP 656](https://www.python.org/dev/peps/pep-0656/) for more details).
 
 Auditwheel detects the version of the manylinux / musllinux standard in the image through the `AUDITWHEEL_PLAT` environment variable, as cibuildwheel has no way of detecting the correct `--plat` command line argument to pass to auditwheel for a custom image. If a custom image does not correctly set this `AUDITWHEEL_PLAT` environment variable, the `CIBW_ENVIRONMENT` option can be used to do so (e.g., `CIBW_ENVIRONMENT='AUDITWHEEL_PLAT="manylinux2010_$(uname -m)"'`).
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1102,6 +1102,10 @@ Auditwheel detects the version of the manylinux / musllinux standard in the imag
     # Build using a different image from the docker registry
     CIBW_MANYLINUX_X86_64_IMAGE: dockcross/manylinux-x64
     CIBW_MANYLINUX_I686_IMAGE: dockcross/manylinux-x86
+
+    # Build musllinux wheels using the musllinux_1_1 image
+    CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
+    CIBW_MUSLLINUX_I686_IMAGE: musllinux_1_1
     ```
 
 !!! tab examples "pyproject.toml"
@@ -1129,6 +1133,10 @@ Auditwheel detects the version of the manylinux / musllinux standard in the imag
     # Build using a different image from the docker registry
     manylinux-x86_64-image = "dockcross/manylinux-x64"
     manylinux-i686-image = "dockcross/manylinux-x86"
+
+    # Build musllinux wheels using the musllinux_1_1 image
+    musllinux-x86_64-image = "musllinux_1_1"
+    musllinux-i686-image = "musllinux_1_1"
     ```
 
     Like any other option, these can be placed in `[tool.cibuildwheel.linux]`

--- a/test/utils.py
+++ b/test/utils.py
@@ -160,7 +160,7 @@ def expected_wheels(
             manylinux_versions = ["manylinux_2_17", "manylinux2014"]
 
     if musllinux_versions is None:
-        musllinux_versions = ["musllinux_1_1"]
+        musllinux_versions = ["musllinux_1_2"]
 
     if python_abi_tags is None:
         python_abi_tags = [

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -86,7 +86,7 @@ def test_build_default_launches(monkeypatch):
     assert identifiers == {f"{x}-manylinux_i686" for x in ALL_IDS}
 
     kwargs = build_in_container.call_args_list[2][1]
-    assert "quay.io/pypa/musllinux_1_1_x86_64" in kwargs["container"]["image"]
+    assert "quay.io/pypa/musllinux_1_2_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["container"]["enforce_32_bit"]
 
@@ -96,7 +96,7 @@ def test_build_default_launches(monkeypatch):
     }
 
     kwargs = build_in_container.call_args_list[3][1]
-    assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["container"]["image"]
+    assert "quay.io/pypa/musllinux_1_2_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
     assert kwargs["container"]["enforce_32_bit"]
 
@@ -197,7 +197,7 @@ before-all = "true"
     }
 
     kwargs = build_in_container.call_args_list[6][1]
-    assert "quay.io/pypa/musllinux_1_1_i686" in kwargs["container"]["image"]
+    assert "quay.io/pypa/musllinux_1_2_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
     assert kwargs["container"]["enforce_32_bit"]
 


### PR DESCRIPTION
Statistics for musl (mostly Alpine but also some OpenWRT)

BigQuery sql query:
```sql
SELECT
  details.distro.name as distro_name,
  details.distro.version as distro_version,
  details.distro.libc.lib as libc_name,
  details.distro.libc.version as libc_version,
  COUNT(*) as download_count,
FROM `bigquery-public-data.pypi.file_downloads`
WHERE timestamp BETWEEN TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -6 DAY) AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)
  AND details.installer.name = "pip"
  AND details.system.name = "Linux"
  AND file.filename LIKE "%musllinux%"
  AND (details.distro.libc.lib IS NULL OR details.distro.libc.lib != "glibc")
GROUP BY
  distro_name, distro_version, libc_name, libc_version
ORDER BY
  download_count DESC
LIMIT 100
```

Once [reduced](https://docs.google.com/spreadsheets/d/1FHOYgutOLUzZZHjbuDJYsGxIDKsjiUd_47CXzxJ13gE/edit?usp=sharing), this gives:

| version | percentage |
| ------------- | ------- | 
| musllinux_1_2 | 97.5 % |
| musllinux_1_1 | 2.5 % |

If we omit the filter on musllinux wheel downloads, this gives:

| version | percentage |
| ------------- | ------- | 
| musllinux_1_2 | 90.5 % |
| musllinux_1_1 | 9.5 % |

It's worth noting that musl libc 1.1 is EOL and Alpine Linux 3.12 also (support ended 2 years ago, 01 May 2022)