### PR TITLE
chore: update examples to use python 3.12

### DIFF
--- a/examples/cirrus-ci-intel-mac.yml
+++ b/examples/cirrus-ci-intel-mac.yml
@@ -11,10 +11,11 @@ macos_task:
   name: Build macOS x86_64 and arm64 wheels.
   macos_instance:
     image: ghcr.io/cirruslabs/macos-sonoma-xcode
-
   env:
-    PATH: /opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
     CIBW_ARCHS_MACOS: x86_64 arm64
   install_pre_requirements_script:
-    - brew install python@3.10
+    - brew install python@3.12
+    - python3.12 -m venv ${VENV_ROOT}
   <<: *BUILD_AND_STORE_WHEELS

--- a/examples/cirrus-ci-minimal.yml
+++ b/examples/cirrus-ci-minimal.yml
@@ -15,9 +15,14 @@ linux_x86_task:
     platform: linux
     cpu: 4
     memory: 4G
-
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
   install_pre_requirements_script:
-    - apt install -y python3-venv python-is-python3
+    - add-apt-repository -y ppa:deadsnakes/ppa
+    - apt-get update
+    - apt-get install -y python3.12-venv
+    - python3.12 -m venv ${VENV_ROOT}
   <<: *BUILD_AND_STORE_WHEELS
 
 linux_aarch64_task:
@@ -29,9 +34,14 @@ linux_aarch64_task:
     platform: linux
     cpu: 4
     memory: 4G
-
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
   install_pre_requirements_script:
-    - apt install -y python3-venv python-is-python3
+    - add-apt-repository -y ppa:deadsnakes/ppa
+    - apt-get update
+    - apt-get install -y python3.12-venv
+    - python3.12 -m venv ${VENV_ROOT}
   <<: *BUILD_AND_STORE_WHEELS
 
 windows_x86_task:
@@ -42,7 +52,7 @@ windows_x86_task:
     memory: 4G
 
   install_pre_requirements_script:
-    - choco install -y --no-progress python3 --version 3.10.6
+    - choco install -y --no-progress python3 --version 3.12.4
     - refreshenv
     - echo PATH=%PATH% >> "%CIRRUS_ENV%"
   <<: *BUILD_AND_STORE_WHEELS
@@ -51,9 +61,10 @@ macos_arm64_task:
   name: Build macOS arm64 wheels.
   macos_instance:
     image: ghcr.io/cirruslabs/macos-sonoma-xcode
-
   env:
-    PATH: /opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
   install_pre_requirements_script:
-    - brew install python@3.10
+    - brew install python@3.12
+    - python3.12 -m venv ${VENV_ROOT}
   <<: *BUILD_AND_STORE_WHEELS

--- a/examples/gitlab-with-qemu.yml
+++ b/examples/gitlab-with-qemu.yml
@@ -1,5 +1,5 @@
 linux:
-  image: python:3.8
+  image: python:3.12
   # make a docker daemon available for cibuildwheel to use
   services:
     - name: docker:dind

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -4,7 +4,7 @@
 os: linux
 dist: focal
 language: python
-python: "3.9"
+python: "3.12"
 
 jobs:
   include:
@@ -14,10 +14,10 @@ jobs:
     - os: windows
       language: shell
       before_install:
-        - choco upgrade python -y --version 3.8.6
-        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        - choco upgrade python -y --version 3.12.4
+        - export PATH="/c/Python312:/c/Python312/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
-        - ln -s /c/Python38/python.exe /c/Python38/python3.exe
+        - ln -s /c/Python312/python.exe /c/Python312/python3.exe
 
 install:
   - python3 -m pip install cibuildwheel==2.19.2

--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: focal
 language: python
-python: "3.9"
+python: "3.12"
 
 jobs:
   include:
@@ -20,10 +20,10 @@ jobs:
     - os: windows
       language: shell
       before_install:
-        - choco upgrade python -y --version 3.8.6
-        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        - choco upgrade python -y --version 3.12.4
+        - export PATH="/c/Python312:/c/Python312/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
-        - ln -s /c/Python38/python.exe /c/Python38/python3.exe
+        - ln -s /c/Python312/python.exe /c/Python312/python3.exe
 
 install:
   - python3 -m pip install cibuildwheel==2.19.2

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -8,17 +8,15 @@
 os: linux
 dist: focal
 language: python
-python:
-  - 3.7
-  - 3.8
+python: "3.12"
 
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" = windows ]]; then
-        choco upgrade python -y --version 3.8.6
-        export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        choco upgrade python -y --version 3.12.4
+        export PATH="/c/Python312:/c/Python312/Scripts:$PATH"
         # make sure it's on PATH as 'python3'
-        ln -s /c/Python38/python.exe /c/Python38/python3.exe
+        ln -s /c/Python312/python.exe /c/Python312/python3.exe
     fi
 
 install:


### PR DESCRIPTION
Towards #1912 
There's also the EOL of python 3.8 coming soon so we'd better have examples using the latest stable version of Python to run cibuildwheel.