### PR TITLE
fix(ci): CircleCI / Azure Pipelines / GitLab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
 version: 2
 
 jobs:
-  osx-python3.9:
+  osx-python3.12:
     macos:
-      xcode: 12.5.1
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
     environment:
       PYTHON: python3
     steps:
@@ -17,9 +18,9 @@ jobs:
           command: venv/bin/python ./bin/run_tests.py
           no_output_timeout: 30m
 
-  linux-python3.9:
+  linux-python3.12:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.12
     environment:
       PYTHON: python3
       # Temporarily restrict the tests that are run on CircleCI to prevent
@@ -61,6 +62,6 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      - osx-python3.9
-      - linux-python3.9
+      - osx-python3.12
+      - linux-python3.12
       - linux-aarch64

--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -2,10 +2,12 @@
 set -o errexit
 set -o xtrace
 
+if [ "$(uname -s)" == "Darwin" ]; then
+  sudo softwareupdate --install-rosetta --agree-to-license
+fi
+
 $PYTHON --version
-$PYTHON -m pip --version
-$PYTHON -m virtualenv --version
-$PYTHON -m virtualenv --no-setuptools --no-wheel -p "$PYTHON" venv
+$PYTHON -m venv venv
 venv/bin/python -m pip install -U pip
 venv/bin/python -m pip install -e ".[dev]"
 venv/bin/python -m pip freeze

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 linux:
-  image: python:3.8
+  image: python:3.12
   services:
     - name: docker:dind
       entrypoint: ["env", "-u", "DOCKER_HOST"]
@@ -23,9 +23,9 @@ windows:
   variables:
     PYTEST_ADDOPTS: -k "unit_test or test_0_basic" --suppress-no-test-exit-code
   before_script:
-    - choco install python -y --version 3.8.6
+    - choco install python -y --version 3.12.4
   script:
     - py -m pip install -e ".[dev]" pytest-custom-exit-code
     - py bin\run_tests.py
   tags:
-    - windows
+    - saas-windows-medium-amd64

--- a/CI.md
+++ b/CI.md
@@ -1,10 +1,10 @@
 This is a summary of the host Python versions and platforms covered by the different CI platforms:
 
-|         | 3.8                                                    | 3.9                   | 3.10      | 3.12           |
-|---------|--------------------------------------------------------|-----------------------|-----------|----------------|
-| Linux   | AppVeyor¹ / Azure Pipelines / GitLab¹ / GitHub Actions | CircleCI¹ / Travis CI | Cirrus CI | GitHub Actions |
-| macOS   | AppVeyor¹ / Azure Pipelines                            | CircleCI¹ / Travis CI | Cirrus CI | GitHub Actions |
-| Windows | AppVeyor¹ / Azure Pipelines / GitLab¹                  | Travis CI             | Cirrus CI | GitHub Actions |
+|         | 3.8                                                    | 3.9       | 3.10      | 3.12                                 |
+|---------|--------------------------------------------------------|-----------|-----------|--------------------------------------|
+| Linux   | AppVeyor¹ / Azure Pipelines / GitLab¹ / GitHub Actions | Travis CI | Cirrus CI | CircleCI¹ / GitHub Actions           |
+| macOS   | AppVeyor¹ / Azure Pipelines                            |           | Cirrus CI | CircleCI¹ / GitHub Actions           |
+| Windows | AppVeyor¹ / Azure Pipelines / GitLab¹                  | Travis CI | Cirrus CI | GitHub Actions  / GitLab¹            |
 
 > ¹ Runs a reduced set of tests to reduce CI load
 

--- a/CI.md
+++ b/CI.md
@@ -1,10 +1,10 @@
 This is a summary of the host Python versions and platforms covered by the different CI platforms:
 
-|         | 3.8                                                    | 3.9       | 3.10      | 3.12                                 |
-|---------|--------------------------------------------------------|-----------|-----------|--------------------------------------|
-| Linux   | AppVeyor¹ / Azure Pipelines / GitLab¹ / GitHub Actions | Travis CI | Cirrus CI | CircleCI¹ / GitHub Actions           |
-| macOS   | AppVeyor¹ / Azure Pipelines                            |           | Cirrus CI | CircleCI¹ / GitHub Actions           |
-| Windows | AppVeyor¹ / Azure Pipelines / GitLab¹                  | Travis CI | Cirrus CI | GitHub Actions  / GitLab¹            |
+|         | 3.8                                          | 3.9       | 3.10      | 3.12                                 |
+|---------|----------------------------------------------|-----------|-----------|--------------------------------------|
+| Linux   | AppVeyor¹ / Azure Pipelines / GitHub Actions | Travis CI | Cirrus CI | CircleCI¹ / GitHub Actions / GitLab¹ |
+| macOS   | AppVeyor¹ / Azure Pipelines                  |           | Cirrus CI | CircleCI¹ / GitHub Actions           |
+| Windows | AppVeyor¹ / Azure Pipelines                  | Travis CI | Cirrus CI | GitHub Actions  / GitLab¹            |
 
 > ¹ Runs a reduced set of tests to reduce CI load
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: macos_38
-  pool: {vmImage: 'macOS-11'}
+  pool: {vmImage: 'macOS-12'}
   steps:
     - task: UsePythonVersion@0
       inputs:

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -14,7 +14,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 
 - job: macos
-  pool: {vmImage: 'macOS-11'}
+  pool: {vmImage: 'macOS-12'}
   steps:
     - task: UsePythonVersion@0
     - bash: |

--- a/examples/circleci-minimal.yml
+++ b/examples/circleci-minimal.yml
@@ -4,14 +4,14 @@ jobs:
   linux-wheels:
     working_directory: ~/linux-wheels
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.12
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Build the Linux wheels.
           command: |
-            pip3 install --user cibuildwheel==2.19.1
+            python3 -m pip install --user cibuildwheel==2.19.1
             cibuildwheel --output-dir wheelhouse
       - store_artifacts:
           path: wheelhouse/
@@ -36,12 +36,14 @@ jobs:
   osx-wheels:
     working_directory: ~/osx-wheels
     macos:
-      xcode: 12.5.1
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:
           name: Build the OS X wheels.
           command: |
+            sudo softwareupdate --install-rosetta --agree-to-license  # for python<=3.8 or x86_64/universal2 tests
             pip3 install cibuildwheel==2.19.1
             cibuildwheel --output-dir wheelhouse
       - store_artifacts:

--- a/examples/gitlab-minimal.yml
+++ b/examples/gitlab-minimal.yml
@@ -1,5 +1,5 @@
 linux:
-  image: python:3.8
+  image: python:3.12
   # make a docker daemon available for cibuildwheel to use
   services:
     - name: docker:dind
@@ -21,7 +21,7 @@ linux:
 windows:
   image: mcr.microsoft.com/windows/servercore:1809
   before_script:
-    - choco install python -y --version 3.8.6
+    - choco install python -y --version 3.12.4
     - choco install git.install -y
     - py -m pip install cibuildwheel==2.19.1
   script:
@@ -30,4 +30,4 @@ windows:
     paths:
       - wheelhouse/
   tags:
-    - windows
+    - saas-windows-medium-amd64


### PR DESCRIPTION
- CircleCI:
move to python 3.12
CircleCI does not support Intel macOS runners anymore.
c.f. https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

- Azure Pipelines:
macOS-11 has been removed. move to macOS-12

- GitLab:
Windows tag has changed.
move to python 3.12
fix #1897 