### PR TITLE
fix(CI): Cirrus CI macos jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ macos_arm64_cp38_task:
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}
-    PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto'
+    PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto or test_dummy_serial'
   install_pre_requirements_script:
     - brew install python@3.12
     - python3.12 -m venv ${VENV_ROOT}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ windows_x86_task:
 
 macos_arm64_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sonoma
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}
@@ -73,7 +73,7 @@ macos_arm64_task:
 
 macos_arm64_cp38_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sonoma
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}

--- a/examples/cirrus-ci-minimal.yml
+++ b/examples/cirrus-ci-minimal.yml
@@ -60,7 +60,7 @@ windows_x86_task:
 macos_arm64_task:
   name: Build macOS arm64 wheels.
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sonoma
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   env:
     VENV_ROOT: ${HOME}/venv-cibuildwheel
     PATH: ${VENV_ROOT}/bin:${PATH}


### PR DESCRIPTION
The macos_arm64_cp38 job fails because it selects 0 serial tests.
The macos_arm64 was failing on iOS tests, move to `sequoia` in order to fix those.