### PR TITLE
tests: show xfail traceback summaries again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,12 +94,7 @@ Homepage = "https://github.com/pypa/cibuildwheel"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = [
-  "-rfEsX",  # TODO: replace with -ra when pytest > 8.2.2 is released
-  "--showlocals",
-  "--strict-markers",
-  "--strict-config",
-]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 junit_family = "xunit2"
 xfail_strict = true
 filterwarnings = ["error"]


### PR DESCRIPTION
This reverts #1865 now that pytest 8.3 has been released (https://github.com/pytest-dev/pytest/releases/tag/8.3.0) and moves the xfail tracebacks to a separate flag.

(I was just doing this for geopandas and noticed this case in the github issue links and thought I may as well open a PR. I'm grateful for the hard work that goes into cibuildwheel but I don't keep up with the development of it, so feel free to supercede this / collapse this in with other changes if that's a smoother development process for you all!)