### PR TITLE
Bump to Pyodide 0.27

### DIFF
--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -190,5 +190,5 @@ python_configurations = [
 
 [pyodide]
 python_configurations = [
-  { identifier = "cp312-pyodide_wasm32", version = "3.12", pyodide_version = "0.26.4", pyodide_build_version = "0.29.0", emscripten_version = "3.1.58", node_version = "v20" },
+  { identifier = "cp312-pyodide_wasm32", version = "3.12", pyodide_version = "0.27.0", pyodide_build_version = "0.29.2", emscripten_version = "3.1.58", node_version = "v20" },
 ]

--- a/cibuildwheel/resources/constraints-pyodide312.txt
+++ b/cibuildwheel/resources/constraints-pyodide312.txt
@@ -2,7 +2,7 @@
 #    nox -s update_constraints
 annotated-types==0.7.0
     # via pydantic
-anyio==4.6.2.post1
+anyio==4.7.0
     # via httpx
 auditwheel-emscripten==0.0.16
     # via pyodide-build
@@ -10,16 +10,16 @@ build==1.2.2.post1
     # via
     #   -r .nox/update_constraints/tmp/constraints-pyodide.in
     #   pyodide-build
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via typer
-cmake==3.31.1
+cmake==3.31.2
     # via pyodide-build
 distlib==0.3.9
     # via virtualenv
@@ -29,7 +29,7 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via unearth
 idna==3.10
     # via
@@ -52,15 +52,15 @@ pip==24.3.1
     # via -r .nox/update_constraints/tmp/constraints-pyodide.in
 platformdirs==4.3.6
     # via virtualenv
-pydantic==2.10.1
+pydantic==2.10.4
     # via
     #   pyodide-build
     #   pyodide-lock
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
 pygments==2.18.0
     # via rich
-pyodide-build==0.29.0
+pyodide-build==0.29.2
     # via -r .nox/update_constraints/tmp/constraints-pyodide.in
 pyodide-cli==0.2.4
     # via
@@ -79,31 +79,30 @@ rich==13.9.4
     #   pyodide-build
     #   pyodide-cli
     #   typer
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.7
     # via pyodide-build
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 shellingham==1.5.4
     # via typer
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-typer==0.13.1
+    # via anyio
+typer==0.15.1
     # via
     #   auditwheel-emscripten
     #   pyodide-build
     #   pyodide-cli
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   pydantic
     #   pydantic-core
     #   typer
 unearth==0.17.2
     # via pyodide-build
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via
     #   build
     #   pyodide-build


### PR DESCRIPTION
## Description

https://github.com/pyodide/pyodide/releases/tag/0.27.0 is now available on 01-01-2025, and so are the [new xbuildenvs](https://github.com/pyodide/pyodide/blob/1e37b7fce9b89f82cd39b7578317c41ddf0aa947/pyodide-cross-build-environments.json#L2-L9) for it. This PR updates the Pyodide version from 0.26.4 to 0.27.0, and the version of `pyodide-build` from 0.29.0 to 0.29.2.