### PR TITLE
fix: support --no-isolation with build[uv]

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -282,7 +282,7 @@ def build_in_container(
                 if not 0 <= build_options.build_verbosity < 2:
                     msg = f"build_verbosity {build_options.build_verbosity} is not supported for build frontend. Ignoring."
                     log.warning(msg)
-                if use_uv:
+                if use_uv and "--no-isolation" not in extra_flags and "-n" not in extra_flags:
                     extra_flags += ["--installer=uv"]
                 container.call(
                     [

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -505,7 +505,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     if not 0 <= build_options.build_verbosity < 2:
                         msg = f"build_verbosity {build_options.build_verbosity} is not supported for build frontend. Ignoring."
                         log.warning(msg)
-                    if use_uv:
+                    if use_uv and "--no-isolation" not in extra_flags and "-n" not in extra_flags:
                         extra_flags.append("--installer=uv")
                     call(
                         "python",

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -441,7 +441,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     if not 0 <= build_options.build_verbosity < 2:
                         msg = f"build_verbosity {build_options.build_verbosity} is not supported for build frontend. Ignoring."
                         log.warning(msg)
-                    if use_uv:
+                    if use_uv and "--no-isolation" not in extra_flags and "-n" not in extra_flags:
                         extra_flags.append("--installer=uv")
                     call(
                         "python",

--- a/docs/options.md
+++ b/docs/options.md
@@ -657,6 +657,12 @@ optional `args` option.
     will change the default to [build][], in line with the PyPA's recommendation.
     If you want to try `build` before this, you can use this option.
 
+!!! warning
+    If you are using `build[uv]` and are passing `--no-isolation` or `-n`, we
+    will detect this and avoid passing `--installer=uv` to build, but still
+    install all packages with uv. We do not currently detect combined short
+    options, like `-xn`!
+
 [pip]: https://pip.pypa.io/en/stable/cli/pip_wheel/
 [build]: https://github.com/pypa/build/
 [uv]: https://github.com/astral-sh/uv


### PR DESCRIPTION
Fixing #1887. I didn't special case chained short flags, like `-xn` or `-nx`, maybe we should?
