### PR TITLE
chore: un-pin virtualenv update

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -181,7 +181,9 @@ def setup_python(
 
     log.step("Setting up build environment...")
     venv_path = tmp / "venv"
-    env = virtualenv(base_python, venv_path, dependency_constraint_flags)
+    env = virtualenv(
+        python_configuration.version, base_python, venv_path, dependency_constraint_flags
+    )
     venv_bin_path = venv_path / "bin"
     assert venv_bin_path.exists()
     # Fix issue with site.py setting the wrong `sys.prefix`, `sys.exec_prefix`,

--- a/cibuildwheel/resources/virtualenv.toml
+++ b/cibuildwheel/resources/virtualenv.toml
@@ -1,2 +1,2 @@
-version = "20.21.1"
-url = "https://github.com/pypa/get-virtualenv/blob/20.21.1/public/virtualenv.pyz?raw=true"
+py36 = { version = "20.21.1", url = "https://github.com/pypa/get-virtualenv/blob/20.21.1/public/virtualenv.pyz?raw=true" }
+default = { version = "20.26.2", url = "https://github.com/pypa/get-virtualenv/blob/20.26.2/public/virtualenv.pyz?raw=true" }

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -246,7 +246,9 @@ def setup_python(
 
     log.step("Setting up build environment...")
     venv_path = tmp / "venv"
-    env = virtualenv(base_python, venv_path, dependency_constraint_flags)
+    env = virtualenv(
+        python_configuration.version, base_python, venv_path, dependency_constraint_flags
+    )
 
     # set up environment variables for run_with_env
     env["PYTHON_VERSION"] = python_configuration.version

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -111,7 +111,6 @@ def test_dependency_constraints_file(tmp_path, build_frontend_env):
             """
             pip=={pip}
             delocate=={delocate}
-            importlib-metadata<3,>=0.12; python_version < "3.8"
             """.format(**tool_versions)
         )
     )


### PR DESCRIPTION
virtualenv has been pinned to 20.21.1 in order to be able to create python 3.6 venvs.

This commit allows to pin virtualenv for given versions of pythons which in turns re-allows updates as a default.