### PR TITLE
chore(tests): do not use hard-coded paths in tests

### DIFF
--- a/test/test_before_build.py
+++ b/test/test_before_build.py
@@ -14,26 +14,21 @@ project_with_before_build_asserts = test_projects.new_c_project(
 
         # assert that the Python version as written to pythonversion_bb.txt in the CIBW_BEFORE_BUILD step
         # is the same one as is currently running.
-        version_file = 'c:\\pythonversion_bb.txt' if sys.platform == 'win32' else '/tmp/pythonversion_bb.txt'
-        with open(version_file) as f:
+        with open('pythonversion_bb.txt') as f:
             stored_version = f.read()
         print('stored_version', stored_version)
         print('sys.version', sys.version)
         assert stored_version == sys.version
 
-        # check that the executable also was written
-        executable_file = 'c:\\pythonexecutable_bb.txt' if sys.platform == 'win32' else '/tmp/pythonexecutable_bb.txt'
-        with open(executable_file) as f:
-            stored_executable = f.read()
-        print('stored_executable', stored_executable)
-        print('sys.executable', sys.executable)
+        # check that the prefix also was written
+        with open('pythonprefix_bb.txt') as f:
+            stored_prefix = f.read()
+        print('stored_prefix', stored_prefix)
+        print('sys.prefix', sys.prefix)
+        #  Works around path-comparison bugs caused by short-paths on Windows e.g.
+        #  vssadm~1 instead of vssadministrator
 
-        # windows/mac are case insensitive
-        stored_path = os.path.realpath(stored_executable).lower()
-        current_path = os.path.realpath(sys.executable).lower()
-
-        # TODO: This is not valid in an virtual environment
-        assert stored_path == current_path, '{0} != {1}'.format(stored_path, current_path)
+        assert os.stat(stored_prefix) == os.stat(sys.prefix)
         """
     )
 )
@@ -44,8 +39,8 @@ def test(tmp_path):
     project_with_before_build_asserts.generate(project_dir)
 
     before_build = (
-        """python -c "import sys; open('{output_dir}pythonversion_bb.txt', 'w').write(sys.version)" && """
-        '''python -c "import sys; open('{output_dir}pythonexecutable_bb.txt', 'w').write(sys.executable)"'''
+        """python -c "import sys; open('{project}/pythonversion_bb.txt', 'w').write(sys.version)" && """
+        '''python -c "import sys; open('{project}/pythonprefix_bb.txt', 'w').write(sys.prefix)"'''
     )
 
     # build the wheels
@@ -54,8 +49,7 @@ def test(tmp_path):
         add_env={
             # write python version information to a temporary file, this is
             # checked in setup.py
-            "CIBW_BEFORE_BUILD": before_build.format(output_dir="/tmp/"),
-            "CIBW_BEFORE_BUILD_WINDOWS": before_build.format(output_dir=r"c:\\"),
+            "CIBW_BEFORE_BUILD": before_build,
         },
     )
 

--- a/test/test_before_build.py
+++ b/test/test_before_build.py
@@ -28,7 +28,7 @@ project_with_before_build_asserts = test_projects.new_c_project(
         #  Works around path-comparison bugs caused by short-paths on Windows e.g.
         #  vssadm~1 instead of vssadministrator
 
-        assert os.stat(stored_prefix) == os.stat(sys.prefix)
+        assert os.path.samefile(stored_prefix, sys.prefix)
         """
     )
 )

--- a/test/test_before_test.py
+++ b/test/test_before_test.py
@@ -30,7 +30,7 @@ class TestBeforeTest(TestCase):
         #  Works around path-comparison bugs caused by short-paths on Windows e.g.
         #  vssadm~1 instead of vssadministrator
 
-        assert os.stat(stored_prefix) == os.stat(sys.prefix)
+        assert os.path.samefile(stored_prefix, sys.prefix)
 """
 
 

--- a/test/test_before_test.py
+++ b/test/test_before_test.py
@@ -6,7 +6,10 @@ before_test_project = test_projects.new_c_project()
 before_test_project.files["test/spam_test.py"] = r"""
 import sys
 import os
+from pathlib import Path
 from unittest import TestCase
+
+PROJECT_DIR = Path(__file__).joinpath("..", "..").resolve()
 
 
 class TestBeforeTest(TestCase):
@@ -14,18 +17,14 @@ class TestBeforeTest(TestCase):
         # assert that the Python version as written to pythonversion_bt.txt in the CIBW_BEFORE_TEST step
         # is the same one as is currently running.
         # because of use symlinks in MacOS run this test is also need
-        version_file = 'c:\\pythonversion_bt.txt' if sys.platform == 'win32' else '/tmp/pythonversion_bt.txt'
-        with open(version_file) as f:
-            stored_version = f.read()
+        stored_version = PROJECT_DIR.joinpath('pythonversion_bt.txt').read_text()
         print('stored_version', stored_version)
         print('sys.version', sys.version)
         assert stored_version == sys.version
 
     def test_prefix(self):
         # check that the prefix also was written
-        prefix_file = 'c:\\pythonprefix_bt.txt' if sys.platform == 'win32' else '/tmp/pythonprefix_bt.txt'
-        with open(prefix_file) as f:
-            stored_prefix = f.read()
+        stored_prefix = PROJECT_DIR.joinpath('pythonprefix_bt.txt').read_text()
         print('stored_prefix', stored_prefix)
         print('sys.prefix', sys.prefix)
         #  Works around path-comparison bugs caused by short-paths on Windows e.g.
@@ -41,14 +40,19 @@ def test(tmp_path):
     test_project_dir = project_dir / "dependency"
     test_projects.new_c_project().generate(test_project_dir)
 
+    before_test = (
+        """python -c "import os, sys; open('{project}/pythonversion_bt.txt', 'w').write(sys.version)" && """
+        """python -c "import os, sys; open('{project}/pythonprefix_bt.txt', 'w').write(sys.prefix)" && """
+        """python -m pip install {project}/dependency"""
+    )
+
     # build the wheels
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
         add_env={
             # write python version information to a temporary file, this is
             # checked in setup.py
-            "CIBW_BEFORE_TEST": """python -c "import sys; open('/tmp/pythonversion_bt.txt', 'w').write(sys.version)" && python -c "import sys; open('/tmp/pythonprefix_bt.txt', 'w').write(sys.prefix)" && python -m pip install {project}/dependency""",
-            "CIBW_BEFORE_TEST_WINDOWS": """python -c "import sys; open('c:\\pythonversion_bt.txt', 'w').write(sys.version)" && python -c "import sys; open('c:\\pythonprefix_bt.txt', 'w').write(sys.prefix)" && python -m pip install {project}/dependency""",
+            "CIBW_BEFORE_TEST": before_test,
             "CIBW_TEST_REQUIRES": "pytest",
             # the 'false ||' bit is to ensure this command runs in a shell on
             # mac/linux.


### PR DESCRIPTION
This would help reduce the amount of specific code for pyodide in #1456 

