### PR TITLE
ci: revert QEMU workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,11 +63,6 @@ jobs:
     - name: Set up QEMU
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
-      with:
-        # This should be temporary
-        # xref https://github.com/docker/setup-qemu-action/issues/188
-        # xref https://github.com/tonistiigi/binfmt/issues/215
-        image: tonistiigi/binfmt:qemu-v8.1.5
 
     - name: Install dependencies
       run: |
@@ -169,11 +164,6 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-      with:
-        # This should be temporary
-        # xref https://github.com/docker/setup-qemu-action/issues/188
-        # xref https://github.com/tonistiigi/binfmt/issues/215
-        image: tonistiigi/binfmt:qemu-v8.1.5
 
     - name: Run the emulation tests
       run: uv run pytest --run-emulation ${{ matrix.arch }} test/test_emulation.py


### PR DESCRIPTION
`tonistiigi/binfmt:latest` has been updated and the workaround should not be needed anymore.

close #2257