### PR TITLE
chore: move `AlreadyBuiltWheelError` & `NonPlatformWheelError` to `errors.py`

### DIFF
--- a/cibuildwheel/errors.py
+++ b/cibuildwheel/errors.py
@@ -4,6 +4,8 @@ a different return code, by defining them all here, we can ensure that they're
 semantically clear and unique.
 """
 
+import textwrap
+
 
 class FatalError(BaseException):
     """
@@ -25,3 +27,34 @@ class NothingToDoError(FatalError):
 
 class DeprecationError(FatalError):
     return_code = 4
+
+
+class NonPlatformWheelError(FatalError):
+    def __init__(self) -> None:
+        message = textwrap.dedent(
+            """
+            Build failed because a pure Python wheel was generated.
+
+            If you intend to build a pure-Python wheel, you don't need cibuildwheel - use
+            `pip wheel -w DEST_DIR .` instead.
+
+            If you expected a platform wheel, check your project configuration, or run
+            cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
+            """
+        )
+        super().__init__(message)
+        self.return_code = 5
+
+
+class AlreadyBuiltWheelError(FatalError):
+    def __init__(self, wheel_name: str) -> None:
+        message = textwrap.dedent(
+            f"""
+            Build failed because a wheel named {wheel_name} was already generated in the current run.
+
+            If you expected another wheel to be generated, check your project configuration, or run
+            cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
+            """
+        )
+        super().__init__(message)
+        self.return_code = 6

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -18,10 +18,8 @@ from .oci_container import OCIContainer, OCIContainerEngineConfig
 from .options import BuildOptions, Options
 from .typing import PathOrStr
 from .util import (
-    AlreadyBuiltWheelError,
     BuildFrontendConfig,
     BuildSelector,
-    NonPlatformWheelError,
     find_compatible_wheel,
     get_build_verbosity_extra_flags,
     prepare_command,
@@ -306,7 +304,7 @@ def build_in_container(
             container.call(["mkdir", "-p", repaired_wheel_dir])
 
             if built_wheel.name.endswith("none-any.whl"):
-                raise NonPlatformWheelError()
+                raise errors.NonPlatformWheelError()
 
             if build_options.repair_command:
                 log.step("Repairing wheel...")
@@ -321,7 +319,7 @@ def build_in_container(
 
             for repaired_wheel in repaired_wheels:
                 if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise AlreadyBuiltWheelError(repaired_wheel.name)
+                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
 
         if build_options.test_command and build_options.test_selector(config.identifier):
             log.step("Testing wheel...")

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -25,11 +25,9 @@ from .options import Options
 from .typing import PathOrStr
 from .util import (
     CIBW_CACHE_PATH,
-    AlreadyBuiltWheelError,
     BuildFrontendConfig,
     BuildFrontendName,
     BuildSelector,
-    NonPlatformWheelError,
     call,
     combine_constraints,
     detect_ci_provider,
@@ -525,7 +523,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 repaired_wheel_dir.mkdir()
 
                 if built_wheel.name.endswith("none-any.whl"):
-                    raise NonPlatformWheelError()
+                    raise errors.NonPlatformWheelError()
 
                 if build_options.repair_command:
                     log.step("Repairing wheel...")
@@ -550,7 +548,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
 
                 if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise AlreadyBuiltWheelError(repaired_wheel.name)
+                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
 
                 log.step_end()
 

--- a/cibuildwheel/pyodide.py
+++ b/cibuildwheel/pyodide.py
@@ -17,10 +17,8 @@ from .options import Options
 from .typing import PathOrStr
 from .util import (
     CIBW_CACHE_PATH,
-    AlreadyBuiltWheelError,
     BuildFrontendConfig,
     BuildSelector,
-    NonPlatformWheelError,
     call,
     combine_constraints,
     download,
@@ -299,7 +297,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 built_wheel = next(built_wheel_dir.glob("*.whl"))
 
                 if built_wheel.name.endswith("none-any.whl"):
-                    raise NonPlatformWheelError()
+                    raise errors.NonPlatformWheelError()
 
                 if build_options.repair_command:
                     log.step("Repairing wheel...")
@@ -316,7 +314,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
 
                 if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise AlreadyBuiltWheelError(repaired_wheel.name)
+                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
 
             if build_options.test_command and build_options.test_selector(config.identifier):
                 log.step("Testing wheel...")

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -462,37 +462,6 @@ class BuildFrontendConfig:
             return {"name": self.name, "args": repr(self.args)}
 
 
-class NonPlatformWheelError(Exception):
-    def __init__(self) -> None:
-        message = textwrap.dedent(
-            """
-            cibuildwheel: Build failed because a pure Python wheel was generated.
-
-            If you intend to build a pure-Python wheel, you don't need cibuildwheel - use
-            `pip wheel -w DEST_DIR .` instead.
-
-            If you expected a platform wheel, check your project configuration, or run
-            cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
-            """
-        )
-
-        super().__init__(message)
-
-
-class AlreadyBuiltWheelError(Exception):
-    def __init__(self, wheel_name: str) -> None:
-        message = textwrap.dedent(
-            f"""
-            cibuildwheel: Build failed because a wheel named {wheel_name} was already generated in the current run.
-
-            If you expected another wheel to be generated, check your project configuration, or run
-            cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
-            """
-        )
-
-        super().__init__(message)
-
-
 def strtobool(val: str) -> bool:
     return val.lower() in {"y", "yes", "t", "true", "on", "1"}
 

--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -22,11 +22,9 @@ from .options import Options
 from .typing import PathOrStr
 from .util import (
     CIBW_CACHE_PATH,
-    AlreadyBuiltWheelError,
     BuildFrontendConfig,
     BuildFrontendName,
     BuildSelector,
-    NonPlatformWheelError,
     call,
     combine_constraints,
     download,
@@ -462,7 +460,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 repaired_wheel_dir.mkdir()
 
                 if built_wheel.name.endswith("none-any.whl"):
-                    raise NonPlatformWheelError()
+                    raise errors.NonPlatformWheelError()
 
                 if build_options.repair_command:
                     log.step("Repairing wheel...")
@@ -478,7 +476,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
 
                 if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise AlreadyBuiltWheelError(repaired_wheel.name)
+                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
 
             test_selected = options.globals.test_selector(config.identifier)
             if test_selected and config.arch == "ARM64" != platform_module.machine():

--- a/test/test_custom_repair_wheel.py
+++ b/test/test_custom_repair_wheel.py
@@ -38,7 +38,7 @@ def test(tmp_path, capfd):
     else:
         expectation = does_not_raise()
 
-    with expectation:
+    with expectation as exc_info:
         result = utils.cibuildwheel_run(
             project_dir,
             add_env={
@@ -49,6 +49,7 @@ def test(tmp_path, capfd):
     captured = capfd.readouterr()
     if num_builds > 1:
         assert "Build failed because a wheel named" in captured.err
+        assert exc_info.value.returncode == 6
     else:
         # We only produced one wheel (currently Pyodide)
         # check that it has the right name

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -31,10 +31,11 @@ def test(tmp_path, capfd):
     project_dir = tmp_path / "project"
     pure_python_project.generate(project_dir)
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
         print("produced wheels:", utils.cibuildwheel_run(project_dir))
 
     captured = capfd.readouterr()
     print("out", captured.out)
     print("err", captured.err)
+    assert exc_info.value.returncode == 5
     assert "Build failed because a pure Python wheel was generated" in captured.err


### PR DESCRIPTION
Part of the effort for #1857 / #1873. Follow-up on #1719.