### PR TITLE
fix: update the macOS image used on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,7 @@ windows_x86_task:
 
 macos_arm64_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
 
   env:
     PATH: /opt/homebrew/opt/python@3.10/libexec/bin:$PATH
@@ -62,7 +62,7 @@ macos_arm64_task:
 
 macos_arm64_cp38_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
 
   env:
     PATH: /opt/homebrew/opt/python@3.10/libexec/bin:$PATH

--- a/examples/cirrus-ci-intel-mac.yml
+++ b/examples/cirrus-ci-intel-mac.yml
@@ -10,7 +10,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 macos_task:
   name: Build macOS x86_64 and arm64 wheels.
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}

--- a/examples/cirrus-ci-minimal.yml
+++ b/examples/cirrus-ci-minimal.yml
@@ -60,7 +60,7 @@ windows_x86_task:
 macos_arm64_task:
   name: Build macOS arm64 wheels.
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}


### PR DESCRIPTION
Use `ghcr.io/cirruslabs/macos-runner:sonoma` instead of `ghcr.io/cirruslabs/macos-sonoma-xcode` which is not supported anymore.