### PR TITLE
fix: make sure pyodide works without setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,11 +24,11 @@ branding:
 runs:
   using: composite
   steps:
-    # Set up a non-EOL, cibuildwheel & pipx supported Python version
+    # Set up the version of Python that supports pyodide
     - uses: actions/setup-python@v5
       id: python
       with:
-        python-version: "3.8 - 3.12"
+        python-version: "3.12"
         update-environment: false
 
     - id: cibw

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 from collections.abc import Sequence, Set
 from dataclasses import dataclass
 from pathlib import Path
@@ -92,7 +93,11 @@ def install_xbuildenv(env: dict[str, str], pyodide_version: str) -> str:
 def get_base_python(identifier: str) -> Path:
     implementation_id = identifier.split("-")[0]
     majorminor = implementation_id[len("cp") :]
-    major_minor = f"{majorminor[0]}.{majorminor[1:]}"
+    version_info = (int(majorminor[0]), int(majorminor[1:]))
+    if version_info == sys.version_info[:2]:
+        return Path(sys.executable)
+
+    major_minor = ".".join(str(v) for v in version_info)
     python_name = f"python{major_minor}"
     which_python = shutil.which(python_name)
     if which_python is None:


### PR DESCRIPTION
Currently we are not always getting a version of Python that supports the pyodide platform in the action. This makes sure we do that.

Edit: This is not actually correct, the problem with or without this is cibuildwheel is looking for and can't find 3.12, even though it is running on 3.12. Running a setup-python (that updates the environment) before this fixes the problem. Maybe our discovery needs to be widened to include `sys.executable`?