### PR TITLE
ci/doc: move azure macOS build to `macOS-13`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: macos_38
-  pool: {vmImage: 'macOS-12'}
+  pool: {vmImage: 'macOS-13'}
   steps:
     - task: UsePythonVersion@0
       inputs:

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -14,7 +14,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 
 - job: macos
-  pool: {vmImage: 'macOS-12'}
+  pool: {vmImage: 'macOS-13'}
   steps:
     - task: UsePythonVersion@0
     - bash: |


### PR DESCRIPTION
The macOS-12 environment is deprecated.