### PR TITLE
chore: bump pyodide

### DIFF
--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -169,5 +169,5 @@ python_configurations = [
 
 [pyodide]
 python_configurations = [
-  { identifier = "cp312-pyodide_wasm32", version = "3.12.1", pyodide_version = "0.26.0", emscripten_version = "3.1.58", node_version = "v20" },
+  { identifier = "cp312-pyodide_wasm32", version = "3.12.1", pyodide_version = "0.26.1", emscripten_version = "3.1.58", node_version = "v20" },
 ]

--- a/cibuildwheel/resources/constraints-pyodide312.txt
+++ b/cibuildwheel/resources/constraints-pyodide312.txt
@@ -64,7 +64,7 @@ pydantic-core==2.18.4
     # via pydantic
 pygments==2.18.0
     # via rich
-pyodide-build==0.26.0
+pyodide-build==0.26.1
     # via -r .nox/update_constraints/tmp/constraints-pyodide.in
 pyodide-cli==0.2.3
     # via
@@ -102,12 +102,12 @@ typer==0.12.3
     #   pyodide-cli
 types-requests==2.32.0.20240602
     # via pyodide-build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   pydantic
     #   pydantic-core
     #   typer
-unearth==0.15.3
+unearth==0.15.4
     # via pyodide-build
 urllib3==2.2.1
     # via

--- a/cibuildwheel/resources/constraints-python310.txt
+++ b/cibuildwheel/resources/constraints-python310.txt
@@ -26,9 +26,9 @@ pyproject-hooks==1.1.0
     # via build
 tomli==2.0.1
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in
-zipp==3.19.1
+zipp==3.19.2
     # via importlib-metadata

--- a/cibuildwheel/resources/constraints-python311.txt
+++ b/cibuildwheel/resources/constraints-python311.txt
@@ -22,7 +22,7 @@ platformdirs==4.2.2
     # via virtualenv
 pyproject-hooks==1.1.0
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python312.txt
+++ b/cibuildwheel/resources/constraints-python312.txt
@@ -22,7 +22,7 @@ platformdirs==4.2.2
     # via virtualenv
 pyproject-hooks==1.1.0
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python313.txt
+++ b/cibuildwheel/resources/constraints-python313.txt
@@ -22,7 +22,7 @@ platformdirs==4.2.2
     # via virtualenv
 pyproject-hooks==1.1.0
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in

--- a/cibuildwheel/resources/constraints-python38.txt
+++ b/cibuildwheel/resources/constraints-python38.txt
@@ -26,9 +26,9 @@ pyproject-hooks==1.1.0
     # via build
 tomli==2.0.1
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in
-zipp==3.19.1
+zipp==3.19.2
     # via importlib-metadata

--- a/cibuildwheel/resources/constraints-python39.txt
+++ b/cibuildwheel/resources/constraints-python39.txt
@@ -26,9 +26,9 @@ pyproject-hooks==1.1.0
     # via build
 tomli==2.0.1
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in
-zipp==3.19.1
+zipp==3.19.2
     # via importlib-metadata

--- a/cibuildwheel/resources/constraints.txt
+++ b/cibuildwheel/resources/constraints.txt
@@ -22,7 +22,7 @@ platformdirs==4.2.2
     # via virtualenv
 pyproject-hooks==1.1.0
     # via build
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via delocate
 virtualenv==20.26.2
     # via -r cibuildwheel/resources/constraints.in


### PR DESCRIPTION
Bumping for pyodide 0.26.1, which contains some important fixes.

We should probably automate this. You can get the emscripten version from pyodide build, not sure if there's a better way.