### PR TITLE
chore: remove pip beta workaround

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -352,10 +352,6 @@ def build_in_container(
             virtualenv_env["PATH"] = f"{venv_dir / 'bin'}:{virtualenv_env['PATH']}"
             virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
-            # TODO remove me once virtualenv provides pip>=24.1b1
-            if config.version == "3.13" and not use_uv:
-                container.call(["pip", "install", "pip>=24.1b1"], env=virtualenv_env)
-
             if build_options.before_test:
                 before_test_prepared = prepare_command(
                     build_options.before_test,


### PR DESCRIPTION
pip 24.1 is now embedded in virtualenv