### PR TITLE
fix: support empty CIBW_PLATFORM

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -240,7 +240,7 @@ def _compute_platform_auto() -> PlatformName:
 
 
 def _compute_platform(args: CommandLineArguments) -> PlatformName:
-    platform_option_value = args.platform or os.environ.get("CIBW_PLATFORM", "auto")
+    platform_option_value = args.platform or os.environ.get("CIBW_PLATFORM", "") or "auto"
 
     if args.only and args.platform is not None:
         msg = "--platform cannot be specified with --only, it is computed from --only"

--- a/test/utils.py
+++ b/test/utils.py
@@ -23,15 +23,14 @@ EMULATED_ARCHS: Final[list[str]] = sorted(
 )
 SINGLE_PYTHON_VERSION: Final[tuple[int, int]] = (3, 12)
 
-platform: str
-
-if "CIBW_PLATFORM" in os.environ:
-    platform = os.environ["CIBW_PLATFORM"]
+platform = os.environ.get("CIBW_PLATFORM", "")
+if platform:
+    pass
 elif sys.platform.startswith("linux"):
     platform = "linux"
 elif sys.platform.startswith("darwin"):
     platform = "macos"
-elif sys.platform in ["win32", "cygwin"]:
+elif sys.platform.startswith(("win32", "cygwin")):
     platform = "windows"
 else:
     msg = f"Unsupported platform {sys.platform!r}"

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -10,7 +10,7 @@ from cibuildwheel.architecture import Architecture
 from ..conftest import MOCK_PACKAGE_DIR
 
 
-@pytest.mark.parametrize("option_value", [None, "auto"])
+@pytest.mark.parametrize("option_value", [None, "auto", ""])
 def test_platform_unset_or_auto(monkeypatch, intercepted_build_args, option_value):
     if option_value is None:
         monkeypatch.delenv("CIBW_PLATFORM", raising=False)


### PR DESCRIPTION
Empty environment variables should be treated like unset environment variables where possible. This wasn't done for `CIBW_PLATFORM` #1965 (before `pyodide`, there wasn't much reason to set this on CI). 
