### PR TITLE
fix: use bash instead of sh on musllinux

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -192,7 +192,7 @@ def build_in_container(
             project=container_project_path,
             package=container_package_dir,
         )
-        container.call(["sh", "-c", before_all_prepared], env=env)
+        container.call(["bash", "-c", before_all_prepared], env=env)
 
     built_wheels: list[PurePosixPath] = []
 
@@ -258,7 +258,7 @@ def build_in_container(
                     project=container_project_path,
                     package=container_package_dir,
                 )
-                container.call(["sh", "-c", before_build_prepared], env=env)
+                container.call(["bash", "-c", before_build_prepared], env=env)
 
             log.step("Building wheel...")
 
@@ -320,7 +320,7 @@ def build_in_container(
                 repair_command_prepared = prepare_command(
                     build_options.repair_command, wheel=built_wheel, dest_dir=repaired_wheel_dir
                 )
-                container.call(["sh", "-c", repair_command_prepared], env=env)
+                container.call(["bash", "-c", repair_command_prepared], env=env)
             else:
                 container.call(["mv", built_wheel, repaired_wheel_dir])
 
@@ -365,7 +365,7 @@ def build_in_container(
                     project=container_project_path,
                     package=container_package_dir,
                 )
-                container.call(["sh", "-c", before_test_prepared], env=virtualenv_env)
+                container.call(["bash", "-c", before_test_prepared], env=virtualenv_env)
 
             # Install the wheel we just built
             # Note: If auditwheel produced two wheels, it's because the earlier produced wheel
@@ -394,7 +394,7 @@ def build_in_container(
             container.call(["mkdir", "-p", test_cwd])
             container.copy_into(test_fail_cwd_file, test_cwd / "test_fail.py")
 
-            container.call(["sh", "-c", test_command_prepared], cwd=test_cwd, env=virtualenv_env)
+            container.call(["bash", "-c", test_command_prepared], cwd=test_cwd, env=virtualenv_env)
 
             # clean up test environment
             container.call(["rm", "-rf", testing_temp_dir])
@@ -478,7 +478,7 @@ def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
 
 
 def _matches_prepared_command(error_cmd: Sequence[str], command_template: str) -> bool:
-    if len(error_cmd) < 3 or error_cmd[0:2] != ["sh", "-c"]:
+    if len(error_cmd) < 3 or error_cmd[0:2] != ["bash", "-c"]:
         return False
     command_prefix = command_template.split("{", maxsplit=1)[0].strip()
     return error_cmd[2].startswith(command_prefix)

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -355,7 +355,7 @@ class OCIContainer:
                     "exec",
                     "-i",
                     str(self.name),
-                    "sh",
+                    "bash",
                     "-c",
                     f"cat > {shell_quote(to_path)}",
                 ],

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -108,7 +108,7 @@ def test_environment(container_engine):
     ) as container:
         assert (
             container.call(
-                ["sh", "-c", "echo $TEST_VAR"], env={"TEST_VAR": "1"}, capture_output=True
+                ["bash", "-c", "echo $TEST_VAR"], env={"TEST_VAR": "1"}, capture_output=True
             )
             == "1\n"
         )
@@ -120,9 +120,9 @@ def test_environment_pass(container_engine, monkeypatch):
     with OCIContainer(
         engine=container_engine, image=DEFAULT_IMAGE, oci_platform=DEFAULT_OCI_PLATFORM
     ) as container:
-        assert container.call(["sh", "-c", "echo $CIBUILDWHEEL"], capture_output=True) == "1\n"
+        assert container.call(["bash", "-c", "echo $CIBUILDWHEEL"], capture_output=True) == "1\n"
         assert (
-            container.call(["sh", "-c", "echo $SOURCE_DATE_EPOCH"], capture_output=True)
+            container.call(["bash", "-c", "echo $SOURCE_DATE_EPOCH"], capture_output=True)
             == "1489957071\n"
         )
 
@@ -182,7 +182,7 @@ def test_large_environment(container_engine):
     ) as container:
         # check the length of d
         assert (
-            container.call(["sh", "-c", "echo ${#d}"], env=large_environment, capture_output=True)
+            container.call(["bash", "-c", "echo ${#d}"], env=large_environment, capture_output=True)
             == f"{long_env_var_length}\n"
         )
 


### PR DESCRIPTION
Fix #2036. As an alternate, manylinux could set the default shell on the musllinux images to bash, which would allow us to respect the default shell if someone provided a customize linux. And it would be more consistent across both sets of images. It's present there, but not default. @mayeut, thoughts?
