### PR TITLE
Handle case where output_dir does not already exist on macos & windows

### DIFF
--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -641,8 +641,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                with contextlib.suppress(FileNotFoundError):
-                    (build_options.output_dir / repaired_wheel.name).unlink()
+                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -640,7 +640,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
+                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 import os
 import platform

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -640,10 +640,16 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
+                output_dir = build_options.output_dir.resolve()
+                output_wheel = output_dir.joinpath(repaired_wheel.name).resolve()
+                output_wheel.unlink(missing_ok=True)
 
-                shutil.move(str(repaired_wheel), build_options.output_dir)
-                built_wheels.append(build_options.output_dir / repaired_wheel.name)
+                # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
+                output_dir.mkdir(parents=True, exist_ok=True)
+                
+                # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
+                shutil.move(repaired_wheel, output_wheel)
+                built_wheels.append(output_wheel)
 
             # clean up
             shutil.rmtree(identifier_tmp_dir)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -644,13 +644,13 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_wheel = output_dir.joinpath(repaired_wheel.name).resolve()
                 output_wheel.unlink(missing_ok=True)
 
-                # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
+                # shutil.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-                # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
+                # using shutil.move() as Path.rename() is not guaranteed to work across filesystem boundaries
                 shutil.move(
                     str(repaired_wheel), str(output_wheel)
-                )  # explicit str() needed for mypy3.8
+                )  # explicit str() needed for Python 3.8 - can change to Paths when we drop 3.8 support
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -648,9 +648,8 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using shutil.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(
-                    str(repaired_wheel), str(output_wheel)
-                )  # explicit str() needed for Python 3.8 - can change to Paths when we drop 3.8 support
+                # explicit str() needed for Python 3.8
+                shutil.move(str(repaired_wheel), str(output_wheel))
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -646,7 +646,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
                 output_dir.mkdir(parents=True, exist_ok=True)
-                
+
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
                 shutil.move(repaired_wheel, output_wheel)
                 built_wheels.append(output_wheel)

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -648,7 +648,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(repaired_wheel, output_wheel)
+                shutil.move(str(repaired_wheel), str(output_wheel)) # explicit str() needed for mypy3.8
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -648,7 +648,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(str(repaired_wheel), str(output_wheel)) # explicit str() needed for mypy3.8
+                shutil.move(
+                    str(repaired_wheel), str(output_wheel)
+                )  # explicit str() needed for mypy3.8
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -644,7 +644,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
                 moved_wheel = move_file(repaired_wheel, output_wheel)
                 if moved_wheel != output_wheel.resolve():
-                    log.warning("{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}")
+                    log.warning(
+                        "{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
+                    )
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -395,8 +395,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                with contextlib.suppress(FileNotFoundError):
-                    (build_options.output_dir / repaired_wheel.name).unlink()
+                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import shutil
 import sys

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -394,7 +394,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
+                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -26,6 +26,7 @@ from .util import (
     extract_zip,
     find_compatible_wheel,
     get_pip_version,
+    move_file,
     prepare_command,
     read_python_configs,
     shell,
@@ -394,9 +395,11 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (overwrite existing)
             if compatible_wheel is None:
-                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
+                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
+                moved_wheel = move_file(repaired_wheel, output_wheel)
+                if moved_wheel != output_wheel.resolve():
+                    log.warning("{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}")
+                built_wheels.append(output_wheel)
 
-                shutil.move(str(repaired_wheel), build_options.output_dir)
-                built_wheels.append(build_options.output_dir / repaired_wheel.name)
     finally:
         pass

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -398,7 +398,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
                 moved_wheel = move_file(repaired_wheel, output_wheel)
                 if moved_wheel != output_wheel.resolve():
-                    log.warning("{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}")
+                    log.warning(
+                        "{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
+                    )
                 built_wheels.append(output_wheel)
 
     finally:

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -382,7 +382,8 @@ def move_file(src_file: Path, dst_file: Path) -> Path:
 
     if dst_file.is_dir():
         # Cannot overwrite a directory with a file
-        raise IsADirectoryError
+        msg = "dst_file must be a valid target filename, not an existing directory."
+        raise IsADirectoryError(msg)
     dst_file.unlink(missing_ok=True)
     dst_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -381,7 +381,6 @@ def move_file(src_file: Path, dst_file: Path) -> Path:
     dst_file = dst_file.resolve()
 
     if dst_file.is_dir():
-        # Cannot overwrite a directory with a file
         msg = "dst_file must be a valid target filename, not an existing directory."
         raise IsADirectoryError(msg)
     dst_file.unlink(missing_ok=True)

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -362,7 +362,7 @@ def extract_tar(tar_src: Path, dest: Path) -> None:
 
 def move_file(src_file: Path, dst_file: Path) -> Path:
     """Moves a file safely while avoiding potential semantic confusion:
-     
+
     1. `dst_file` must point to the target filename, not a directory
     2. `dst_file` will be overwritten if it already exists
     3. any missing parent directories will be created
@@ -373,7 +373,7 @@ def move_file(src_file: Path, dst_file: Path) -> Path:
         NotADirectoryError: If any part of the intermediate path to `dst_file` is an existing file
         IsADirectoryError: If `dst_file` points directly to an existing directory
     """
-    
+
     # Importing here as logger needs various functions from util -> circular imports
     from .logger import log
 
@@ -392,7 +392,7 @@ def move_file(src_file: Path, dst_file: Path) -> Path:
     resulting_file = Path(resulting_file).resolve()
     log.notice(f"Moved {src_file} to {resulting_file}")
     return Path(resulting_file)
-    
+
 
 class DependencyConstraints:
     def __init__(self, base_file_path: Path):

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 import textwrap
 from collections.abc import MutableMapping, Sequence, Set
-from contextlib import suppress
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -542,7 +542,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (remove if already exists)
             if compatible_wheel is None:
-                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
+                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -543,8 +543,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (remove if already exists)
             if compatible_wheel is None:
-                with suppress(FileNotFoundError):
-                    (build_options.output_dir / repaired_wheel.name).unlink()
+                (build_options.output_dir / repaired_wheel.name).unlink(missing_ok=True)
 
                 shutil.move(str(repaired_wheel), build_options.output_dir)
                 built_wheels.append(build_options.output_dir / repaired_wheel.name)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -546,13 +546,13 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_wheel = output_dir.joinpath(repaired_wheel.name).resolve()
                 output_wheel.unlink(missing_ok=True)
 
-                # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
+                # shutil.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-                # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
+                # using shutil.move() as Path.rename() is not guaranteed to work across filesystem boundaries
                 shutil.move(
                     str(repaired_wheel), str(output_wheel)
-                )  # explicit str() needed for mypy3.8
+                )  # explicit str() needed for Python 3.8 - can change to Paths when we drop 3.8 support
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -542,10 +542,16 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (remove if already exists)
             if compatible_wheel is None:
-                build_options.output_dir.joinpath(repaired_wheel.name).unlink(missing_ok=True)
+                output_dir = build_options.output_dir.resolve()
+                output_wheel = output_dir.joinpath(repaired_wheel.name).resolve()
+                output_wheel.unlink(missing_ok=True)
 
-                shutil.move(str(repaired_wheel), build_options.output_dir)
-                built_wheels.append(build_options.output_dir / repaired_wheel.name)
+                # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
+                output_dir.mkdir(parents=True, exist_ok=True)
+                
+                # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
+                shutil.move(repaired_wheel, output_wheel)
+                built_wheels.append(output_wheel)
 
             # clean up
             # (we ignore errors because occasionally Windows fails to unlink a file and we

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -550,9 +550,8 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using shutil.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(
-                    str(repaired_wheel), str(output_wheel)
-                )  # explicit str() needed for Python 3.8 - can change to Paths when we drop 3.8 support
+                # explicit str() needed for Python 3.8
+                shutil.move(str(repaired_wheel), str(output_wheel))
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -548,7 +548,7 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 # os.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
                 output_dir.mkdir(parents=True, exist_ok=True)
-                
+
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
                 shutil.move(repaired_wheel, output_wheel)
                 built_wheels.append(output_wheel)

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -546,7 +546,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
                 moved_wheel = move_file(repaired_wheel, output_wheel)
                 if moved_wheel != output_wheel.resolve():
-                    log.warning("{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}")
+                    log.warning(
+                        "{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
+                    )
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -550,7 +550,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(repaired_wheel, output_wheel)
+                shutil.move(str(repaired_wheel), str(output_wheel)) # explicit str() needed for mypy3.8
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -33,6 +33,7 @@ from .util import (
     find_compatible_wheel,
     get_build_verbosity_extra_flags,
     get_pip_version,
+    move_file,
     prepare_command,
     read_python_configs,
     shell,
@@ -542,16 +543,10 @@ def build(options: Options, tmp_path: Path) -> None:
 
             # we're all done here; move it to output (remove if already exists)
             if compatible_wheel is None:
-                output_dir = build_options.output_dir.resolve()
-                output_wheel = output_dir.joinpath(repaired_wheel.name).resolve()
-                output_wheel.unlink(missing_ok=True)
-
-                # shutil.move() will rename the file to what we were expecting to be the parent directory if we don't ensure it exists
-                output_dir.mkdir(parents=True, exist_ok=True)
-
-                # using shutil.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                # explicit str() needed for Python 3.8
-                shutil.move(str(repaired_wheel), str(output_wheel))
+                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
+                moved_wheel = move_file(repaired_wheel, output_wheel)
+                if moved_wheel != output_wheel.resolve():
+                    log.warning("{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}")
                 built_wheels.append(output_wheel)
 
             # clean up

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -550,7 +550,9 @@ def build(options: Options, tmp_path: Path) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
                 # using os.move() as Path.rename() is not guaranteed to work across filesystem boundaries
-                shutil.move(str(repaired_wheel), str(output_wheel)) # explicit str() needed for mypy3.8
+                shutil.move(
+                    str(repaired_wheel), str(output_wheel)
+                )  # explicit str() needed for mypy3.8
                 built_wheels.append(output_wheel)
 
             # clean up


### PR DESCRIPTION
### [Updated 2024-06-04]

In cases where the output_dir does not already exist, the attempt to move the tested wheel to the output_dir actually ends up creating a file named `output_dir` rather than `outputdir/wheelname.whl`

This leads to the build process failing on macos and windows if the directory does not exist, or is removed as part of a before-build clean.

This PR updates the handling of the final wheels to:
1. explicitly resolve the output directory path
2. explicitly create the output directory if it does not already exist
3. then move the wheel file

It also cleans up the handling of errors by making use of built in pathlib.Path functionality rather than with contextlib.suppress

It has been tested in Github actions CI against a specific project & commit which provided a consistent, reproducible error described in #1850.

Fixes #1850 

### Original
Pathlib apparently raises a `NotADirectoryError` instead of a `FileNotFoundError` on macos. This causes builds to fail after testing if the output_dir does not already exist.

This PR fixes #1850 by using `missing_ok=True` introduced with pathlib 3.8 and trusting that Pathlib are able to handle the different errors provided on different OS.

For the sake of consistency it also updates windows and pyodide to follow the same pattern at the same point in the code.