### PR TITLE
ci: update to astral-sh/setup-uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
 
-    - uses: yezz123/setup-uv@v4
+    - uses: astral-sh/setup-uv@v2
 
     # free some space to prevent reaching GHA disk space limits
     - name: Clean docker images


### PR DESCRIPTION
I think we need a fix here due to uv not handling pre-releases if `VIRTUAL_ENV` is used (I think this a bug with https://github.com/astral-sh/uv/pull/7300). Edit: change in behavior requires `--python`, which we were missing on Linux. Pushed fix to #2008.