### PR TITLE
docs: fix options page

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,5 +11,5 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - uv pip install .[docs]
-    - .venv/bin/python -m mkdocs build --site-dir $READTHEDOCS_OUTPUT/html
+    - uv pip install -e.[docs]
+    - . .venv/bin/activate && mkdocs build --strict --verbose --site-dir $READTHEDOCS_OUTPUT/html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,3 +49,5 @@ plugins:
       module_name: docs/main
       j2_variable_start_string: «
       j2_variable_end_string: »
+      on_error_fail: true
+      on_undefined: strict

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,7 +133,7 @@ def docs(session: nox.Session) -> None:
     Build the docs. Will serve unless --non-interactive
     """
     session.install("-e.[docs]")
-    session.run("mkdocs", "serve" if session.interactive else "build")
+    session.run("mkdocs", "serve" if session.interactive else "build", "--strict", *session.posargs)
 
 
 @nox.session


### PR DESCRIPTION
The options page is broken, and mkdocs "helpfully" hides errors and just puts them on the output page!

MkDocs macros breaks if the Python environment isn't activated. ¯\_(ツ)_/¯
