### PR TITLE
fix: include VIRTUAL_ENV variable

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -343,6 +343,7 @@ def build_in_container(
 
             virtualenv_env = env.copy()
             virtualenv_env["PATH"] = f"{venv_dir / 'bin'}:{virtualenv_env['PATH']}"
+            virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
             # TODO remove me once virtualenv provides pip>=24.1b1
             if config.version == "3.13":

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -576,6 +576,7 @@ def build(options: Options, tmp_path: Path) -> None:
                             virtualenv_env["PATH"],
                         ]
                     )
+                    virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
                     # check that we are using the Python from the virtual environment
                     call_with_arch("which", "python", env=virtualenv_env)

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -353,6 +353,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         virtualenv_env["PATH"],
                     ]
                 )
+                virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
                 # check that we are using the Python from the virtual environment
                 call("which", "python", env=virtualenv_env)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -700,6 +700,7 @@ def virtualenv(
     paths = [str(venv_path), str(venv_path / "Scripts")] if IS_WIN else [str(venv_path / "bin")]
     env = os.environ.copy()
     env["PATH"] = os.pathsep.join([*paths, env["PATH"]])
+    env["VIRTUAL_ENV"] = str(venv_path)
     return env
 
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -521,6 +521,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         virtualenv_env["PATH"],
                     ]
                 )
+                virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
                 # check that we are using the Python from the virtual environment
                 call("where", "python", env=virtualenv_env)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -58,6 +58,7 @@ class TestSpam(TestCase):
 
         self.assertTrue(path_contains(sys.prefix, sys.executable))
         self.assertTrue(path_contains(sys.prefix, spam.__file__))
+        self.assertIn("VIRTUAL_ENV", os.environ)
 
     def test_uname(self):
         if platform.system() == "Windows":


### PR DESCRIPTION
Include the `VIRTUAL_ENV` variable when running "in" a virtualenv. This will be useful when we start trying out uv.