### PR TITLE
fix(docs/faq): update rust toolchain intructions

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -288,11 +288,34 @@ If you build Rust wheels, you need to download the Rust compilers in manylinux.
 If you support 32-bit Windows, you need to add this as a potential target. You
 can do this on GitHub Actions, for example, with:
 
-```yaml
-CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
-CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
-CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
-```
+!!! tab examples "Environment variables"
+
+    ```yaml
+    CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y && rustup show active-toolchain &>/dev/null || rustup toolchain install
+    CIBW_BEFORE_ALL_WINDOWS: rustup show active-toolchain || rustup toolchain install && rustup target add i686-pc-windows-msvc
+    CIBW_BEFORE_ALL_MACOS: rustup show active-toolchain &>/dev/null || rustup toolchain install
+    CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+    ```
+
+!!! tab examples "pyproject.toml"
+
+    ```toml
+    [tool.cibuildwheel.linux]
+    before-all = [
+    "curl -sSf https://sh.rustup.rs | sh -s -- -y",
+    "rustup show active-toolchain &>/dev/null || rustup toolchain install",
+    ]
+    environment = { PATH = "$HOME/.cargo/bin:$PATH" }
+
+    [tool.cibuildwheel.macos]
+    before-all = "rustup show active-toolchain &>/dev/null || rustup toolchain install"
+
+    [tool.cibuildwheel.windows]
+    before-all = [
+    "rustup show active-toolchain || rustup toolchain install",
+    "rustup target add i686-pc-windows-msvc",
+    ]
+    ```
 
 Rust does not provide Cargo for musllinux 32-bit, so that needs to be skipped:
 


### PR DESCRIPTION
Fixes https://github.com/pypa/cibuildwheel/issues/2303

This change did fix my CI, as you can see over here: https://github.com/Ravencentric/rnzb/pull/10/files.

I basically grabbed the PowerShell commands from the blog post: https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280, and then added equivalent commands for Linux and macOS. I've also added a `pyproject.toml` for the same. I'm not really sure if this is the best way to handle it, so any feedback or suggestions on whether this is the right approach would be really welcome!