### PR TITLE
tests: don't print xfails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,12 @@ Homepage = "https://github.com/pypa/cibuildwheel"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = [
+  "-rfEsX",  # TODO: replace with -ra when pytest > 8.2.2 is released
+  "--showlocals",
+  "--strict-markers",
+  "--strict-config",
+]
 junit_family = "xunit2"
 xfail_strict = true
 filterwarnings = ["error"]


### PR DESCRIPTION
These xfails are being printed as tracebacks on every test run. Since they are known to not work, let's hide them for now.
