### PR TITLE
chore: better determinism for the test virtual environment

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -337,7 +337,7 @@ def build_in_container(
             # Use embedded dependencies from virtualenv to ensure determinism
             venv_args = ["--no-periodic-update", "--pip=embed"]
             # In Python<3.12, setuptools & wheel are installed as well
-            if Version(config.version) < Version("3.12.0a0"):
+            if Version(config.version) < Version("3.12"):
                 venv_args.extend(("--setuptools=embed", "--wheel=embed"))
             container.call(["python", "-m", "virtualenv", *venv_args, venv_dir], env=env)
 

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Literal, Tuple
 
 from filelock import FileLock
+from packaging.version import Version
 
 from ._compat.typing import assert_never
 from .architecture import Architecture
@@ -359,6 +360,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_options.environment,
                 build_frontend.name,
             )
+            pip_version = get_pip_version(env)
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
             if compatible_wheel:
@@ -384,7 +386,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 extra_flags += build_frontend.args
 
                 build_env = env.copy()
-                build_env["VIRTUALENV_PIP"] = get_pip_version(env)
+                build_env["VIRTUALENV_PIP"] = pip_version
                 if build_options.dependency_constraints:
                     constraint_path = build_options.dependency_constraints.get_for_python_version(
                         config.version
@@ -560,9 +562,12 @@ def build(options: Options, tmp_path: Path) -> None:
                     call_with_arch = functools.partial(call, *arch_prefix)
                     shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")
 
-                    # Use --no-download to ensure determinism by using seed libraries
-                    # built into virtualenv
-                    call_with_arch("python", "-m", "virtualenv", "--no-download", venv_dir, env=env)
+                    # Use pip version from the initial env to ensure determinism
+                    venv_args = ["--no-periodic-update", f"--pip={pip_version}"]
+                    # In Python<3.12, setuptools & wheel are installed as well, use virtualenv embedded ones
+                    if Version(config.version) < Version("3.12.0a0"):
+                        venv_args.extend(("--setuptools=embed", "--wheel=embed"))
+                    call_with_arch("python", "-m", "virtualenv", *venv_args, venv_dir, env=env)
 
                     virtualenv_env = env.copy()
                     virtualenv_env["PATH"] = os.pathsep.join(
@@ -574,10 +579,6 @@ def build(options: Options, tmp_path: Path) -> None:
 
                     # check that we are using the Python from the virtual environment
                     call_with_arch("which", "python", env=virtualenv_env)
-
-                    # TODO remove me once virtualenv provides pip>=24.1b1
-                    if config.version == "3.13":
-                        call("python", "-m", "pip", "install", "pip>=24.1b1", env=virtualenv_env)
 
                     if build_options.before_test:
                         before_test_prepared = prepare_command(

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -565,7 +565,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     # Use pip version from the initial env to ensure determinism
                     venv_args = ["--no-periodic-update", f"--pip={pip_version}"]
                     # In Python<3.12, setuptools & wheel are installed as well, use virtualenv embedded ones
-                    if Version(config.version) < Version("3.12.0a0"):
+                    if Version(config.version) < Version("3.12"):
                         venv_args.extend(("--setuptools=embed", "--wheel=embed"))
                     call_with_arch("python", "-m", "virtualenv", *venv_args, venv_dir, env=env)
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -387,6 +387,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_options.environment,
                 build_frontend.name,
             )
+            pip_version = get_pip_version(env)
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
             if compatible_wheel:
@@ -415,7 +416,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 extra_flags += build_frontend.args
 
                 build_env = env.copy()
-                build_env["VIRTUALENV_PIP"] = get_pip_version(env)
+                build_env["VIRTUALENV_PIP"] = pip_version
                 if build_options.dependency_constraints:
                     constraints_path = build_options.dependency_constraints.get_for_python_version(
                         config.version
@@ -511,9 +512,12 @@ def build(options: Options, tmp_path: Path) -> None:
                 call("pip", "install", "virtualenv", *dependency_constraint_flags, env=env)
                 venv_dir = identifier_tmp_dir / "venv-test"
 
-                # Use --no-download to ensure determinism by using seed libraries
-                # built into virtualenv
-                call("python", "-m", "virtualenv", "--no-download", venv_dir, env=env)
+                # Use pip version from the initial env to ensure determinism
+                venv_args = ["--no-periodic-update", f"--pip={pip_version}"]
+                # In Python<3.12, setuptools & wheel are installed as well, use virtualenv embedded ones
+                if Version(config.version) < Version("3.12.0a0"):
+                    venv_args.extend(("--setuptools=embed", "--wheel=embed"))
+                call("python", "-m", "virtualenv", *venv_args, venv_dir, env=env)
 
                 virtualenv_env = env.copy()
                 virtualenv_env["PATH"] = os.pathsep.join(
@@ -525,10 +529,6 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 # check that we are using the Python from the virtual environment
                 call("where", "python", env=virtualenv_env)
-
-                # TODO remove me once virtualenv provides pip>=24.1b1
-                if config.version.startswith("3.13."):
-                    call("python", "-m", "pip", "install", "--pre", "-U", "pip", env=virtualenv_env)
 
                 if build_options.before_test:
                     before_test_prepared = prepare_command(

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -515,7 +515,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 # Use pip version from the initial env to ensure determinism
                 venv_args = ["--no-periodic-update", f"--pip={pip_version}"]
                 # In Python<3.12, setuptools & wheel are installed as well, use virtualenv embedded ones
-                if Version(config.version) < Version("3.12.0a0"):
+                if Version(config.version) < Version("3.12"):
                     venv_args.extend(("--setuptools=embed", "--wheel=embed"))
                 call("python", "-m", "virtualenv", *venv_args, venv_dir, env=env)
 


### PR DESCRIPTION
While reviewing #1456, the way that the test virtual environment was seeded was bugging me.

We're not really enforcing anything other than "do not download something new" but, it did not prevent using some version already in virtualenv cache (unlikely in CI but still possible, more likely for local builds).

This PR ensures that the test virtual environment gets seeded with determinism w.r.t. pip, setuptools & wheel versions.