### PR TITLE
examples/github-deploy.yml: add `print-hash: true` to log hashes to log

### DIFF
--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -89,6 +89,7 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
+          print-hash: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
- `print-hash: true` shows hashes of files to be uploaded:
  https://github.com/pypa/gh-action-pypi-publish#showing-hash-values-of-files-to-be-uploaded
- it is a good idea to log artifact hashes in the build logs
- in the docs as well:
  - [ ] https://github.com/pypa/cibuildwheel/blob/1826f7068262b8cb6b59fe9dd1b408a825d63fa6/docs/deliver-to-pypi.md?plain=1#L78-L84