### PR TITLE
fix: do not pre-seed setuptools / wheel in virtual environment

### DIFF
--- a/cibuildwheel/resources/constraints-python36.txt
+++ b/cibuildwheel/resources/constraints-python36.txt
@@ -48,3 +48,5 @@ zipp==3.6.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.3.1
     # via -r cibuildwheel/resources/constraints.in
+setuptools==59.6.0
+    # via -r cibuildwheel/resources/constraints.in

--- a/test/test_abi_variants.py
+++ b/test/test_abi_variants.py
@@ -4,6 +4,12 @@ import textwrap
 
 from . import test_projects, utils
 
+pyproject_toml = r"""
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+"""
+
 limited_api_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(
         r"""
@@ -29,6 +35,8 @@ limited_api_project = test_projects.new_c_project(
     setup_py_extension_args_add="**extension_kwargs",
     setup_py_setup_args_add="cmdclass=cmdclass",
 )
+
+limited_api_project.files["pyproject.toml"] = pyproject_toml
 
 
 def test_abi3(tmp_path):
@@ -154,6 +162,8 @@ ctypes_project.files["test/add_test.py"] = textwrap.dedent(
         assert ctypesexample.summing.add(a, b) == [5, 7, 9]
     """
 )
+
+ctypes_project.files["pyproject.toml"] = pyproject_toml
 
 
 def test_abi_none(tmp_path, capfd):


### PR DESCRIPTION
Since https://github.com/pypa/cibuildwheel/commit/9879937c6374b3fa6c29a578be3170751d61b80b, setuptools & wheel are not pinned/installed anymore.
We should not pre-seed the virtual environment with those either.
