### PR TITLE
mac: sanitize rpaths by default

### DIFF
--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -759,7 +759,7 @@
             }
           ],
           "title": "CIBW_REPAIR_WHEEL_COMMAND",
-          "default": "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+          "default": "delocate-wheel --sanitize-rpaths --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
         },
         "test-command": {
           "$ref": "#/properties/test-command"

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -43,7 +43,7 @@ musllinux-s390x-image = "musllinux_1_2"
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+repair-wheel-command = "delocate-wheel --sanitize-rpaths --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
 


### PR DESCRIPTION
it is opt-in in delocate-wheel (I'd say it should probably be default there, too), but should probably be the default to avoid leaking CI paths into rpath of shipped binaries

This is consistent with default behavior of auditwheel.

upstream issue [suggests](https://github.com/matthew-brett/delocate/issues/101#issuecomment-1822178608) tools like cibuildwheel opt-in by default.