### PR TITLE
fix: more reliably validate Podman API version 

### DIFF
--- a/cibuildwheel/errors.py
+++ b/cibuildwheel/errors.py
@@ -61,4 +61,6 @@ class AlreadyBuiltWheelError(FatalError):
 
 
 class OCIEngineTooOldError(FatalError):
-    return_code = 7
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.return_code = 7

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -105,7 +105,7 @@ def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
 
         def version_from_string(str: ver):
             return Version(ver.replace("-", "+"))
-        
+
         if engine.name == "docker":
             # --platform support was introduced in 1.32 as experimental
             # docker cp, as used by cibuildwheel, has been fixed in v24 => API 1.43, https://github.com/moby/moby/issues/38995

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -98,6 +98,7 @@ class OCIContainerEngineConfig:
 
 DEFAULT_ENGINE = OCIContainerEngineConfig("docker")
 
+
 def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
     try:
         if engine.name == "docker":

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -97,8 +97,10 @@ class OCIContainerEngineConfig:
 
 DEFAULT_ENGINE = OCIContainerEngineConfig("docker")
 
+
 def _version_from_string(version: str) -> Version:
     return Version(version.replace("-", "+"))
+
 
 def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
     try:

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -103,8 +103,8 @@ def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
         version_string = call(engine.name, "version", "-f", "{{json .}}", capture_stdout=True)
         version_info = json.loads(version_string.strip())
 
-        def version_from_string(str: ver):
-            return Version(ver.replace("-", "+"))
+        def version_from_string(version) -> Version:
+            return Version(version.replace("-", "+"))
 
         if engine.name == "docker":
             # --platform support was introduced in 1.32 as experimental

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -97,25 +97,23 @@ class OCIContainerEngineConfig:
 
 DEFAULT_ENGINE = OCIContainerEngineConfig("docker")
 
+def _version_from_string(version: str) -> Version:
+    return Version(version.replace("-", "+"))
 
 def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
     try:
         version_string = call(engine.name, "version", "-f", "{{json .}}", capture_stdout=True)
         version_info = json.loads(version_string.strip())
-
-        def version_from_string(str: version) -> Version:  # noqa: ARG001, F821
-            return Version(version.replace("-", "+"))  # noqa: F821
-
         if engine.name == "docker":
             # --platform support was introduced in 1.32 as experimental
             # docker cp, as used by cibuildwheel, has been fixed in v24 => API 1.43, https://github.com/moby/moby/issues/38995
-            client_api_version = version_from_string(version_info["Client"]["ApiVersion"])
-            engine_api_version = version_from_string(version_info["Server"]["ApiVersion"])
+            client_api_version = _version_from_string(version_info["Client"]["ApiVersion"])
+            engine_api_version = _version_from_string(version_info["Server"]["ApiVersion"])
             version_supported = min(client_api_version, engine_api_version) >= Version("1.43")
         elif engine.name == "podman":
-            client_api_version = version_from_string(version_info["Client"]["APIVersion"])
+            client_api_version = _version_from_string(version_info["Client"]["APIVersion"])
             if "Server" in version_info:
-                engine_api_version = version_from_string(version_info["Server"]["APIVersion"])
+                engine_api_version = _version_from_string(version_info["Server"]["APIVersion"])
             else:
                 engine_api_version = client_api_version
             # --platform support was introduced in v3

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -103,8 +103,8 @@ def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
         version_string = call(engine.name, "version", "-f", "{{json .}}", capture_stdout=True)
         version_info = json.loads(version_string.strip())
 
-        def version_from_string(version) -> Version:
-            return Version(version.replace("-", "+"))
+        def version_from_string(str: version) -> Version:  # noqa: ARG001, F821
+            return Version(version.replace("-", "+"))  # noqa: F821
 
         if engine.name == "docker":
             # --platform support was introduced in 1.32 as experimental

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -8,13 +8,21 @@ import shutil
 import subprocess
 import sys
 import textwrap
+from contextlib import nullcontext
 from pathlib import Path, PurePath, PurePosixPath
 
 import pytest
 import tomli_w
 
+import cibuildwheel.oci_container
 from cibuildwheel.environment import EnvironmentAssignmentBash
-from cibuildwheel.oci_container import OCIContainer, OCIContainerEngineConfig, OCIPlatform
+from cibuildwheel.errors import OCIEngineTooOldError
+from cibuildwheel.oci_container import (
+    OCIContainer,
+    OCIContainerEngineConfig,
+    OCIPlatform,
+    _check_engine_version,
+)
 from cibuildwheel.util import CIProvider, detect_ci_provider
 
 # Test utilities
@@ -569,3 +577,64 @@ def test_multiarch_image(container_engine, platform):
             OCIPlatform.S390X: "s390x",
         }
         assert output_map[platform] == output.strip()
+
+
+@pytest.mark.parametrize(
+    ("engine_name", "version", "context"),
+    [
+        (
+            "docker",
+            None,  # 17.12.1-ce does supports "docker version --format '{{json . }}'" so a version before that
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        (
+            "docker",
+            '{"Client":{"Version":"19.03.15","ApiVersion": "1.40"},"Server":{"ApiVersion": "1.40"}}',
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        (
+            "docker",
+            '{"Client":{"Version":"20.10.0","ApiVersion":"1.41"},"Server":{"ApiVersion":"1.41"}}',
+            nullcontext(),
+        ),
+        (
+            "docker",
+            '{"Client":{"Version":"24.0.0","ApiVersion":"1.43"},"Server":{"ApiVersion":"1.43"}}',
+            nullcontext(),
+        ),
+        (
+            "docker",
+            '{"Client":{"ApiVersion":"1.43"},"Server":{"ApiVersion":"1.30"}}',
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        (
+            "docker",
+            '{"Client":{"ApiVersion":"1.30"},"Server":{"ApiVersion":"1.43"}}',
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        ("podman", '{"Client":{"Version":"5.2.0"},"Server":{"Version":"5.1.2"}}', nullcontext()),
+        ("podman", '{"Client":{"Version":"4.9.4-rhel"}}', nullcontext()),
+        (
+            "podman",
+            '{"Client":{"Version":"5.2.0"},"Server":{"Version":"2.1.2"}}',
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        (
+            "podman",
+            '{"Client":{"Version":"2.2.0"},"Server":{"Version":"5.1.2"}}',
+            pytest.raises(OCIEngineTooOldError),
+        ),
+        ("podman", '{"Client":{"Version":"3.0~rc1-rhel"}}', nullcontext()),
+        ("podman", '{"Client":{"Version":"2.1.0~rc1"}}', pytest.raises(OCIEngineTooOldError)),
+    ],
+)
+def test_engine_version(engine_name, version, context, monkeypatch):
+    def mockcall(*args, **kwargs):
+        if version is None:
+            raise subprocess.CalledProcessError(1, " ".join(str(arg) for arg in args))
+        return version
+
+    monkeypatch.setattr(cibuildwheel.oci_container, "call", mockcall)
+    engine = OCIContainerEngineConfig.from_config_string(engine_name)
+    with context:
+        _check_engine_version(engine)

--- a/unit_test/utils_test.py
+++ b/unit_test/utils_test.py
@@ -6,6 +6,7 @@ from pathlib import PurePath
 import pytest
 
 from cibuildwheel.util import (
+    FlexibleVersion,
     find_compatible_wheel,
     fix_ansi_codes_for_github_actions,
     format_safe,
@@ -206,3 +207,17 @@ def test_parse_key_value_string():
         "name": ["docker"],
         "create_args": [],
     }
+
+
+def test_flexible_version_comparisons():
+    assert FlexibleVersion("2.0") == FlexibleVersion("2")
+    assert FlexibleVersion("2.0") < FlexibleVersion("2.1")
+    assert FlexibleVersion("2.1") > FlexibleVersion("2")
+    assert FlexibleVersion("1.9.9") < FlexibleVersion("2.0")
+    assert FlexibleVersion("1.10") > FlexibleVersion("1.9.9")
+    assert FlexibleVersion("3.0.1") > FlexibleVersion("3.0")
+    assert FlexibleVersion("3.0") < FlexibleVersion("3.0.1")
+    # Suffix should not affect comparisons
+    assert FlexibleVersion("1.0.1-rhel") > FlexibleVersion("1.0")
+    assert FlexibleVersion("1.0.1-rhel") < FlexibleVersion("1.1")
+    assert FlexibleVersion("1.0.1") == FlexibleVersion("v1.0.1")


### PR DESCRIPTION
This PR addresses two separate issues sometimes encountered with Podman:
 1. Sometimes, the `podman` cli utility does not support the `version` subcommand, whose output is currently used for ascertaining the "APIVersion".
 2. Podman's reported "Client.APIVersion" sometimes includes characters that the Version class cannot parse (e.g., "4.9.4-rhel")

For clients whose `podman version -f "{{json .}}"` command does function as expected, the reported "Version" and "APIVersion" values seem to match; so, this PR implements an alternate method of determining Podman's version that seems to behave more reliably across distributions + architectures: we use regex to match a valid version pattern from the single-line output of the `podman --version` command.

fix #2020 


*edit: rewritten for clarity