### PR TITLE
feat: add armv7l in auto_archs when running on aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: jammy
 language: python
 
 branches:
@@ -8,29 +8,19 @@ branches:
 
 jobs:
   include:
-    - name: Linux | x86_64 + i686 | Python 3.11
-      python: 3.11
+    - name: Linux | x86_64 + i686 | Python 3.12
+      python: 3.12
       services: docker
       env: PYTHON=python
 
-    - name: Linux | arm64 | Python 3.11
-      python: 3.11
+    - name: Linux | arm64 | Python 3.12
+      python: 3.12
       services: docker
-      arch: arm64-graviton2
-      group: edge
-      virt: vm
+      arch: arm64
       env: PYTHON=python
-      # docker is outdated in the arm64-graviton2 vm focal image (19.x)
-      # we need to upgrade to get >= 24.0
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
-          packages:
-            - docker-ce docker-ce-cli containerd.io
 
-    - name: Linux | ppc64le | Python 3.11
-      python: 3.11
+    - name: Linux | ppc64le | Python 3.12
+      python: 3.12
       services: docker
       arch: ppc64le
       allow_failure: True
@@ -40,16 +30,16 @@ jobs:
         # c.f. https://travis-ci.community/t/running-out-of-disk-space-quota-when-using-docker-on-ppc64le/11634
         - PYTEST_ADDOPTS='-k "not test_manylinuxXXXX_only"'
 
-    - name: Windows | x86_64 | Python 3.11
+    - name: Windows | x86_64 | Python 3.12
       os: windows
       language: shell
       before_install:
-        - choco upgrade python3 -y --version 3.11.9 --limit-output --params "/InstallDir:C:\\Python311"
+        - choco upgrade python3 -y --version 3.12.8 --limit-output --params "/InstallDir:C:\\Python312"
       env:
-        - PYTHON=C:\\Python311\\python
+        - PYTHON=C:\\Python312\\python
 
-    - name: Linux | s390x | Python 3.11
-      python: 3.11
+    - name: Linux | s390x | Python 3.12
+      python: 3.12
       services: docker
       arch: s390x
       allow_failure: True

--- a/CI.md
+++ b/CI.md
@@ -1,11 +1,11 @@
 This is a summary of the host Python versions and platforms covered by the different CI platforms:
 
-|         | 3.11                                         | 3.12                                        | 3.13           |
-|---------|----------------------------------------------|---------------------------------------------|----------------|
-| Linux   | Azure Pipelines / GitHub Actions / Travis CI | AppVeyor¹ / CircleCI¹ / Cirrus CI / GitLab¹ | GitHub Actions |
-| macOS   | Azure Pipelines / GitLab¹                    | AppVeyor¹ / CircleCI¹ / Cirrus CI / GitLab¹ | GitHub Actions |
-| Windows | Azure Pipelines / Travis CI                  | AppVeyor¹ / Cirrus CI / GitLab¹             | GitHub Actions |
+|         | 3.11                             | 3.12                                                    | 3.13           |
+|---------|----------------------------------|---------------------------------------------------------|----------------|
+| Linux   | Azure Pipelines / GitHub Actions | AppVeyor¹ / CircleCI¹ / Cirrus CI / GitLab¹ / Travis CI | GitHub Actions |
+| macOS   | Azure Pipelines                  | AppVeyor¹ / CircleCI¹ / Cirrus CI / GitLab¹             | GitHub Actions |
+| Windows | Azure Pipelines                  | AppVeyor¹ / Cirrus CI / GitLab¹ / Travis CI             | GitHub Actions |
 
 > ¹ Runs a reduced set of tests to reduce CI load
 
-Non-x86 architectures are covered on Travis CI using Python 3.11.
+Non-x86 architectures are covered on Travis CI using Python 3.12.

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -26,10 +26,7 @@ jobs:
           # configure cibuildwheel on Linux to build native archs ('auto'),
           # and to split the remaining architectures between the x86_64 and
           # ARM runners
-          # armv7l can be built without QEMU on GitHub Actions ARM runners but that's
-          # not the case on all ARM64 hardware hence 'auto armv7l' for native archs
-          # on the GHA ARM64 runner
-          CIBW_ARCHS_LINUX: ${{ runner.arch == 'X64' && 'auto ppc64le s390x' || 'auto armv7l' }}
+          CIBW_ARCHS_LINUX: ${{ runner.arch == 'X64' && 'auto ppc64le s390x' || 'auto' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/examples/travis-ci-deploy.yml
+++ b/examples/travis-ci-deploy.yml
@@ -2,7 +2,7 @@
 # commit, but will only push to PyPI on tagged commits.
 
 os: linux
-dist: focal
+dist: jammy
 language: python
 python: "3.12"
 

--- a/examples/travis-ci-minimal.yml
+++ b/examples/travis-ci-minimal.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: jammy
 language: python
 python: "3.12"
 

--- a/examples/travis-ci-test-and-deploy.yml
+++ b/examples/travis-ci-test-and-deploy.yml
@@ -6,7 +6,7 @@
 # distribution is also created.
 
 os: linux
-dist: focal
+dist: jammy
 language: python
 python: "3.12"
 

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -108,6 +108,9 @@ def test(manylinux_image, tmp_path):
     if manylinux_image in {"manylinux_2_28", "manylinux_2_34"} and platform.machine() == "x86_64":
         # We don't have a manylinux_2_28+ image for i686
         add_env["CIBW_ARCHS"] = "x86_64"
+    if platform.machine() == "aarch64":
+        # We just have a manylinux_2_31 image for armv7l
+        add_env["CIBW_ARCHS"] = "aarch64"
 
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env=add_env)
 
@@ -149,5 +152,9 @@ def test(manylinux_image, tmp_path):
     if manylinux_image in {"manylinux_2_28", "manylinux_2_34"} and platform.machine() == "x86_64":
         # We don't have a manylinux_2_28+ image for i686
         expected_wheels = [w for w in expected_wheels if "i686" not in w]
+
+    if platform.machine() == "aarch64":
+        # We just have a manylinux_2_31 image for armv7l
+        expected_wheels = [w for w in expected_wheels if "armv7l" not in w]
 
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_musllinux_X_Y_only.py
+++ b/test/test_musllinux_X_Y_only.py
@@ -38,7 +38,7 @@ def test(musllinux_image, tmp_path):
 
     # build the wheels
     add_env = {
-        "CIBW_SKIP": "*-manylinux*",
+        "CIBW_SKIP": "*-manylinux* *_armv7l",
         "CIBW_MUSLLINUX_X86_64_IMAGE": musllinux_image,
         "CIBW_MUSLLINUX_I686_IMAGE": musllinux_image,
         "CIBW_MUSLLINUX_AARCH64_IMAGE": musllinux_image,
@@ -54,4 +54,5 @@ def test(musllinux_image, tmp_path):
         musllinux_versions=[musllinux_image],
         single_python=True,
     )
+    expected_wheels = [w for w in expected_wheels if "armv7l" not in w]
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -68,7 +68,7 @@ class TestSpam(TestCase):
         # See #336 for more info.
         bits = struct.calcsize("P") * 8
         if bits == 32:
-            self.assertIn(platform.machine(), ["i686", "wasm32"])
+            self.assertIn(platform.machine(), ["i686", "armv7l","armv8l", "wasm32"])
 '''
 
 

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from cibuildwheel import __main__, linux, macos, pyodide, windows
+from cibuildwheel import __main__, architecture, linux, macos, pyodide, windows
 from cibuildwheel.util import file
 
 
@@ -44,8 +44,8 @@ def mock_protection(monkeypatch):
     monkeypatch.setattr(linux, "build", fail_on_call)
     monkeypatch.setattr(macos, "build", fail_on_call)
     monkeypatch.setattr(pyodide, "build", fail_on_call)
-
     monkeypatch.setattr(Path, "mkdir", ignore_call)
+    monkeypatch.setattr(architecture, "_check_aarch32_el0", lambda: True)
 
 
 @pytest.fixture(autouse=True)

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -555,7 +555,7 @@ def test_local_image(
 ) -> None:
     if (
         detect_ci_provider() in {CIProvider.travis_ci}
-        and pm in {"s390x", "ppc64le"}
+        and pm != "x86_64"
         and platform != DEFAULT_OCI_PLATFORM
     ):
         pytest.skip("Skipping test because docker on this platform does not support QEMU")
@@ -585,7 +585,7 @@ def test_local_image(
 def test_multiarch_image(container_engine, platform):
     if (
         detect_ci_provider() in {CIProvider.travis_ci}
-        and pm in {"s390x", "ppc64le"}
+        and pm != "x86_64"
         and platform != DEFAULT_OCI_PLATFORM
     ):
         pytest.skip("Skipping test because docker on this platform does not support QEMU")


### PR DESCRIPTION
This depends on aarch32 EL0 support and thus is done conditionally.

This uses a `linux32` call to check for support.

Things weren't working well on Travis CI for some reason. Given all examples are using LXD, I updated tests to use that as well and running armv7l  does not seem supported on that infrastructure.

The feature was first requested in https://github.com/pypa/cibuildwheel/pull/2135#discussion_r1924179661