### PR TITLE
fix: avoid races in filesystem ops

### DIFF
--- a/bin/update_how_it_works_image.py
+++ b/bin/update_how_it_works_image.py
@@ -42,8 +42,7 @@ def main() -> None:
     )
 
     dest_path = Path("docs/data/how-it-works.png")
-    if dest_path.exists():
-        dest_path.unlink()
+    dest_path.unlink(missing_ok=True)
 
     Path(screenshot).rename(dest_path)
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -399,8 +399,7 @@ def build_in_directory(args: CommandLineArguments) -> None:
 
     output_dir = options.globals.output_dir
 
-    if not output_dir.exists():
-        output_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     tmp_path = Path(mkdtemp(prefix="cibw-run-")).resolve(strict=True)
     try:

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -25,8 +25,7 @@ CIBW_CACHE_PATH: Final[Path] = Path(
 def download(url: str, dest: Path) -> None:
     print(f"+ Download {url} to {dest}")
     dest_dir = dest.parent
-    if not dest_dir.exists():
-        dest_dir.mkdir(parents=True)
+    dest_dir.mkdir(parents=True, exist_ok=True)
 
     # we've had issues when relying on the host OS' CA certificates on Windows,
     # so we use certifi (this sounds odd but requests also does this by default)

--- a/test/test_custom_repair_wheel.py
+++ b/test/test_custom_repair_wheel.py
@@ -21,8 +21,7 @@ platform = wheel.stem.split("-")[-1]
 name = f"spam-0.1.0-py2-none-{platform}.whl"
 dest = dest_dir / name
 dest_dir.mkdir(parents=True, exist_ok=True)
-if dest.exists():
-    dest.unlink()
+dest.unlink(missing_ok=True)
 shutil.copy(wheel, dest)
 """
 


### PR DESCRIPTION
Use `exist_ok` and `missing_ok` in pathlib operations where we can.

I didn't do an exhaustive audit of pathlib usage, but I did look at places where the code was using `path.exists()`. There's still a couple of places with this pattern:

```python
if path.exists():
    shutil.rmtree(path)
```

I don't think there's an elegant solution that will work across Python versions currently, although in 3.13 I think one can do:

```python
try:
    shutil.rmtree(path)
except FileNotFoundError:
    pass
```

Because: "*Changed in version 3.13*: `rmtree()` now ignores `FileNotFoundError` exceptions for all but the top-level path." (https://docs.python.org/3.13/library/shutil.html#shutil.rmtree)

Fixes #2279.