### PR TITLE
fix(ci): Cirrus CI does not allow armv7l builds on aarch64

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -27,6 +27,7 @@ SINGLE_PYTHON_VERSION: Final[tuple[int, int]] = (3, 12)
 _AARCH64_CAN_RUN_ARMV7: Final[bool] = Architecture.aarch64.value not in EMULATED_ARCHS and {
     None: Architecture.armv7l.value not in EMULATED_ARCHS,
     CIProvider.travis_ci: False,
+    CIProvider.cirrus_ci: False,
 }.get(detect_ci_provider(), True)
 
 platform = os.environ.get("CIBW_PLATFORM", "")


### PR DESCRIPTION
c.f. last build on main

`linux32 uname -m` fails on Cirrus CI