### PR TITLE
chore: only build on push to main for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ branches:
   only:
   - main
 
+# only build the main branch or PR that explicitely want to test with Travis CI
+if: (type = "push") OR (commit_message =~ /travis-ci/)
+
 jobs:
   include:
     - name: Linux | x86_64 + i686 | Python 3.12


### PR DESCRIPTION
As mentioned in #2290, start reducing Travis-CI testing on x86_64.
With the 1 concurrent job plan, it should allow to get a faster status for Pull Requests.