### PR TITLE
chore: use python from setup-python step to run nox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      id: python
       with:
         python-version: "3.x"
     - uses: pre-commit/action@v3.0.1
     - name: Check manifest
-      run: pipx run nox -s check_manifest
+      run: pipx run --python "${{ steps.python.outputs.python-path }}" nox -s check_manifest
     - name: PyLint checks
-      run: pipx run nox -s pylint -- --output-format=github
+      run: pipx run --python "${{ steps.python.outputs.python-path }}" nox -s pylint -- --output-format=github
 
   test:
     name: Test on ${{ matrix.os }} (${{ matrix.python_version }})


### PR DESCRIPTION
In preparation for #1912, always use the latest stable python to run nox  in the lint job.