### PR TITLE
DOC: Document macOS 3.8 arm64 workaround

### DIFF
--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -109,7 +109,7 @@ python_configurations = [
   { identifier = "cp36-macosx_x86_64", version = "3.6", url = "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg" },
   { identifier = "cp37-macosx_x86_64", version = "3.7", url = "https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg" },
   { identifier = "cp38-macosx_x86_64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
-  { identifier = "cp38-macosx_arm64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
+  { identifier = "cp38-macosx_arm64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg" },
   { identifier = "cp38-macosx_universal2", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
   { identifier = "cp39-macosx_x86_64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg" },
   { identifier = "cp39-macosx_arm64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg" },

--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -109,7 +109,7 @@ python_configurations = [
   { identifier = "cp36-macosx_x86_64", version = "3.6", url = "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg" },
   { identifier = "cp37-macosx_x86_64", version = "3.7", url = "https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg" },
   { identifier = "cp38-macosx_x86_64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
-  { identifier = "cp38-macosx_arm64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg" },
+  { identifier = "cp38-macosx_arm64", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
   { identifier = "cp38-macosx_universal2", version = "3.8", url = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg" },
   { identifier = "cp39-macosx_x86_64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg" },
   { identifier = "cp39-macosx_arm64", version = "3.9", url = "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg" },

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -372,14 +372,6 @@ So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`
   if: runner.os == 'macOS' && runner.arch == 'ARM64'
 ```
 
-There is also an 'experimental' installer available that's built natively for arm64 that you can install manually with something like:
-
-```bash
-curl -o /tmp/Python38.pkg https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
-sudo installer -pkg /tmp/Python38.pkg -target /
-sh "/Applications/Python 3.8/Install Certificates.command"
-```
-
 Then cibuildwheel will detect that it's installed and use it instead. However, you probably don't want to build x86_64 wheels on this Python, unless you're happy with them only supporting macOS 11+.
 
 ### macOS: Library dependencies do not satisfy target MacOS

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -363,7 +363,7 @@ If you're building on an arm64 runner, you might notice something strange about 
 
 This is fine for simple C extensions, but for more complicated builds on arm64 it becomes an issue.
 
-So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`) on Python 3.8, before invoking cibuildwheel, you should install a native arm64 Python 3.8 interpreter on the runner. On GitHub actions you can set this up easily using the `setup-python` action with something like:
+So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`) on Python 3.8, before invoking cibuildwheel, you should install a native arm64 Python 3.8 interpreter on the runner:
 
 
 !!! tab "GitHub Actions"
@@ -375,7 +375,7 @@ So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`
       if: runner.os == 'macOS' && runner.arch == 'ARM64'
     ```
 
-!!! tab "Other CIs"
+!!! tab "Generic"
 
     ```bash
     curl -o /tmp/Python38.pkg https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -363,10 +363,16 @@ If you're building on an arm64 runner, you might notice something strange about 
 
 This is fine for simple C extensions, but for more complicated builds on arm64 it becomes an issue.
 
-So, if the cross-compilation is an issue for you, there is an 'experimental' installer available that's built natively for arm64.
+So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`) on Python 3.8, before invoking cibuildwheel, you should install a native arm64 Python 3.8 interpreter on the runner. On GitHub actions you can set this up easily using the `setup-python` action with something like:
 
-To use this installer and perform native CPython 3.8 building, before invoking cibuildwheel, install the universal2 version of Python on your arm64 runner, something like:
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: 3.8
+  if: runner.os == 'macOS' && runner.arch == 'ARM64'
+```
 
+There is also an 'experimental' installer available that's built natively for arm64 that you can install manually with something like:
 
 ```bash
 curl -o /tmp/Python38.pkg https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -365,12 +365,23 @@ This is fine for simple C extensions, but for more complicated builds on arm64 i
 
 So, if you want to build macOS arm64 wheels on an arm64 runner (e.g., `macos-14`) on Python 3.8, before invoking cibuildwheel, you should install a native arm64 Python 3.8 interpreter on the runner. On GitHub actions you can set this up easily using the `setup-python` action with something like:
 
-```yaml
-- uses: actions/setup-python@v5
-  with:
-    python-version: 3.8
-  if: runner.os == 'macOS' && runner.arch == 'ARM64'
-```
+
+!!! tab "GitHub Actions"
+
+    ```yaml
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.8
+      if: runner.os == 'macOS' && runner.arch == 'ARM64'
+    ```
+
+!!! tab "Other CIs"
+
+    ```bash
+    curl -o /tmp/Python38.pkg https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
+    sudo installer -pkg /tmp/Python38.pkg -target /
+    sh "/Applications/Python 3.8/Install Certificates.command"
+    ```
 
 Then cibuildwheel will detect that it's installed and use it instead. However, you probably don't want to build x86_64 wheels on this Python, unless you're happy with them only supporting macOS 11+.
 


### PR DESCRIPTION
I just hit https://github.com/pypa/cibuildwheel/issues/1278 :

https://github.com/h5py/h5py/actions/runs/9472096444/job/26096834822#step:9:483

```
    error: dlopen(/Users/runner/work/h5py/h5py/cache/hdf5/1.12.2-arm64/lib/libhdf5.dylib, 0x0006): tried:

... '/Users/runner/work/h5py/h5py/cache/hdf5/1.12.2-arm64/lib/libhdf5.200.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
```

Using the suggestion from https://github.com/pypa/cibuildwheel/issues/1278#issuecomment-2052099631 in https://github.com/h5py/h5py/pull/2444/commits/87cf54c343e70e43885aa876aa1fee131726cb2a fixes it:

https://github.com/h5py/h5py/actions/runs/9472215836/job/26097237985?pr=2444#step:9:179

@cretz do you want to open a quick PR instead so you can get credit (and blame 😄 ) for this change?