### PR TITLE
DOC: fix link to correct PR number

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Changelog
 - 🛠 Provide CPython 3.13.0b3. (#1913)
 - 🛠 Remove some workarounds now that pip 21.1 is available. (#1891, #1892)
 - 📚 Remove nosetest from our docs. (#1821)
-- 📚 Document the macOS ARM workaround for 3.8 on GHA. (#1971)
+- 📚 Document the macOS ARM workaround for 3.8 on GHA. (#1871)
 - 📚 GitLab CI + macOS is now a supported platform with an example. (#1911)
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ title: Changelog
 - 🛠 Provide CPython 3.13.0b3. (#1913)
 - 🛠 Remove some workarounds now that pip 21.1 is available. (#1891, #1892)
 - 📚 Remove nosetest from our docs. (#1821)
-- 📚 Document the macOS ARM workaround for 3.8 on GHA. (#1971)
+- 📚 Document the macOS ARM workaround for 3.8 on GHA. (#1871)
 - 📚 GitLab CI + macOS is now a supported platform with an example. (#1911)
 
 


### PR DESCRIPTION
This fixes a link to the correct PR number.

The description for https://github.com/pypa/cibuildwheel/releases/tag/v2.19.2 can be manually edited using the web UI.