### PR TITLE
feat: Print FatalError messages using Logger

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -255,7 +255,7 @@ def _compute_platform_auto() -> PlatformName:
         return "windows"
     else:
         msg = (
-            'cibuildwheel: Unable to detect platform from "sys.platform". cibuildwheel doesn\'t '
+            'Unable to detect platform from "sys.platform". cibuildwheel doesn\'t '
             "support building wheels for this platform. You might be able to build for a different "
             "platform using the --platform argument. Check --help output for more information."
         )
@@ -345,9 +345,8 @@ def print_new_wheels(msg: str, output_dir: Path) -> Generator[None, None, None]:
 def build_in_directory(args: CommandLineArguments) -> None:
     platform: PlatformName = _compute_platform(args)
     if platform == "pyodide" and sys.platform == "win32":
-        msg = "cibuildwheel: Building for pyodide is not supported on Windows"
-        print(msg, file=sys.stderr)
-        sys.exit(2)
+        msg = "Building for pyodide is not supported on Windows"
+        raise errors.ConfigurationError(msg)
 
     options = compute_options(platform=platform, command_line_arguments=args, env=os.environ)
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -70,7 +70,7 @@ def main() -> None:
         if log.step_active:
             log.step_end_with_error(message)
         else:
-            print(f"cibuildwheel: {message}", file=sys.stderr)
+            log.error(message)
 
         if global_options.print_traceback_on_error:
             traceback.print_exc(file=sys.stderr)

--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -10,6 +10,8 @@ from collections.abc import Set
 from enum import Enum
 from typing import Final, Literal, assert_never
 
+from cibuildwheel import errors
+
 from .typing import PlatformName
 
 PRETTY_NAMES: Final[dict[PlatformName, str]] = {
@@ -89,7 +91,11 @@ class Architecture(Enum):
             elif arch_str == "auto32":
                 result |= Architecture.bitness_archs(platform=platform, bitness="32")
             else:
-                result.add(Architecture(arch_str))
+                try:
+                    result.add(Architecture(arch_str))
+                except ValueError as e:
+                    msg = f"Invalid architecture '{arch_str}'"
+                    raise errors.ConfigurationError(msg) from e
         return result
 
     @staticmethod

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -453,12 +453,12 @@ def build(options: Options, tmp_path: Path) -> None:  # noqa: ARG001
         except subprocess.CalledProcessError as error:
             msg = unwrap(
                 f"""
-                cibuildwheel: {build_step.container_engine.name} not found. An
-                OCI exe like Docker or Podman is required to run Linux builds.
-                If you're building on Travis CI, add `services: [docker]` to
-                your .travis.yml. If you're building on Circle CI in Linux,
-                add a `setup_remote_docker` step to your .circleci/config.yml.
-                If you're building on Cirrus CI, use `docker_builder` task.
+                {build_step.container_engine.name} not found. An OCI exe like
+                Docker or Podman is required to run Linux builds. If you're
+                building on Travis CI, add `services: [docker]` to your
+                .travis.yml. If you're building on Circle CI in Linux, add a
+                `setup_remote_docker` step to your .circleci/config.yml. If
+                you're building on Cirrus CI, use `docker_builder` task.
                 """
             )
             raise errors.ConfigurationError(msg) from error

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -135,24 +135,24 @@ class Logger:
 
     def notice(self, message: str) -> None:
         if self.fold_mode == "github":
-            print(f"::notice::{message}\n", file=sys.stderr)
+            print(f"::notice::cibuildwheel: {message}\n", file=sys.stderr)
         else:
             c = self.colors
-            print(f"{c.bold}Note{c.end}: {message}\n", file=sys.stderr)
+            print(f"cibuildwheel: {c.bold}note{c.end}: {message}\n", file=sys.stderr)
 
     def warning(self, message: str) -> None:
         if self.fold_mode == "github":
-            print(f"::warning::{message}\n", file=sys.stderr)
+            print(f"::warning::cibuildwheel: {message}\n", file=sys.stderr)
         else:
             c = self.colors
-            print(f"{c.yellow}Warning{c.end}: {message}\n", file=sys.stderr)
+            print(f"cibuildwheel: {c.yellow}warning{c.end}: {message}\n", file=sys.stderr)
 
     def error(self, error: BaseException | str) -> None:
         if self.fold_mode == "github":
-            print(f"::error::{error}\n", file=sys.stderr)
+            print(f"::error::cibuildwheel: {error}\n", file=sys.stderr)
         else:
             c = self.colors
-            print(f"{c.bright_red}Error{c.end}: {error}\n", file=sys.stderr)
+            print(f"cibuildwheel: {c.bright_red}error{c.end}: {error}\n", file=sys.stderr)
 
     @property
     def step_active(self) -> bool:

--- a/cibuildwheel/macos.py
+++ b/cibuildwheel/macos.py
@@ -267,7 +267,7 @@ def setup_python(
     which_python = call("which", "python", env=env, capture_stdout=True).strip()
     print(which_python)
     if which_python != str(venv_bin_path / "python"):
-        msg = "cibuildwheel: python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
+        msg = "python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
         raise errors.FatalError(msg)
     call("python", "--version", env=env)
 
@@ -277,7 +277,7 @@ def setup_python(
         which_pip = call("which", "pip", env=env, capture_stdout=True).strip()
         print(which_pip)
         if which_pip != str(venv_bin_path / "pip"):
-            msg = "cibuildwheel: pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it."
+            msg = "pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it."
             raise errors.FatalError(msg)
         call("pip", "--version", env=env)
 

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -43,7 +43,7 @@ def test_unknown_platform_on_ci(monkeypatch, capsys):
     assert exit.value.code == 2
     _, err = capsys.readouterr()
 
-    assert 'cibuildwheel: Unable to detect platform from "sys.platform"' in err
+    assert 'Unable to detect platform from "sys.platform"' in err
 
 
 def test_unknown_platform(monkeypatch, capsys):
@@ -54,7 +54,7 @@ def test_unknown_platform(monkeypatch, capsys):
     _, err = capsys.readouterr()
 
     assert exit.value.code == 2
-    assert "cibuildwheel: Unsupported platform: nonexistent" in err
+    assert "Unsupported platform: nonexistent" in err
 
 
 def test_platform_argument(platform, intercepted_build_args, monkeypatch):
@@ -278,4 +278,4 @@ def test_pyodide_on_windows(monkeypatch, capsys):
     _, err = capsys.readouterr()
 
     assert exit.value.code == 2
-    assert "cibuildwheel: Building for pyodide is not supported on Windows" in err
+    assert "Building for pyodide is not supported on Windows" in err


### PR DESCRIPTION
This makes them appear GHA annotations in CI logs, which makes them easier to spot. I've also added the "cibuildwheel: " prefix to those errors, I think it helps when viewing a log to know which tool is talking to you - it can be difficult to understand with build tools.
