### PR TITLE
Bump Ruff to 0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.4
+  rev: v0.8.0
   hooks:
   - id: ruff
     args: ["--fix", "--show-fixes"]

--- a/cibuildwheel/_compat/typing.py
+++ b/cibuildwheel/_compat/typing.py
@@ -8,7 +8,7 @@ else:
     from typing import NotRequired, Self, assert_never
 
 __all__ = (
-    "assert_never",
     "NotRequired",
     "Self",
+    "assert_never",
 )

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -9,7 +9,6 @@ __all__ = (
     "PLATFORMS",
     "PathOrStr",
     "PlatformName",
-    "PLATFORMS",
     "PopenBytes",
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,6 @@ ignore = [
   "PLR",    # Design related pylint codes
   "E501",   # Line too long
   "RET504", "RET505", "RET508",  # else after control flow
-  "PT004",  # Rename suggested for returnless fixtures
   "PT007",  # False positive
   "PYI025", # Set as AbstractSet
   "ISC001", # Conflicts with formatter


### PR DESCRIPTION
Hi! I just released Ruff 0.8.0. This release removes `PT004`, which had been deprecated for a few releases, so Ruff 0.8.0 would have started emitting warnings when linting `cibuildwheel` due to the fact that you have `PT004` explicitly ignored in your Ruff config.

This PR gets rid of `PT004` from your Ruff config. There's also some additional changes made here due to the stabilisation of [`unsorted-dunder-all`](https://docs.astral.sh/ruff/rules/unsorted-dunder-all/) (`RUF022`) in this release -- let me know if these are unwelcome, and I can add them to the `tool.ruff.lint.ignore` list.