### PR TITLE
set VSCMD_ARG_TGT_ARCH based on targetted architecture

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -157,8 +157,8 @@ def setup_setuptools_cross_compile(
     # identifies the target, not the host
     vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
     current_tgt_arch = vscmd_arg_tgt_arch[python_configuration.arch]
-    if env.get("VSCMD_ARG_TGT_ARCH", current_tgt_arch) != current_tgt_arch:
-        msg = f"VSCMD_ARG_TGT_ARCH must be set to {current_tgt_arch}, got {env['VSCMD_ARG_TGT_ARCH']}. Make sure you setup MSVC targeting the right architecture."
+    if (env.get("VSCMD_ARG_TGT_ARCH") or current_tgt_arch) != current_tgt_arch:
+        msg = f"VSCMD_ARG_TGT_ARCH must be set to {current_tgt_arch!r}, got {env['VSCMD_ARG_TGT_ARCH']!r}. If you're setting up MSVC yourself (e.g. using vcvarsall.bat or msvc-dev-cmd), make sure to target the right architecture. Alternatively, run cibuildwheel without configuring MSVC, and let the build backend handle it."
         raise errors.FatalError(msg)
     env["VSCMD_ARG_TGT_ARCH"] = current_tgt_arch
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -155,8 +155,9 @@ def setup_setuptools_cross_compile(
 
     # Set environment variable so that setuptools._distutils.get_platform()
     # identifies the target, not the host
-    vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
-    env["VSCMD_ARG_TGT_ARCH"] = vscmd_arg_tgt_arch[python_configuration.arch]
+    if not env.get("VSCMD_ARG_TGT_ARCH"):
+        vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
+        env["VSCMD_ARG_TGT_ARCH"] = vscmd_arg_tgt_arch[python_configuration.arch]
 
     # (This file must be default/locale encoding, so we can't pass 'encoding')
     distutils_cfg.write_text(

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -155,9 +155,12 @@ def setup_setuptools_cross_compile(
 
     # Set environment variable so that setuptools._distutils.get_platform()
     # identifies the target, not the host
-    if not env.get("VSCMD_ARG_TGT_ARCH"):
-        vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
-        env["VSCMD_ARG_TGT_ARCH"] = vscmd_arg_tgt_arch[python_configuration.arch]
+    vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
+    current_tgt_arch = vscmd_arg_tgt_arch[python_configuration.arch]
+    if env.get("VSCMD_ARG_TGT_ARCH", current_tgt_arch) != current_tgt_arch:
+         msg = f"VSCMD_ARG_TGT_ARCH must be set to {current_tgt_arch}, got {env['VSCMD_ARG_TGT_ARCH']}. Make sure you setup MSVC targetting the right architecture."
+         raise errors.FatalError(msg)
+    env["VSCMD_ARG_TGT_ARCH"] = current_tgt_arch
 
     # (This file must be default/locale encoding, so we can't pass 'encoding')
     distutils_cfg.write_text(

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -158,8 +158,8 @@ def setup_setuptools_cross_compile(
     vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
     current_tgt_arch = vscmd_arg_tgt_arch[python_configuration.arch]
     if env.get("VSCMD_ARG_TGT_ARCH", current_tgt_arch) != current_tgt_arch:
-         msg = f"VSCMD_ARG_TGT_ARCH must be set to {current_tgt_arch}, got {env['VSCMD_ARG_TGT_ARCH']}. Make sure you setup MSVC targetting the right architecture."
-         raise errors.FatalError(msg)
+        msg = f"VSCMD_ARG_TGT_ARCH must be set to {current_tgt_arch}, got {env['VSCMD_ARG_TGT_ARCH']}. Make sure you setup MSVC targeting the right architecture."
+        raise errors.FatalError(msg)
     env["VSCMD_ARG_TGT_ARCH"] = current_tgt_arch
 
     # (This file must be default/locale encoding, so we can't pass 'encoding')

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -152,6 +152,12 @@ def setup_setuptools_cross_compile(
     # set the platform name
     map_plat = {"32": "win32", "64": "win-amd64", "ARM64": "win-arm64"}
     plat_name = map_plat[python_configuration.arch]
+
+    # Set environment variable so that setuptools._distutils.get_platform()
+    # identifies the target, not the host
+    vscmd_arg_tgt_arch = {"32": "x86", "64": "x64", "ARM64": "arm64"}
+    env["VSCMD_ARG_TGT_ARCH"] = vscmd_arg_tgt_arch[python_configuration.arch]
+
     # (This file must be default/locale encoding, so we can't pass 'encoding')
     distutils_cfg.write_text(
         textwrap.dedent(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ test = [
     "pytest-timeout",
     "pytest-xdist",
     "pytest>=6",
+    "setuptools",
     "tomli_w",
     "validate-pyproject",
 ]
@@ -140,6 +141,8 @@ disallow_untyped_decorators = true
 [[tool.mypy.overrides]]
 module = [
     "setuptools",
+    "setuptools._distutils", # needed even if only directly import setuptools._distutils.util
+    "setuptools._distutils.util",
     "pytest", # ignored in pre-commit to speed up check
     "bashlex",
     "bashlex.*",

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -1,5 +1,6 @@
 # ruff: noqa: ARG001
 import contextlib
+import sys
 from pathlib import Path
 from typing import Dict
 
@@ -8,11 +9,14 @@ import setuptools._distutils.util
 
 from cibuildwheel.windows import PythonConfiguration, setup_setuptools_cross_compile
 
+# monkeypatching os.name is too flaky. E.g. It works on my machine, but fails in pipeline
+if not sys.platform.startswith("win"):
+    pytest.skip("Windows-only tests", allow_module_level=True)
+
 
 @contextlib.contextmanager
 def patched_environment(monkeypatch: pytest.MonkeyPatch, environment: Dict[str, str]):
     with monkeypatch.context() as mp:
-        mp.setattr("os.name", "nt")
         for envvar, val in environment.items():
             mp.setenv(name=envvar, value=val)
         yield

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -1,0 +1,88 @@
+# ruff: noqa: ARG001
+import contextlib
+from pathlib import Path
+from typing import Dict
+
+import pytest
+import setuptools._distutils.util
+
+from cibuildwheel.windows import PythonConfiguration, setup_setuptools_cross_compile
+
+
+@contextlib.contextmanager
+def patched_environment(monkeypatch: pytest.MonkeyPatch, environment: Dict[str, str]):
+    with monkeypatch.context() as mp:
+        mp.setattr("os.name", "nt")
+        for envvar, val in environment.items():
+            mp.setenv(name=envvar, value=val)
+        yield
+
+
+def test_x86(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arch = "32"
+    environment: Dict[str, str] = {}
+
+    configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
+
+    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
+    with patched_environment(monkeypatch, environment):
+        target_platform = setuptools._distutils.util.get_platform()
+
+    assert environment["VSCMD_ARG_TGT_ARCH"] == "x86"
+    assert target_platform == "win32"
+
+
+def test_x64(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arch = "64"
+    environment: Dict[str, str] = {}
+
+    configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
+
+    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
+    with patched_environment(monkeypatch, environment):
+        target_platform = setuptools._distutils.util.get_platform()
+
+    assert environment["VSCMD_ARG_TGT_ARCH"] == "x64"
+    assert target_platform == "win-amd64"
+
+
+def test_arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arch = "ARM64"
+    environment: Dict[str, str] = {}
+
+    configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
+
+    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
+    with patched_environment(monkeypatch, environment):
+        target_platform = setuptools._distutils.util.get_platform()
+
+    assert environment["VSCMD_ARG_TGT_ARCH"] == "arm64"
+    assert target_platform == "win-arm64"
+
+
+def test_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arch = "32"
+    environment = {"VSCMD_ARG_TGT_ARCH": "arm64"}
+
+    configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
+
+    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
+    with patched_environment(monkeypatch, environment):
+        target_platform = setuptools._distutils.util.get_platform()
+
+    assert environment["VSCMD_ARG_TGT_ARCH"] == "arm64"
+    assert target_platform == "win-arm64"
+
+
+def test_env_blank(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arch = "32"
+    environment = {"VSCMD_ARG_TGT_ARCH": ""}
+
+    configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
+
+    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
+    with patched_environment(monkeypatch, environment):
+        target_platform = setuptools._distutils.util.get_platform()
+
+    assert environment["VSCMD_ARG_TGT_ARCH"] == "x86"
+    assert target_platform == "win32"

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -1,4 +1,3 @@
-# ruff: noqa: ARG001
 import contextlib
 import sys
 from pathlib import Path

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -7,6 +7,7 @@ from typing import Dict
 import pytest
 import setuptools._distutils.util
 
+from cibuildwheel.errors import FatalError
 from cibuildwheel.util import CIProvider, detect_ci_provider
 from cibuildwheel.windows import PythonConfiguration, setup_setuptools_cross_compile
 
@@ -68,18 +69,14 @@ def test_arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert target_platform == "win-arm64"
 
 
-def test_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_env_set(tmp_path: Path):
     arch = "32"
     environment = {"VSCMD_ARG_TGT_ARCH": "x64"}
 
     configuration = PythonConfiguration("irrelevant", arch, "irrelevant", None)
 
-    setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
-    with patched_environment(monkeypatch, environment):
-        target_platform = setuptools._distutils.util.get_platform()
-
-    assert environment["VSCMD_ARG_TGT_ARCH"] == "x64"
-    assert target_platform == "win-amd64"
+    with pytest.raises(FatalError, match="VSCMD_ARG_TGT_ARCH"):
+        setup_setuptools_cross_compile(tmp_path, configuration, tmp_path, environment)
 
 
 def test_env_blank(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
This fixes #1861 and any other build setups which make use of `setuptools._distutils.util.get_platform()` on windows

### Approach
- Uses `dict` lookup pattern analog to many other places within the code
- Only sets the variable if it has not already been set manually
- Will overwrite a pre-set `VSCMD_ARG_TGT_ARCH=""`
- Tests `monkeypatch` the environment before calling `setuptools._distutils.util.get_platform()` and validating returned platform

### Test availability
- Tests are set to only run on windows
- monkeypatching `os.name` in a tight context worked locally (Win11 + WSL2 + Ubunutu 22.04), but fails in pipeline on github actions
- all tests pass on github actions windows runner but tests targeting arm64 fail on azure pipeline. I'm assuming this is a weird, azure-specific thing in their environment and have set the arm64 test to skip on azure

#### Potential refactoring idea for a future PR
- I'd like to refactor the various mapping lookups into a WindowsArchitecture `dataclass` - there are many places with the pattern `somevar = architecture_mapping_dict[arch]` which would be more readable as `somevar = targetarchitecure.somevar`