### PR TITLE
chore: remove cached_property from utils

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -6,10 +6,10 @@ import contextlib
 import dataclasses
 import difflib
 import enum
-import functools
 import shlex
 import textwrap
 from collections.abc import Callable, Generator, Iterable, Iterator, Set
+from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import Any, Literal, Mapping, Sequence, TypedDict, Union  # noqa: TID251
 
@@ -31,7 +31,6 @@ from .util import (
     BuildSelector,
     DependencyConstraints,
     TestSelector,
-    cached_property,
     format_safe,
     resources_dir,
     selector_matches,
@@ -839,7 +838,7 @@ def compute_options(
     return options
 
 
-@functools.lru_cache(maxsize=None)
+@lru_cache(maxsize=None)
 def _get_pinned_container_images() -> Mapping[str, Mapping[str, str]]:
     """
     This looks like a dict of dicts, e.g.

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from collections.abc import Generator, Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from pathlib import Path, PurePath
 from tempfile import TemporaryDirectory
 from time import sleep
@@ -41,7 +41,6 @@ from .typing import PathOrStr, PlatformName
 
 __all__ = [
     "MANYLINUX_ARCHS",
-    "cached_property",
     "call",
     "chdir",
     "combine_constraints",


### PR DESCRIPTION
This was a leftover from python 3.7 support removal.