### PR TITLE
fix: support wider range of verbosity settings on other build backends

### DIFF
--- a/cibuildwheel/frontend.py
+++ b/cibuildwheel/frontend.py
@@ -45,8 +45,6 @@ def _get_verbosity_flags(level: int, frontend: BuildFrontendName) -> list[str]:
     elif level > 1:
         return ["-v"]
     elif level < 0:
-        if frontend not in {"build", "build[uv]"}:
-            return ["-q"]
         msg = f"build_verbosity {level} is not supported for {frontend} frontend. Ignoring."
         log.warning(msg)
     return []

--- a/cibuildwheel/frontend.py
+++ b/cibuildwheel/frontend.py
@@ -42,7 +42,11 @@ def _get_verbosity_flags(level: int, frontend: BuildFrontendName) -> list[str]:
             return ["-" + level * "v"]
         if level < 0:
             return ["-" + -level * "q"]
-    elif not 0 <= level < 2:
+    elif level > 1:
+        return ["-v"]
+    elif level < 0:
+        if frontend not in {"build", "build[uv]"}:
+            return ["-q"]
         msg = f"build_verbosity {level} is not supported for {frontend} frontend. Ignoring."
         log.warning(msg)
     return []

--- a/cibuildwheel/frontend.py
+++ b/cibuildwheel/frontend.py
@@ -37,16 +37,19 @@ class BuildFrontendConfig:
 
 
 def _get_verbosity_flags(level: int, frontend: BuildFrontendName) -> list[str]:
-    if frontend == "pip":
-        if level > 0:
-            return ["-" + level * "v"]
-        if level < 0:
+    if level < 0:
+        if frontend == "pip":
             return ["-" + -level * "q"]
-    elif level > 1:
-        return ["-v"]
-    elif level < 0:
+
         msg = f"build_verbosity {level} is not supported for {frontend} frontend. Ignoring."
         log.warning(msg)
+
+    if level > 0:
+        if frontend == "pip":
+            return ["-" + level * "v"]
+        if level > 1:
+            return ["-" + (level - 1) * "v"]
+
     return []
 
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1762,14 +1762,25 @@ export CIBW_DEBUG_TRACEBACK=TRUE
 ### `CIBW_BUILD_VERBOSITY` {: #build-verbosity}
 > Increase/decrease the output of the build
 
-The setting vary a bit between build frontends.
+This setting controls `-v`/`-q` flags to the build frontend. Since there is
+no communication between the build backend and the build frontend, build
+messages from the build backend will always be shown with `1`; higher levels
+will not produce more logging about the build itself. Other levels only affect
+the build frontend output, which is usually things like resolving and
+downloading dependencies. The settings are:
 
-* `-1`: Hide as much build output as possible; passes `-q` to the build frontend. Not supported by `build`/`build[uv]`.
-* `0`: The default. On pip, this hides the build output if the build succeeds, other build frontends produce output from the build backend.
-* `1`: Produces build backend output. On `pip`, this passes `-v`. Other frontends do this by default.
-* `2`: Produces extra output from resolving packages too. On `pip`, this passes `-vv`, other build frontends use `-v`.
-* `3`: Even more resolving output from pip with `-vvv`, other build frontends continue to just pass `-v`.
+|             | build | pip    | desc                             |
+|-------------|-------|--------|----------------------------------|
+| -2          | N/A   | `-qq`  | even more quiet, where supported |
+| -1          | N/A   | `-q`   | quiet mode, where supported      |
+| 0 (default) |       |        | default for build tool           |
+| 1           |       | `-v`   | print backend output             |
+| 2           | `-v`  | `-vv`  | print log messages e.g. resolving info |
+| 3           | `-vv` | `-vvv` | print even more debug info       |
 
+Settings that are not supported for a specific frontend will log a warning.
+The default build frontend is `build`, which does show build backend output by
+default.
 
 Platform-specific environment variables are also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX` | `CIBW_BUILD_VERBOSITY_IOS` | `CIBW_BUILD_VERBOSITY_PYODIDE`
@@ -1779,7 +1790,7 @@ Platform-specific environment variables are also available:<br/>
 !!! tab examples "Environment variables"
 
     ```yaml
-    # Increase pip debugging output
+    # Ensure that the build backend output is present
     CIBW_BUILD_VERBOSITY: 1
     ```
 
@@ -1787,7 +1798,7 @@ Platform-specific environment variables are also available:<br/>
 
     ```toml
     [tool.cibuildwheel]
-    # Increase pip debugging output
+    # Ensure that the build backend output is present
     build-verbosity = 1
     ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1762,13 +1762,13 @@ export CIBW_DEBUG_TRACEBACK=TRUE
 ### `CIBW_BUILD_VERBOSITY` {: #build-verbosity}
 > Increase/decrease the output of the build
 
-The setting vary a bit between build backends.
+The setting vary a bit between build frontends.
 
-* `-1`: Hide as much build output as possible; passes `-q` to the build backend. Not supported by `build`/`build[uv]`.
-* `0`: The default. On pip, this hides the build output if the build succeeds, other build backends produce output from the build backend.
-* `1`: Produces build backend output. On `pip`, this passes `-v`. Other backends do this by default.
-* `2`: Produces extra output from resolving packages too. On `pip`, this passes `-vv`, other build backends use `-v`.
-* `3`: Even more resolving output from pip with `-vvv`, other build backends continue to just pass `-v`.
+* `-1`: Hide as much build output as possible; passes `-q` to the build frontend. Not supported by `build`/`build[uv]`.
+* `0`: The default. On pip, this hides the build output if the build succeeds, other build frontends produce output from the build backend.
+* `1`: Produces build backend output. On `pip`, this passes `-v`. Other frontends do this by default.
+* `2`: Produces extra output from resolving packages too. On `pip`, this passes `-vv`, other build frontends use `-v`.
+* `3`: Even more resolving output from pip with `-vvv`, other build frontends continue to just pass `-v`.
 
 
 Platform-specific environment variables are also available:<br/>

--- a/docs/options.md
+++ b/docs/options.md
@@ -1760,9 +1760,16 @@ export CIBW_DEBUG_TRACEBACK=TRUE
 ```
 
 ### `CIBW_BUILD_VERBOSITY` {: #build-verbosity}
-> Increase/decrease the output of pip wheel
+> Increase/decrease the output of the build
 
-A number from 1 to 3 to increase the level of verbosity (corresponding to invoking pip with `-v`, `-vv`, and `-vvv`), between -1 and -3 (`-q`, `-qq`, and `-qqq`), or just 0 (default verbosity). These flags are useful while debugging a build when the output of the actual build invoked by `pip wheel` is required. Has no effect on the `build` backend, which produces verbose output by default.
+The setting vary a bit between build backends.
+
+* `-1`: Hide as much build output as possible; passes `-q` to the build backend. Not supported by `build`/`build[uv]`.
+* `0`: The default. On pip, this hides the build output if the build succeeds, other build backends produce output from the build backend.
+* `1`: Produces build backend output. On `pip`, this passes `-v`. Other backends do this by default.
+* `2`: Produces extra output from resolving packages too. On `pip`, this passes `-vv`, other build backends use `-v`.
+* `3`: Even more resolving output from pip with `-vvv`, other build backends continue to just pass `-v`.
+
 
 Platform-specific environment variables are also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX` | `CIBW_BUILD_VERBOSITY_IOS` | `CIBW_BUILD_VERBOSITY_PYODIDE`

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -585,8 +585,8 @@ def test_deprecated_image(
         ("build", 0, ["-Ca", "-Cb", "-1"]),
         ("build", 1, ["-Ca", "-Cb", "-1"]),
         ("build", 2, ["-Ca", "-Cb", "-1", "-v"]),
-        ("build", 3, ["-Ca", "-Cb", "-1", "-v"]),
-        ("build[uv]", 3, ["-Ca", "-Cb", "-1", "-v"]),
+        ("build", 3, ["-Ca", "-Cb", "-1", "-vv"]),
+        ("build[uv]", 3, ["-Ca", "-Cb", "-1", "-vv"]),
     ],
 )
 def test_get_build_frontend_extra_flags(


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/issues/2338.

This makes the verbosity setting a bit more useful on other backends. This tries to map the current `pip` meanings to other backends. The key changes are:

* `<0` will support `uv` (#2322), `build` continues to produce a warning. This is a feature that's been requested before for build, btw.
* `1` continues to do nothing on non-`pip` backends
* 2+ now passes multiple `-v` to non-pip backends, since both build and uv support adding extra resolving info (similar to pip's `-vv`) if passing `-v`.
