### PR TITLE
fix: do not use uv on Windows PyPy 3.8

### DIFF
--- a/cibuildwheel/windows.py
+++ b/cibuildwheel/windows.py
@@ -254,8 +254,10 @@ def setup_python(
         raise ValueError(msg)
     assert base_python.exists()
 
-    use_uv = build_frontend == "build[uv]" and Version(python_configuration.version) >= Version(
-        "3.8"
+    use_uv = (
+        build_frontend == "build[uv]"
+        and Version(python_configuration.version) >= Version("3.8")
+        and not python_configuration.identifier.startswith("pp38-")
     )
     uv_path = find_uv()
 
@@ -366,8 +368,10 @@ def build(options: Options, tmp_path: Path) -> None:
         for config in python_configurations:
             build_options = options.build_options(config.identifier)
             build_frontend = build_options.build_frontend or BuildFrontendConfig("pip")
-            use_uv = build_frontend.name == "build[uv]" and Version(config.version) >= Version(
-                "3.8"
+            use_uv = (
+                build_frontend.name == "build[uv]"
+                and Version(config.version) >= Version("3.8")
+                and not config.identifier.startswith("pp38-")
             )
             log.build_start(config.identifier)
 


### PR DESCRIPTION
uv 0.2.25+ does not work with PyPy 3.8 on Windows
Given PyPy 3.8 is EOL, just disable uv for this config rather than ask for it to be supported again in uv.