### PR TITLE
fix: error message when `manylinux-interpreters ensure ...` failed

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -144,25 +144,23 @@ def check_all_python_exist(
 
     for config in platform_configs:
         python_path = config.path / "bin" / "python"
-        ensure_failed = False
-        try:
-            if has_manylinux_interpreters:
-                try:
-                    container.call(["manylinux-interpreters", "ensure", config.path.name])
-                except subprocess.CalledProcessError:
-                    ensure_failed = True
-            container.call(["test", "-x", python_path])
-        except subprocess.CalledProcessError:
-            if ensure_failed:
+        if has_manylinux_interpreters:
+            try:
+                container.call(["manylinux-interpreters", "ensure", config.path.name])
+            except subprocess.CalledProcessError:
                 messages.append(
                     f"  'manylinux-interpreters ensure {config.path.name}' needed to build '{config.identifier}' failed in container running image '{container.image}'."
                     " Either the installation failed or this interpreter is not available in that image. Please check the logs."
                 )
-            else:
+                exist = False
+        else:
+            try:
+                container.call(["test", "-x", python_path])
+            except subprocess.CalledProcessError:
                 messages.append(
                     f"  '{python_path}' executable doesn't exist in image '{container.image}' to build '{config.identifier}'."
                 )
-            exist = False
+                exist = False
     if not exist:
         message = "\n".join(messages)
         raise errors.FatalError(message)

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import subprocess
 import sys
 import textwrap
@@ -133,14 +134,13 @@ def check_all_python_exist(
     *, platform_configs: Iterable[PythonConfiguration], container: OCIContainer
 ) -> None:
     exist = True
-    has_manylinux_interpreters = True
+    has_manylinux_interpreters = False
     messages = []
 
-    try:
+    with contextlib.suppress(subprocess.CalledProcessError):
         # use capture_output to keep quiet
         container.call(["manylinux-interpreters", "--help"], capture_output=True)
-    except subprocess.CalledProcessError:
-        has_manylinux_interpreters = False
+        has_manylinux_interpreters = True
 
     for config in platform_configs:
         python_path = config.path / "bin" / "python"


### PR DESCRIPTION
As reported in https://github.com/pypa/cibuildwheel/pull/2062#issuecomment-2448112031, the error message needs to be fixed.
The failure can also be seen in another build on Travis CI: https://app.travis-ci.com/github/pypa/cibuildwheel/jobs/627703558?serverType=git

2 options proposed:
- If interpreter presence check fails, check the result of `manylinux-interpreters ensure ...` to decide on the error message to present to the user.
- Don't run the presence check when `manylinux-interpreters` is available and rely only on it to pass or fail properly.