### PR TITLE
feat: move default `manylinux` build to `manylinux_2_28`

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -649,8 +649,8 @@ class Options:
                     )
 
                     if not config_value:
-                        # default to manylinux2014
-                        image = pinned_images["manylinux2014"]
+                        # default to manylinux_2_28
+                        image = pinned_images["manylinux_2_28"]
                     elif config_value in pinned_images:
                         image = pinned_images[config_value]
                     else:

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -23,14 +23,14 @@ test-extras = []
 
 container-engine = "docker"
 
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-manylinux-ppc64le-image = "manylinux2014"
-manylinux-s390x-image = "manylinux2014"
-manylinux-pypy_x86_64-image = "manylinux2014"
-manylinux-pypy_i686-image = "manylinux2014"
-manylinux-pypy_aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
+manylinux-pypy_x86_64-image = "manylinux_2_28"
+manylinux-pypy_i686-image = "manylinux_2_28"
+manylinux-pypy_aarch64-image = "manylinux_2_28"
 
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-i686-image = "musllinux_1_2"

--- a/docs/options.md
+++ b/docs/options.md
@@ -1161,14 +1161,14 @@ Platform-specific environment variables are also available:<br/>
 
 The available options are (default value):
 
-- `CIBW_MANYLINUX_X86_64_IMAGE` ([`quay.io/pypa/manylinux2014_x86_64`](https://quay.io/pypa/manylinux2014_x86_64))
-- `CIBW_MANYLINUX_I686_IMAGE` ([`quay.io/pypa/manylinux2014_i686`](https://quay.io/pypa/manylinux2014_i686))
-- `CIBW_MANYLINUX_PYPY_X86_64_IMAGE` ([`quay.io/pypa/manylinux2014_x86_64`](https://quay.io/pypa/manylinux2014_x86_64))
-- `CIBW_MANYLINUX_AARCH64_IMAGE` ([`quay.io/pypa/manylinux2014_aarch64`](https://quay.io/pypa/manylinux2014_aarch64))
-- `CIBW_MANYLINUX_PPC64LE_IMAGE` ([`quay.io/pypa/manylinux2014_ppc64le`](https://quay.io/pypa/manylinux2014_ppc64le))
-- `CIBW_MANYLINUX_S390X_IMAGE` ([`quay.io/pypa/manylinux2014_s390x`](https://quay.io/pypa/manylinux2014_s390x))
-- `CIBW_MANYLINUX_PYPY_AARCH64_IMAGE` ([`quay.io/pypa/manylinux2014_aarch64`](https://quay.io/pypa/manylinux2014_aarch64))
-- `CIBW_MANYLINUX_PYPY_I686_IMAGE` ([`quay.io/pypa/manylinux2014_i686`](https://quay.io/pypa/manylinux2014_i686))
+- `CIBW_MANYLINUX_X86_64_IMAGE` ([`quay.io/pypa/manylinux_2_28_x86_64`](https://quay.io/pypa/manylinux_2_28_x86_64))
+- `CIBW_MANYLINUX_I686_IMAGE` ([`quay.io/pypa/manylinux_2_28_i686`](https://quay.io/pypa/manylinux_2_28_i686))
+- `CIBW_MANYLINUX_PYPY_X86_64_IMAGE` ([`quay.io/pypa/manylinux_2_28_x86_64`](https://quay.io/pypa/manylinux_2_28_x86_64))
+- `CIBW_MANYLINUX_AARCH64_IMAGE` ([`quay.io/pypa/manylinux_2_28_aarch64`](https://quay.io/pypa/manylinux_2_28_aarch64))
+- `CIBW_MANYLINUX_PPC64LE_IMAGE` ([`quay.io/pypa/manylinux_2_28_ppc64le`](https://quay.io/pypa/manylinux_2_28_ppc64le))
+- `CIBW_MANYLINUX_S390X_IMAGE` ([`quay.io/pypa/manylinux_2_28_s390x`](https://quay.io/pypa/manylinux_2_28_s390x))
+- `CIBW_MANYLINUX_PYPY_AARCH64_IMAGE` ([`quay.io/pypa/manylinux_2_28_aarch64`](https://quay.io/pypa/manylinux_2_28_aarch64))
+- `CIBW_MANYLINUX_PYPY_I686_IMAGE` ([`quay.io/pypa/manylinux_2_28_i686`](https://quay.io/pypa/manylinux_2_28_i686))
 - `CIBW_MUSLLINUX_X86_64_IMAGE` ([`quay.io/pypa/musllinux_1_2_x86_64`](https://quay.io/pypa/musllinux_1_2_x86_64))
 - `CIBW_MUSLLINUX_I686_IMAGE` ([`quay.io/pypa/musllinux_1_2_i686`](https://quay.io/pypa/musllinux_1_2_i686))
 - `CIBW_MUSLLINUX_AARCH64_IMAGE` ([`quay.io/pypa/musllinux_1_2_aarch64`](https://quay.io/pypa/musllinux_1_2_aarch64))
@@ -1205,12 +1205,12 @@ Auditwheel detects the version of the manylinux / musllinux standard in the imag
     CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014
     CIBW_MANYLINUX_PYPY_I686_IMAGE: manylinux2014
 
-    # Build using the latest manylinux2014 release, instead of the cibuildwheel
+    # Build using the latest manylinux_2_28 release, instead of the cibuildwheel
     # pinned version
-    CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-    CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-    CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-    CIBW_MANYLINUX_PYPY_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
+    CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:latest
+    CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux_2_28_i686:latest
+    CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:latest
+    CIBW_MANYLINUX_PYPY_I686_IMAGE: quay.io/pypa/manylinux_2_28_i686:latest
 
     # Build using a different image from the docker registry
     CIBW_MANYLINUX_X86_64_IMAGE: dockcross/manylinux-x64
@@ -1236,12 +1236,12 @@ Auditwheel detects the version of the manylinux / musllinux standard in the imag
     manylinux-pypy_x86_64-image = "manylinux2014"
     manylinux-pypy_i686-image = "manylinux2014"
 
-    # Build using the latest manylinux2010 release, instead of the cibuildwheel
+    # Build using the latest manylinux_2_28 release, instead of the cibuildwheel
     # pinned version
-    manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
-    manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:latest"
-    manylinux-pypy_x86_64-image = "quay.io/pypa/manylinux2010_x86_64:latest"
-    manylinux-pypy_i686-image = "quay.io/pypa/manylinux2010_i686:latest"
+    manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:latest"
+    manylinux-i686-image = "quay.io/pypa/manylinux_2_28_i686:latest"
+    manylinux-pypy_x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:latest"
+    manylinux-pypy_i686-image = "quay.io/pypa/manylinux_2_28_i686:latest"
 
     # Build using a different image from the docker registry
     manylinux-x86_64-image = "dockcross/manylinux-x64"

--- a/test/utils.py
+++ b/test/utils.py
@@ -176,9 +176,10 @@ def expected_wheels(
                 "manylinux1",
                 "manylinux_2_17",
                 "manylinux2014",
+                "manylinux_2_28",
             ]
         else:
-            manylinux_versions = ["manylinux_2_17", "manylinux2014"]
+            manylinux_versions = ["manylinux_2_17", "manylinux2014", "manylinux_2_28"]
 
     if musllinux_versions is None:
         musllinux_versions = ["musllinux_1_2"]

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -78,20 +78,20 @@ def test_empty_selector(monkeypatch):
 @pytest.mark.parametrize(
     ("architecture", "image", "full_image"),
     [
-        ("x86_64", None, "quay.io/pypa/manylinux2014_x86_64:*"),
+        ("x86_64", None, "quay.io/pypa/manylinux_2_28_x86_64:*"),
         ("x86_64", "manylinux1", "quay.io/pypa/manylinux1_x86_64:*"),
         ("x86_64", "manylinux2010", "quay.io/pypa/manylinux2010_x86_64:*"),
         ("x86_64", "manylinux2014", "quay.io/pypa/manylinux2014_x86_64:*"),
         ("x86_64", "manylinux_2_24", "quay.io/pypa/manylinux_2_24_x86_64:*"),
         ("x86_64", "manylinux_2_28", "quay.io/pypa/manylinux_2_28_x86_64:*"),
         ("x86_64", "custom_image", "custom_image"),
-        ("i686", None, "quay.io/pypa/manylinux2014_i686:*"),
+        ("i686", None, "quay.io/pypa/manylinux_2_28_i686:*"),
         ("i686", "manylinux1", "quay.io/pypa/manylinux1_i686:*"),
         ("i686", "manylinux2010", "quay.io/pypa/manylinux2010_i686:*"),
         ("i686", "manylinux2014", "quay.io/pypa/manylinux2014_i686:*"),
         ("i686", "manylinux_2_24", "quay.io/pypa/manylinux_2_24_i686:*"),
         ("i686", "custom_image", "custom_image"),
-        ("pypy_x86_64", None, "quay.io/pypa/manylinux2014_x86_64:*"),
+        ("pypy_x86_64", None, "quay.io/pypa/manylinux_2_28_x86_64:*"),
         ("pypy_x86_64", "manylinux1", "manylinux1"),  # Does not exist
         ("pypy_x86_64", "manylinux2010", "quay.io/pypa/manylinux2010_x86_64:*"),
         ("pypy_x86_64", "manylinux2014", "quay.io/pypa/manylinux2014_x86_64:*"),

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -71,7 +71,7 @@ def test_build_default_launches(monkeypatch):
 
     # In Python 3.8+, this can be simplified to [0].kwargs
     kwargs = build_in_container.call_args_list[0][1]
-    assert "quay.io/pypa/manylinux2014_x86_64" in kwargs["container"]["image"]
+    assert "quay.io/pypa/manylinux_2_28_x86_64" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
     assert not kwargs["container"]["enforce_32_bit"]
 
@@ -79,7 +79,7 @@ def test_build_default_launches(monkeypatch):
     assert identifiers == {f"{x}-manylinux_x86_64" for x in ALL_IDS}
 
     kwargs = build_in_container.call_args_list[1][1]
-    assert "quay.io/pypa/manylinux2014_i686" in kwargs["container"]["image"]
+    assert "quay.io/pypa/manylinux_2_28_i686" in kwargs["container"]["image"]
     assert kwargs["container"]["cwd"] == PurePosixPath("/project")
     assert kwargs["container"]["enforce_32_bit"]
 

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -66,7 +66,7 @@ def test_simple_settings(tmp_path, platform, fname):
     )
 
     assert options_reader.get("manylinux-x86_64-image") == "manylinux1"
-    assert options_reader.get("manylinux-i686-image") == "manylinux2014"
+    assert options_reader.get("manylinux-i686-image") == "manylinux_2_28"
 
     with pytest.raises(ConfigOptionError):
         options_reader.get("environment", list_sep=" ")
@@ -95,7 +95,7 @@ def test_envvar_override(tmp_path, platform):
 
     assert options_reader.get("build", list_sep=" ") == "cp38*"
     assert options_reader.get("manylinux-x86_64-image") == "manylinux_2_24"
-    assert options_reader.get("manylinux-i686-image") == "manylinux2014"
+    assert options_reader.get("manylinux-i686-image") == "manylinux_2_28"
 
     assert (
         options_reader.get("test-requires", list_sep=" ")
@@ -261,7 +261,7 @@ manylinux-x86_64-image = ""
     assert options_reader.get("manylinux-i686-image") == ""
     assert options_reader.get("manylinux-aarch64-image") == "manylinux1"
 
-    assert options_reader.get("manylinux-x86_64-image", ignore_empty=True) == "manylinux2014"
+    assert options_reader.get("manylinux-x86_64-image", ignore_empty=True) == "manylinux_2_28"
     assert options_reader.get("manylinux-i686-image", ignore_empty=True) == "manylinux1"
     assert options_reader.get("manylinux-aarch64-image", ignore_empty=True) == "manylinux1"
 


### PR DESCRIPTION
### Summary
This PR moves the default `manylinux` build from `manylinux2014` to `manylinux_2_28`. The main motivation behind this is that CentOS 7, on which `manylinux2014` is based, became end-of-life end of June. It also helps projects by defaulting to more performant wheels that have improved support for modern microarchitectures.

### Motivation
The motivation to move the default `manylinux` build from `manylinux2014` to `manylinux_2_28` is two fold: On the one hand there's a necessity and on the other hand an oppertunity.
- CentOS 7 reached end-of-life in June 2024. This is already impacting users, as can be seem by steeply increased reports in the following (tracking) issues:
  - https://github.com/pypa/cibuildwheel/issues/1772
  - https://github.com/pypa/manylinux/issues/1641
- `manylinux_2_28` offers better performance and support for modern architectures, including AVX-512 support, new optimized mathematical functions, new floating point types, AArch64 and PowerPC optimizations, and [much more](https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=154ab22d7ca065af5233406927302bb7f6a66890;hb=3c03baca37fdcb52c3881e653ca392bba7a99c2b).
- Support for `manylinux_2_28` has steadily risen to 92.8% according to the [manylinux timeline](https://mayeut.github.io/manylinux-timeline/), and is expected to increase further over time.
  ![image](https://github.com/user-attachments/assets/9ebb3503-6efe-4bff-a349-bcfd6dd9d628)
  - According to [glibc versions](https://repology.org/project/glibc/versions), the distro that don't support glibc 2.28 is mainly [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/), which I think they can handle (and a newer Amazon Linux 2023 image has been available for a while).

### Implementation
- Updated default manylinux image references in `cibuildwheel/options.py` and `cibuildwheel/resources/defaults.toml`
- Modified documentation in `docs/options.md` to reflect the new default
- Adjusted test expectations in `test/utils.py` and `unit_test/option_prepare_test.py`

This PR closely follows the default move to `musllinux_1_2` in #1817.

### Impact
- Projects using cibuildwheel will now build `manylinux_2_28` wheels by default
- Existing configurations specifying `manylinux2014` or earlier will continue to work as before
- Users can still override the default to use other manylinux versions if needed

Closes https://github.com/pypa/cibuildwheel/issues/1772.