### PR TITLE
Correct Github Actions CI instability for iOS.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-15]
         python_version: ['3.13']
         include:
         - os: ubuntu-latest

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -34,15 +34,39 @@ if __name__ == "__main__":
         if args.run_podman:
             unit_test_args += ["--run-podman"]
 
+    print(
+        "\n\n================================== UNIT TESTS ==================================",
+        flush=True,
+    )
     subprocess.run(unit_test_args, check=True)
 
-    # integration tests
+    # Run the serial integration tests without multiple processes
+    serial_integration_test_args = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-m",
+        "serial",
+        "-x",
+        "--durations",
+        "0",
+        "--timeout=2400",
+        "test",
+        "-vv",
+    ]
+    print(
+        "\n\n=========================== SERIAL INTEGRATION TESTS ===========================",
+        flush=True,
+    )
+    subprocess.run(serial_integration_test_args, check=True)
+
+    # Non-serial integration tests
     integration_test_args = [
         sys.executable,
         "-m",
         "pytest",
-        "--dist",
-        "loadgroup",
+        "-m",
+        "not serial",
         f"--numprocesses={args.num_processes}",
         "-x",
         "--durations",
@@ -55,4 +79,8 @@ if __name__ == "__main__":
     if sys.platform.startswith("linux") and args.run_podman:
         integration_test_args += ["--run-podman"]
 
+    print(
+        "\n\n========================= NON-SERIAL INTEGRATION TESTS =========================",
+        flush=True,
+    )
     subprocess.run(integration_test_args, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,9 @@ junit_family = "xunit2"
 xfail_strict = true
 filterwarnings = ["error"]
 log_cli_level = "info"
-
+markers = [
+    "serial: tests that must *not* be run in parallel (deselect with '-m \"not serial\"')",
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -18,6 +18,15 @@ basic_project = test_projects.new_c_project(
 )
 
 
+@pytest.mark.serial
+def test_dummy_serial():
+    """A no-op test to ensure that at least one serial test is always found.
+
+    Without this no-op test, CI fails on CircleCI because no serial tests are
+    found, and pytest errors if a test suite finds no tests.
+    """
+
+
 def test(tmp_path, build_frontend_env, capfd):
     project_dir = tmp_path / "project"
     basic_project.generate(project_dir)

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -20,10 +20,12 @@ class TestPlatform(TestCase):
 """
 
 
-# iOS tests shouldn't be run in parallel, because they're dependent on starting
-# a simulator. It's *possible* to start multiple simulators, but not advisable
-# to start as many simulators as there are CPUs on the test machine.
-@pytest.mark.xdist_group(name="ios")
+# iOS tests shouldn't be run in parallel, because they're dependent on calling
+# Xcode, and starting a simulator. These are both multi-threaded operations, and
+# it's easy to overload the CI machine if there are multiple test processes
+# running multithreaded processes. Therefore, they're put in the serial group,
+# which is guaranteed to run single-process.
+@pytest.mark.serial
 @pytest.mark.parametrize(
     "build_config",
     [
@@ -48,6 +50,7 @@ def test_ios_platforms(tmp_path, build_config):
             "CIBW_BUILD": "cp313-*",
             "CIBW_TEST_SOURCES": "tests",
             "CIBW_TEST_COMMAND": "unittest discover tests test_platform.py",
+            "CIBW_BUILD_VERBOSITY": "1",
             **build_config,
         },
     )
@@ -71,7 +74,7 @@ def test_ios_platforms(tmp_path, build_config):
     assert set(actual_wheels) == expected_wheels
 
 
-@pytest.mark.xdist_group(name="ios")
+@pytest.mark.serial
 def test_no_test_sources(tmp_path, capfd):
     if utils.platform != "macos":
         pytest.skip("this test can only run on macOS")


### PR DESCRIPTION
The iOS test suite added by #2286 has proven to be unstable in GitHub Actions CI, failing ~50% of the time. On deeper investigation, the issue appears to be CPU overloading on the CI machine. 

The integration tests run multhreaded using xdist; the ARM64 test machine reports 3 CPUs, and so 3 test threads are started. The iOS tests are isolated into a load group, resulting in the iOS tests being isolated to a single worker; but at the same time, the other two CPUs are allocated other macOS tests to run. The iOS test is itself a multi-process, multi-threaded build, calling Xcode, the iOS Simulator, and the macOS logging infrastructure; when the 2 remaining processes are at 100% utilisation building other tests, it's possible for the process of compiling the iOS project and booting a simulator clone to take a long time. The iOS testbed currently has a hard-coded 5 minute timeout waiting for Xcode to compile the project and boot a simulator; this is the timeout that is causing test failures.

This PR makes two changes to fix this.

Firstly, it splits the integration testbed into 2 phases. Instead of using an iOS load group, a pytest marker is used to identify the iOS tests as "serial" tests. The test suite then runs the integration test suite in two parts: all the serial tests are executed single process; and the non-serial tests are then executed multi-process. This effectively means that all the iOS tests run sequentially, then the rest of the test suite runs in parallel (as it always has done). 

Secondly, the macOS ARM64 builds have been updated to use the macOS-15 runner. The macOS-15 runner is currently listed as "beta"; but it has been available for almost 6 months, and if history is any indication, will become the default runner in the very near future. The macOS-15 runner has two notable improvements:

1. The build machines are *significantly* faster. I've seen a single `test_ios.py::test_ios_platforms` run in as little as 94 seconds, with the complete macOS test suite completing in 22 minutes - down from 36 minutes on the macOS-14 runner.
2. The macOS-15 runner defaults to using Xcode 16, whereas the macOS-14 runner defaults to Xcode 15. Xcode 15 had a number of issues with slow simulator startup; the 15.0, 15.1 and 15.2 releases [were unusably slow](https://github.com/actions/runner-images/issues/9591). The current 15.4 image is *better*, but not as good as Xcode 16. 

Apple "best practice" strongly encourages developers to keep on the "stable bleeding edge" of Xcode tooling, so upgrading to use Xcode 16 is generally a good idea anyway. It is possible to use Xcode 16 on a macOS-14 base image - but due to (1), the performance is still *much* worse than the macOS-15 runner (the worst iOS test execution time I've seen is 392s). Switching to macOS-15 also means that we don't need to explicitly maintain the version of Xcode, as the macOS-15 runner will always use the latest version of Xcode 16 that has been published.

Fixes #2335 - It's obviously difficult to categorically *prove* this, but I've run 4 builds on the macOS-15 runner with serial test isolation, with test execution times ranging from 94-215s [^1]. That time *includes* installing the compiled app on the simulator *and* running the test - so it's finishing well under the 5 minute/300s timeout that was causing test failures. I've also run 3 successful builds on macOS-14 with Xcode 16.2; these have much worse build times (332-392s), which is more than 5 minutes - but again, *includes* the time to install and run the test suite, which is easily 1/3-1/2 of the overall test time. Those tests have been run during US PST business hours *and* during AU AWST business hours, which limits the possible influence of "time of day" and overall system load on the problem.

[^1]: If you want to audit the test results, the CI runs of interest are the last 7 commits attached to #2336. The full CI runs report as fails because the CircleCI configuration fails - but that's a false positive because of a bad configuration disabling the use of CircleCI. The Github macOS-13 and macOS-14/15 runners are the only results of significance.
