### PR TITLE
linux: use Python 3.9 in before_all

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -180,7 +180,7 @@ def build_in_container(
         log.step("Running before_all...")
 
         env = container.get_environment()
-        env["PATH"] = f'/opt/python/cp38-cp38/bin:{env["PATH"]}'
+        env["PATH"] = f'/opt/python/cp39-cp39/bin:{env["PATH"]}'
         env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
         env["PIP_ROOT_USER_ACTION"] = "ignore"
         env = before_all_options.environment.as_dictionary(

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -168,7 +168,7 @@ class OCIContainer:
         ...     print(self.debug_info())
     """
 
-    UTILITY_PYTHON = "/opt/python/cp38-cp38/bin/python"
+    UTILITY_PYTHON = "/opt/python/cp39-cp39/bin/python"
 
     process: PopenBytes
     bash_stdin: IO[bytes]


### PR DESCRIPTION
3.8 is EOL, move to 3.9

Also use Python 3.9 for utility python in oci_container.

As a side note, 3.9 is the last version available across all images being used in cibuildwheel tests.

