### PR TITLE
docs: fix nox docs command

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,7 +109,7 @@ You can see a list of sessions by typing `nox -l`; here are a few common ones:
 ```console
 nox -s lint                    # Run the linters (default)
 nox -s tests [-- PYTEST-ARGS]  # Run the tests   (default)
-nox -s docs -- serve           # Build and serve the documentation
+nox -s docs                    # Build and serve the documentation
 nox -s build                   # Make SDist and wheel
 ```
 


### PR DESCRIPTION
A minor update to the contributing guide. `nox -s docs` is currently configured to build and serve the docs, so `nox -s docs -- serve` causes an error.