### PR TITLE
fix: always resolve --python argument

### DIFF
--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -96,6 +96,10 @@ def virtualenv(
     dependency_constraint_flags are ignored since nothing is installed in the
     venv. Otherwise, pip is installed, and setuptools + wheel if Python < 3.12.
     """
+
+    # virtualenv may fail if this is a symlink.
+    python = python.resolve()
+
     assert python.exists()
 
     if use_uv:


### PR DESCRIPTION
This will fix https://github.com/pypa/cibuildwheel/issues/2327. `uvx git+https://github.com/henryiii/cibuildwheel@henryiii/fix/uvx --only cp312-pyodide_wasm32` does seem to pass with this.

Virtualenv can break if the `--python` argument is a symlink.