### PR TITLE
refactor: pull out dependency_constraint

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 jobs:
 - job: linux_311
   timeoutInMinutes: 120
-  pool: {vmImage: 'Ubuntu-20.04'}
+  pool: {vmImage: 'Ubuntu-22.04'}
   steps:
     - task: UsePythonVersion@0
       inputs:
@@ -27,7 +27,7 @@ jobs:
     - bash: |
         python -m pip install dependency-groups
         python -m dependency_groups test | xargs python -m pip install -e.
-        python ./bin/run_tests.py --num-processes 2
+        python ./bin/run_tests.py
 
 - job: windows_311
   pool: {vmImage: 'windows-2019'}

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -8,7 +8,11 @@ import sys
 from pathlib import Path
 
 if __name__ == "__main__":
-    default_cpu_count = os.cpu_count() or 2
+    if sys.version_info < (3, 13):
+        default_cpu_count = os.cpu_count() or 2
+    else:
+        default_cpu_count = os.process_cpu_count() or 2
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--run-podman", action="store_true", default=False, help="run podman tests (linux only)"

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -177,8 +177,8 @@ def cross_virtualenv(
     :param build_python: The path to the python binary for the build platform
     :param venv_path: The path where the cross virtual environment should be
         created.
-    :param dependency_constraint_flags: Any flags that should be used when
-        constraining dependencies in the environment.
+    :param dependency_constraint: A path to a constraint file that should be
+        used when constraining dependencies in the environment.
     :param xbuild_tools: A list of executable names (without paths) that are
         on the path, but must be preserved in the cross environment.
     """
@@ -326,8 +326,6 @@ def setup_python(
 
     log.step("Creating cross build environment...")
 
-    dependency_constraint_flags = constraint_flags(dependency_constraint)
-
     venv_path = tmp / "venv"
     env = cross_virtualenv(
         py_version=python_configuration.version,
@@ -352,7 +350,7 @@ def setup_python(
         "install",
         "--upgrade",
         "pip",
-        *dependency_constraint_flags,
+        *constraint_flags(dependency_constraint),
         env=env,
         cwd=venv_path,
     )
@@ -398,7 +396,7 @@ def setup_python(
             "install",
             "--upgrade",
             "build[virtualenv]",
-            *dependency_constraint_flags,
+            *constraint_flags(dependency_constraint),
             env=env,
         )
     else:

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -219,8 +219,6 @@ def setup_python(
         f"{base_python.name} not found, has {list(base_python.parent.iterdir())}"
     )
 
-    dependency_constraint_flags = constraint_flags(dependency_constraint)
-
     log.step("Setting up build environment...")
     venv_path = tmp / "venv"
     env = virtualenv(
@@ -257,7 +255,7 @@ def setup_python(
             "install",
             "--upgrade",
             "pip",
-            *dependency_constraint_flags,
+            *constraint_flags(dependency_constraint),
             env=env,
             cwd=venv_path,
         )
@@ -352,7 +350,7 @@ def setup_python(
             "install",
             "--upgrade",
             "delocate",
-            *dependency_constraint_flags,
+            *constraint_flags(dependency_constraint),
             env=env,
         )
     elif build_frontend == "build":
@@ -362,7 +360,7 @@ def setup_python(
             "--upgrade",
             "delocate",
             "build[virtualenv]",
-            *dependency_constraint_flags,
+            *constraint_flags(dependency_constraint),
             env=env,
         )
     elif build_frontend == "build[uv]":
@@ -374,7 +372,7 @@ def setup_python(
             "--upgrade",
             "delocate",
             "build[virtualenv, uv]",
-            *dependency_constraint_flags,
+            *constraint_flags(dependency_constraint),
             env=env,
         )
     else:
@@ -428,7 +426,6 @@ def build(options: Options, tmp_path: Path) -> None:
             constraints_path = build_options.dependency_constraints.get_for_python_version(
                 version=config.version, tmp_dir=identifier_tmp_dir
             )
-            dependency_constraint_flags = constraint_flags(constraints_path)
 
             base_python, env = setup_python(
                 identifier_tmp_dir / "build",
@@ -620,7 +617,13 @@ def build(options: Options, tmp_path: Path) -> None:
                     # set up a virtual environment to install and test from, to make sure
                     # there are no dependencies that were pulled in at build time.
                     if not use_uv:
-                        call("pip", "install", "virtualenv", *dependency_constraint_flags, env=env)
+                        call(
+                            "pip",
+                            "install",
+                            "virtualenv",
+                            *constraint_flags(constraints_path),
+                            env=env,
+                        )
 
                     venv_dir = identifier_tmp_dir / f"venv-test-{testing_arch}"
 

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -152,7 +152,7 @@ def setup_python(
 
     log.step("Setting up build environment...")
     venv_path = tmp / "venv"
-    env = virtualenv(python_configuration.version, base_python, venv_path, [], use_uv=False)
+    env = virtualenv(python_configuration.version, base_python, venv_path, None, use_uv=False)
     venv_bin_path = venv_path / "bin"
     assert venv_bin_path.exists()
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
@@ -269,8 +269,8 @@ def build(options: Options, tmp_path: Path) -> None:
             constraints_path = build_options.dependency_constraints.get_for_python_version(
                 version=config.version, variant="pyodide", tmp_dir=identifier_tmp_dir
             )
-            dependency_constraint_flags: Sequence[PathOrStr] = (
-                ["-c", constraints_path] if constraints_path else []
+            dependency_constraint_flags = (
+                ["-c", constraints_path.as_uri()] if constraints_path else []
             )
 
             env = setup_python(

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -12,7 +12,6 @@ from filelock import FileLock
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import Version
 
-from .typing import PathOrStr
 from .util import resources
 from .util.cmd import call
 from .util.file import CIBW_CACHE_PATH, download
@@ -36,8 +35,18 @@ def _ensure_virtualenv(version: str) -> Path:
     return path
 
 
+def constraint_flags(
+    dependency_constraint: Path | None,
+) -> Sequence[str]:
+    """
+    Returns the flags to pass to pip for the given dependency constraint.
+    """
+
+    return ["-c", dependency_constraint.as_uri()] if dependency_constraint else []
+
+
 def _parse_pip_constraint_for_virtualenv(
-    dependency_constraint_flags: Sequence[PathOrStr],
+    constraint_path: Path | None,
 ) -> str:
     """
     Parses the constraints file referenced by `dependency_constraint_flags` and returns a dict where
@@ -48,10 +57,7 @@ def _parse_pip_constraint_for_virtualenv(
     If it can't get an exact version, the real constraint will be handled by the
     {macos|windows}.setup_python function.
     """
-    assert len(dependency_constraint_flags) in {0, 2}
-    if len(dependency_constraint_flags) == 2:
-        assert dependency_constraint_flags[0] == "-c"
-        constraint_path = Path(dependency_constraint_flags[1])
+    if constraint_path:
         assert constraint_path.exists()
         with constraint_path.open(encoding="utf-8") as constraint_file:
             for line_ in constraint_file:
@@ -84,7 +90,7 @@ def virtualenv(
     version: str,
     python: Path,
     venv_path: Path,
-    dependency_constraint_flags: Sequence[PathOrStr],
+    dependency_constraint: Path | None,
     *,
     use_uv: bool,
 ) -> dict[str, str]:
@@ -103,7 +109,7 @@ def virtualenv(
         call("uv", "venv", venv_path, "--python", python)
     else:
         virtualenv_app = _ensure_virtualenv(version)
-        pip_constraint = _parse_pip_constraint_for_virtualenv(dependency_constraint_flags)
+        pip_constraint = _parse_pip_constraint_for_virtualenv(dependency_constraint)
         additional_flags = [f"--pip={pip_constraint}", "--no-setuptools", "--no-wheel"]
 
         # Using symlinks to pre-installed seed packages is really the fastest way to get a virtual


### PR DESCRIPTION
Pulled out from #2322 to simplify that one. Passes the actual Path or None instead of passing the flags and then parsing the argument back out (!). Also switches to using the URI, but I could do that in 2322 instead if there are any issues (edit: seems fine!).