### PR TITLE
fix(tests): linux tests from macOS/Windows arm64

### DIFF
--- a/test/test_macos_archs.py
+++ b/test/test_macos_archs.py
@@ -202,13 +202,15 @@ def test_universal2_testing_on_arm64(tmp_path, capfd):
     assert set(actual_wheels) == set(expected_wheels)
 
 
-def test_cp38_arm64_testing(tmp_path, capfd):
+def test_cp38_arm64_testing(tmp_path, capfd, request):
     if utils.platform != "macos":
         pytest.skip("this test is only relevant to macos")
     if get_xcode_version() < (12, 2):
         pytest.skip("this test only works with Xcode 12.2 or greater")
     if platform.machine() != "arm64":
         pytest.skip("this test only works on arm64")
+    if request.config.getoption("--run-cp38-universal2"):
+        pytest.skip("--run-cp38-universal2 option skips this test")
 
     project_dir = tmp_path / "project"
     basic_project.generate(project_dir)

--- a/test/utils.py
+++ b/test/utils.py
@@ -147,6 +147,9 @@ def expected_wheels(
 
     if machine_arch is None:
         machine_arch = pm.machine()
+        if platform == "linux" and machine_arch.lower() == "arm64":
+            # we're running linux tests from macOS/Windows arm64, override platform
+            machine_arch = "aarch64"
 
     if manylinux_versions is None:
         if machine_arch == "x86_64":


### PR DESCRIPTION
When running on arm64, macOS reports machine as `arm64` and Windows as `ARM64`. We need to override this to `aarch64` when running linux tests.