### PR TITLE
fix: no module named pip in externally managed envs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
       id: python
       with:
         python-version: "3.12"
-        update-environment: false
+        update-environment: true
 
     - id: cibw
       run: |


### PR DESCRIPTION
Fixes `No module named pip` on self-hosted runners with externally managed Python environments. See https://github.com/pypa/cibuildwheel/issues/2277