### PR TITLE
Build CPython 3.13 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What does it do?
 
 <sup>¹ PyPy is only supported for manylinux wheels.</sup><br>
 <sup>² Windows arm64 support is experimental.</sup><br>
-<sup>³ CPython 3.13 is available using the [`CIBW_PRERELEASE_PYTHONS`](https://cibuildwheel.pypa.io/en/stable/options/#prerelease-pythons) option. Free-threaded mode requires opt-in.</sup><br>
+<sup>³ CPython 3.13 is built by default using Python RCs, starting with cibuildwheel 2.20.</sup><br>
 <sup>⁴ Experimental, not yet supported on PyPI, but can be used directly in web deployment. Use `--platform pyodide` to build.</sup><br>
 
 - Builds manylinux, musllinux, macOS 10.9+, and Windows wheels for CPython and PyPy

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What does it do?
 
 <sup>¹ PyPy is only supported for manylinux wheels.</sup><br>
 <sup>² Windows arm64 support is experimental.</sup><br>
-<sup>³ CPython 3.13 is built by default using Python RCs, starting with cibuildwheel 2.20.</sup><br>
+<sup>³ CPython 3.13 is built by default using Python RCs, starting with cibuildwheel 2.20. Free-threaded mode will still require opt-in using [`CIBW_FREE_THREADED_SUPPORT`](https://cibuildwheel.pypa.io/en/stable/options/#free-threaded-support).</sup><br>
 <sup>⁴ Experimental, not yet supported on PyPI, but can be used directly in web deployment. Use `--platform pyodide` to build.</sup><br>
 
 - Builds manylinux, musllinux, macOS 10.9+, and Windows wheels for CPython and PyPy

--- a/cibuildwheel/util.py
+++ b/cibuildwheel/util.py
@@ -248,7 +248,7 @@ class BuildSelector:
     requires_python: SpecifierSet | None = None
 
     # a pattern that skips prerelease versions, when include_prereleases is False.
-    PRERELEASE_SKIP: ClassVar[str] = "cp313-* cp313t-*"
+    PRERELEASE_SKIP: ClassVar[str] = ""
     prerelease_pythons: bool = False
 
     free_threaded_support: bool = False

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -50,7 +50,7 @@ def test_build_filter_pre():
     assert build_selector("cp313-manylinux_x86_64")
     assert build_selector("cp37-win_amd64")
     assert build_selector("cp313-win_amd64")
-    assert build_selector("cp313t-manylinux_x86_64")
+    assert not build_selector("cp313t-manylinux_x86_64")
 
 
 def test_skip():

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -13,7 +13,7 @@ def test_build():
     assert build_selector("cp310-manylinux_x86_64")
     assert build_selector("cp311-manylinux_x86_64")
     assert build_selector("cp312-manylinux_x86_64")
-    assert not build_selector("cp313-manylinux_x86_64")
+    assert build_selector("cp313-manylinux_x86_64")
     assert build_selector("pp36-manylinux_x86_64")
     assert build_selector("pp37-manylinux_x86_64")
     assert build_selector("cp36-manylinux_i686")
@@ -34,7 +34,7 @@ def test_build():
     assert build_selector("cp310-win_amd64")
     assert build_selector("cp311-win_amd64")
     assert build_selector("cp312-win_amd64")
-    assert not build_selector("cp313-win_amd64")
+    assert build_selector("cp313-win_amd64")
     assert not build_selector("pp36-win_amd64")
     assert not build_selector("pp37-win_amd64")
 
@@ -50,7 +50,7 @@ def test_build_filter_pre():
     assert build_selector("cp313-manylinux_x86_64")
     assert build_selector("cp37-win_amd64")
     assert build_selector("cp313-win_amd64")
-    assert not build_selector("cp313t-manylinux_x86_64")
+    assert build_selector("cp313t-manylinux_x86_64")
 
 
 def test_skip():

--- a/unit_test/linux_build_steps_test.py
+++ b/unit_test/linux_build_steps_test.py
@@ -74,7 +74,7 @@ def test_linux_container_split(tmp_path: Path, monkeypatch):
         "cp313-manylinux_x86_64",
     ]
     assert before_alls(build_steps[0]) == [""] * 4
-    assert container_engines(build_steps[0]) == [default_container_engine] * 3
+    assert container_engines(build_steps[0]) == [default_container_engine] * 4
 
     assert build_steps[1].container_image == "other_container_image"
     assert identifiers(build_steps[1]) == ["cp37-manylinux_x86_64", "cp38-manylinux_x86_64"]

--- a/unit_test/linux_build_steps_test.py
+++ b/unit_test/linux_build_steps_test.py
@@ -71,8 +71,9 @@ def test_linux_container_split(tmp_path: Path, monkeypatch):
         "cp36-manylinux_x86_64",
         "cp311-manylinux_x86_64",
         "cp312-manylinux_x86_64",
+        "cp313-manylinux_x86_64",
     ]
-    assert before_alls(build_steps[0]) == [""] * 3
+    assert before_alls(build_steps[0]) == [""] * 4
     assert container_engines(build_steps[0]) == [default_container_engine] * 3
 
     assert build_steps[1].container_image == "other_container_image"

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -21,6 +21,7 @@ ALL_IDS = {
     "cp310",
     "cp311",
     "cp312",
+    "cp313",
     "pp37",
     "pp38",
     "pp39",
@@ -155,7 +156,7 @@ before-all = "true"
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
         f"{x}-manylinux_x86_64"
-        for x in ALL_IDS - {"cp36", "cp310", "cp311", "cp312", "pp37", "pp38", "pp39", "pp310"}
+        for x in ALL_IDS - {"cp36", "cp310", "cp311", "cp312", "cp313", "pp37", "pp38", "pp39", "pp310"}
     }
     assert kwargs["options"].build_options("cp37-manylinux_x86_64").before_all == ""
 
@@ -166,7 +167,7 @@ before-all = "true"
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
         f"{x}-manylinux_x86_64"
-        for x in ["cp310", "cp311", "cp312", "pp37", "pp38", "pp39", "pp310"]
+        for x in ["cp310", "cp311", "cp312", "cp313", "pp37", "pp38", "pp39", "pp310"]
     }
 
     kwargs = build_in_container.call_args_list[3][1]

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -156,7 +156,8 @@ before-all = "true"
     identifiers = {x.identifier for x in kwargs["platform_configs"]}
     assert identifiers == {
         f"{x}-manylinux_x86_64"
-        for x in ALL_IDS - {"cp36", "cp310", "cp311", "cp312", "cp313", "pp37", "pp38", "pp39", "pp310"}
+        for x in ALL_IDS
+        - {"cp36", "cp310", "cp311", "cp312", "cp313", "pp37", "pp38", "pp39", "pp310"}
     }
     assert kwargs["options"].build_options("cp37-manylinux_x86_64").before_all == ""
 


### PR DESCRIPTION
Enable building with CPython 3.13 by default, no longer requiring `prerelease_pythons` flag to be set true.

Merge after https://github.com/pypa/cibuildwheel/pull/1949 is merged.

Builds upon last-year PRs: https://github.com/pypa/cibuildwheel/pull/1226 and https://github.com/pypa/cibuildwheel/pull/1565.