### PR TITLE
ci: warm-up docker images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ docs = [
 ]
 test = [
     "build",
+    "filelock",
     "jinja2",
     "pytest-timeout",
     "pytest-xdist",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -86,6 +86,9 @@ def docker_warmup_fixture(
     # if we're in CI testing linux, let's warm-up docker images
     if detect_ci_provider() is None or platform != "linux":
         return None
+    if request.config.getoption("--run-emulation", default=None) is not None:
+        # emulation tests only run one test in CI, caching the image only slows down the test
+        return None
 
     if worker_id == "master":
         # not executing with multiple workers

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,15 +53,12 @@ def docker_warmup(request: pytest.FixtureRequest) -> None:
     ]
     for image in images:
         try:
+            command = (
+                "manylinux-interpreters ensure $(manylinux-interpreters list 2>/dev/null | grep -v graalpy) &&"
+                "cpython3.13 -m pip download -d /tmp setuptools wheel pytest"
+            )
             container_id = subprocess.run(
-                [
-                    "docker",
-                    "create",
-                    image,
-                    "bash",
-                    "-c",
-                    "manylinux-interpreters ensure-all && cpython3.13 -m pip download -d /tmp setuptools wheel pytest",
-                ],
+                ["docker", "create", image, "bash", "-c", command],
                 text=True,
                 check=True,
                 stdout=subprocess.PIPE,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -89,6 +89,7 @@ def docker_warmup_fixture(
 
     if worker_id == "master":
         # not executing with multiple workers
+        # it might be unsafe to write to tmp_path_factory.getbasetemp().parent
         return docker_warmup(request)
 
     # get the temp directory shared by all workers

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,11 +34,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def docker_warmup(request: pytest.FixtureRequest) -> None:
     machine = request.config.getoption("--run-emulation", default=None)
     if machine is None:
-        archs = [arch.value for arch in Architecture.auto_archs("linux")]
+        archs = {arch.value for arch in Architecture.auto_archs("linux")}
     elif machine == "all":
-        archs = EMULATED_ARCHS
+        archs = set(EMULATED_ARCHS)
     else:
-        archs = [machine]
+        archs = {machine}
+
+    # Only include architectures where there are missing pre-installed interpreters
+    archs &= {"x86_64", "i686", "aarch64"}
+    if not archs:
+        return
+
     options = Options(
         platform="linux",
         command_line_arguments=CommandLineArguments.defaults(),


### PR DESCRIPTION
Let's see if we can speed-up linux CI by warming-up docker images.
This helps locally but I have a very slow Internet connection so it might not apply here.
