### PR TITLE
fix: support Python 3.14's color CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
         include:
         - os: ubuntu-latest
           python_version: '3.11'
+        - os: ubuntu-latest
+          python_version: '3.14'
     timeout-minutes: 180
     steps:
     - uses: actions/checkout@v4

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -6,12 +6,17 @@
 
 import argparse
 import copy
+import functools
 import json
+import sys
 from typing import Any
 
 import yaml
 
-parser = argparse.ArgumentParser()
+make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+if sys.version_info >= (3, 14):
+    make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+parser = make_parser()
 parser.add_argument("--schemastore", action="store_true", help="Generate schema_store version")
 args = parser.parse_args()
 

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -2,6 +2,7 @@
 
 
 import argparse
+import functools
 import os
 import subprocess
 import sys
@@ -13,7 +14,10 @@ if __name__ == "__main__":
     else:
         default_cpu_count = os.process_cpu_count() or 2
 
-    parser = argparse.ArgumentParser()
+    make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+    if sys.version_info >= (3, 14):
+        make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+    parser = make_parser()
     parser.add_argument(
         "--run-podman", action="store_true", default=False, help="run podman tests (linux only)"
     )

--- a/bin/sample_build.py
+++ b/bin/sample_build.py
@@ -2,6 +2,7 @@
 
 
 import argparse
+import functools
 import os
 import subprocess
 import sys
@@ -12,7 +13,10 @@ if __name__ == "__main__":
     # move cwd to the project root
     os.chdir(Path(__file__).resolve().parents[1])
 
-    parser = argparse.ArgumentParser(description="Runs a sample build")
+    make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+    if sys.version_info >= (3, 14):
+        make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+    parser = make_parser(description="Runs a sample build")
     parser.add_argument("project_python_path", nargs="?", default="test.test_0_basic.basic_project")
 
     options = parser.parse_args()

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import contextlib
 import dataclasses
+import functools
 import os
 import shutil
 import sys
@@ -79,7 +80,10 @@ def main_inner(global_options: GlobalOptions) -> None:
     rather than exiting directly.
     """
 
-    parser = argparse.ArgumentParser(
+    make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+    if sys.version_info >= (3, 14):
+        make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+    parser = make_parser(
         description="Build wheels for all the platforms.",
         epilog="""
             Most options are supplied via environment variables or in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Build Tools",
 ]

--- a/test/test_projects/__main__.py
+++ b/test/test_projects/__main__.py
@@ -1,13 +1,17 @@
+import argparse
+import functools
 import importlib
 import subprocess
 import sys
 import tempfile
-from argparse import ArgumentParser
 from pathlib import Path
 
 
 def main() -> None:
-    parser = ArgumentParser(
+    make_parser = functools.partial(argparse.ArgumentParser, allow_abbrev=False)
+    if sys.version_info >= (3, 14):
+        make_parser = functools.partial(make_parser, color=True, suggest_on_error=True)
+    parser = make_parser(
         prog="python -m test.test_projects", description="Generate a test project to check it out"
     )
     parser.add_argument(


### PR DESCRIPTION
Also turning off abbreviations, and 3.14+'s suggestions for choices.

Adds the 3.14 classifier and runs tests on 3.14 (linux only).
