### PR TITLE
chore(ci): split emulation tests per architecture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       run: pipx run nox -s pylint -- --output-format=github
 
   test:
-    name: Test cibuildwheel on ${{ matrix.os }} (${{ matrix.python_version }})
+    name: Test on ${{ matrix.os }} (${{ matrix.python_version }})
     needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
@@ -125,19 +125,41 @@ jobs:
       run: |
         python ./bin/run_tests.py --run-podman
 
-  test-emulated:
-    name: Test emulated cibuildwheel using qemu
+  emulated-archs:
+    name: Get qemu emulated architectures
     needs: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    outputs:
+      archs: ${{ steps.archs.outputs.archs }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install dependencies
+      run: python -m pip install ".[test]"
+    - name: Get qemu emulated architectures
+      id: archs
       run: |
-        python -m pip install ".[test]"
+        OUTPUT=$(python -c "from json import dumps; from test.utils import EMULATED_ARCHS; print(dumps(EMULATED_ARCHS))")
+        echo "${OUTPUT}"
+        echo "archs=${OUTPUT}" >> "$GITHUB_OUTPUT"
+
+  test-emulated:
+    name: Test Linux ${{ matrix.arch }} using qemu
+    needs: emulated-archs
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(needs.emulated-archs.outputs.archs) }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: python -m pip install ".[test]"
 
     - name: Set up QEMU
       id: qemu
@@ -146,5 +168,4 @@ jobs:
         platforms: all
 
     - name: Run the emulation tests
-      run: |
-        pytest --run-emulation test/test_emulation.py
+      run: pytest --run-emulation ${{ matrix.arch }} test/test_emulation.py

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,12 +8,16 @@ import pytest
 
 from cibuildwheel.util import detect_ci_provider
 
-from .utils import platform
+from .utils import EMULATED_ARCHS, platform
 
 
 def pytest_addoption(parser) -> None:
     parser.addoption(
-        "--run-emulation", action="store_true", default=False, help="run emulation tests"
+        "--run-emulation",
+        action="store",
+        default=None,
+        help="run emulation tests",
+        choices=("all", *EMULATED_ARCHS),
     )
     parser.addoption("--run-podman", action="store_true", default=False, help="run podman tests")
     parser.addoption(

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,8 +13,12 @@ import sys
 from tempfile import TemporaryDirectory
 from typing import Final
 
+from cibuildwheel.architecture import Architecture
 from cibuildwheel.util import CIBW_CACHE_PATH
 
+EMULATED_ARCHS: Final[list[str]] = sorted(
+    arch.value for arch in (Architecture.all_archs("linux") - Architecture.auto_archs("linux"))
+)
 SINGLE_PYTHON_VERSION: Final[tuple[int, int]] = (3, 12)
 
 platform: str
@@ -154,6 +158,7 @@ def expected_wheels(
     python_abi_tags=None,
     include_universal2=False,
     single_python=False,
+    single_arch=False,
 ):
     """
     Returns a list of expected wheels from a run of cibuildwheel.
@@ -237,7 +242,7 @@ def expected_wheels(
         if platform == "linux":
             architectures = [arch_name_for_linux(machine_arch)]
 
-            if machine_arch == "x86_64":
+            if machine_arch == "x86_64" and not single_arch:
                 architectures.append("i686")
 
             if len(manylinux_versions) > 0:


### PR DESCRIPTION
Just to get a faster GHA overall result.
This also allows to run selected architecture locally if need be.