### PR TITLE
chore: use nox 2025.2.9 features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       with:
         python-version: "3.x"
     - uses: pre-commit/action@v3.0.1
-    - name: Check manifest
-      run: pipx run --python "${{ steps.python.outputs.python-path }}" nox -s check_manifest
     - name: PyLint checks
       run: pipx run --python "${{ steps.python.outputs.python-path }}" nox -s pylint -- --output-format=github
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     additional_dependencies: &mypy-dependencies
       - bracex
       - dependency-groups>=1.2
-      - nox
+      - nox>=2025.2.9
       - orjson
       - packaging
       - pygithub

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,45 +1,36 @@
+#!/usr/bin/env -S uv run
+
+# /// script
+# dependencies = ["nox>=2025.2.9"]
+# ///
+
+"""
+cibuildwheel's nox support
+
+Tags:
+
+    lint: All linting jobs
+    update: All update jobs
+
+See sessions with `nox -l`
+"""
+
 from __future__ import annotations
 
 import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any
 
 import nox
 
-nox.needs_version = ">=2024.4.15"
-nox.options.sessions = ["lint", "pylint", "check_manifest", "tests"]
+nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv|virtualenv"
 
 DIR = Path(__file__).parent.resolve()
 
 
-def install_and_run(session: nox.Session, script: str, *args: str, **kwargs: Any) -> str | None:
-    deps = nox.project.load_toml(script)["dependencies"]
-    session.install(*deps)
-    return session.run("python", script, *args, **kwargs)
-
-
-def dep_group(group: str) -> list[str]:
-    return nox.project.load_toml("pyproject.toml")["dependency-groups"][group]  # type: ignore[no-any-return]
-
-
-@nox.session
-def tests(session: nox.Session) -> None:
-    """
-    Run the unit and regular tests.
-    """
-    session.install("-e.", *dep_group("test"))
-    if session.posargs:
-        session.run("pytest", *session.posargs)
-    else:
-        unit_test_args = ["--run-docker"] if sys.platform.startswith("linux") else []
-        session.run("pytest", "unit_test", *unit_test_args)
-        session.run("pytest", "test", "-x", "--durations", "0", "--timeout=2400", "test")
-
-
-@nox.session
+@nox.session(tags=["lint"])
 def lint(session: nox.Session) -> None:
     """
     Run the linter.
@@ -48,7 +39,7 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
-@nox.session
+@nox.session(tags=["lint"])
 def pylint(session: nox.Session) -> None:
     """
     Run pylint.
@@ -59,16 +50,21 @@ def pylint(session: nox.Session) -> None:
 
 
 @nox.session
-def check_manifest(session: nox.Session) -> None:
+def tests(session: nox.Session) -> None:
     """
-    Ensure all needed files are included in the manifest.
+    Run the unit and regular tests.
     """
+    pyproject = nox.project.load_toml()
+    session.install("-e.", *nox.project.dependency_groups(pyproject, "test"))
+    if session.posargs:
+        session.run("pytest", *session.posargs)
+    else:
+        unit_test_args = ["--run-docker"] if sys.platform.startswith("linux") else []
+        session.run("pytest", "unit_test", *unit_test_args)
+        session.run("pytest", "test", "-x", "--durations", "0", "--timeout=2400", "test")
 
-    session.install("check-manifest")
-    session.run("check-manifest", *session.posargs)
 
-
-@nox.session
+@nox.session(default=False, tags=["update"])
 def update_constraints(session: nox.Session) -> None:
     """
     Update the dependencies inplace.
@@ -122,59 +118,60 @@ def update_constraints(session: nox.Session) -> None:
         )
 
 
-@nox.session
+@nox.session(default=False, tags=["update"])
 def update_pins(session: nox.Session) -> None:
     """
     Update the python, docker and virtualenv pins version inplace.
     """
-    session.install("-e.", *dep_group("bin"))
+    pyproject = nox.project.load_toml()
+    session.install("-e.", *nox.project.dependency_groups(pyproject, "bin"))
     session.run("python", "bin/update_pythons.py", "--force")
     session.run("python", "bin/update_docker.py")
     session.run("python", "bin/update_virtualenv.py", "--force")
     session.run("python", "bin/update_nodejs.py", "--force")
 
 
-@nox.session(reuse_venv=True)
+@nox.session(default=False, reuse_venv=True, tags=["update"])
 def update_proj(session: nox.Session) -> None:
     """
     Update the README inplace.
     """
-    install_and_run(
-        session,
+    session.install_and_run_script(
         "bin/projects.py",
         "docs/data/projects.yml",
         *session.posargs,
     )
 
 
-@nox.session(reuse_venv=True)
+@nox.session(default=False, reuse_venv=True, tags=["update"])
 def generate_schema(session: nox.Session) -> None:
     """
     Generate the cibuildwheel.schema.json file.
     """
-    output = install_and_run(session, "bin/generate_schema.py", silent=True)
+    output = session.install_and_run_script("bin/generate_schema.py", silent=True)
     assert isinstance(output, str)
     DIR.joinpath("cibuildwheel/resources/cibuildwheel.schema.json").write_text(output)
 
 
-@nox.session(reuse_venv=True)
+@nox.session(default=False, reuse_venv=True)
 def bump_version(session: nox.Session) -> None:
     """
     Bump cibuildwheel's version. Interactive.
     """
-    install_and_run(session, "bin/bump_version.py")
+    session.install_and_run_script("bin/bump_version.py")
 
 
-@nox.session(python="3.12")
+@nox.session(default=False, python="3.12")
 def docs(session: nox.Session) -> None:
     """
     Build the docs. Will serve unless --non-interactive
     """
-    session.install("-e.", *dep_group("docs"))
+    pyproject = nox.project.load_toml()
+    session.install("-e.", *nox.project.dependency_groups(pyproject, "docs"))
     session.run("mkdocs", "serve" if session.interactive else "build", "--strict", *session.posargs)
 
 
-@nox.session
+@nox.session(default=False)
 def build(session: nox.Session) -> None:
     """
     Build an SDist and wheel.
@@ -190,3 +187,7 @@ def build(session: nox.Session) -> None:
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+if __name__ == "__main__":
+    nox.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,12 +200,12 @@ extend-select = [
   "PYI",         # flake8-pyi
 ]
 ignore = [
-  "PLR",    # Design related pylint codes
-  "E501",   # Line too long
+  "PLR",     # Design related pylint codes
   "RET504", "RET505", "RET508",  # else after control flow
-  "PT007",  # False positive
-  "PYI025", # Set as AbstractSet
-  "ISC001", # Conflicts with formatter
+  "PT007",   # Lists of tuples in Pytest
+  "PYI025",  # Set as AbstractSet
+  "ISC001",  # Conflicts with formatter
+  "EXE003",  # Ruff doesn't like uv?
 ]
 flake8-unused-arguments.ignore-variadic-names = true
 


### PR DESCRIPTION
Using new features in nox 2025. This can now be run with `uv run`, `pipx run`, `hatch run`, etc.
