### PR TITLE
Debug Cirrus CI testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,45 +5,45 @@ run_tests: &RUN_TESTS
     - python -m pip install dependency-groups
     - python -m dependency_groups test | xargs python -m pip install -e.
   run_cibuildwheel_tests_script:
-    - python ./bin/run_tests.py
+    - pytest test -k test_abi3
 
-linux_x86_task:
-  timeout_in: 120m
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder
-    platform: linux
-    cpu: 8
-    memory: 8G
-  env:
-    VENV_ROOT: ${HOME}/venv-cibuildwheel
-    PATH: ${VENV_ROOT}/bin:${PATH}
-  install_pre_requirements_script:
-    - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
-    - add-apt-repository -y ppa:deadsnakes/ppa
-    - apt-get update
-    - apt-get install -y python3.12-venv
-    - python3.12 -m venv ${VENV_ROOT}
-  <<: *RUN_TESTS
+# linux_x86_task:
+#   timeout_in: 120m
+#   compute_engine_instance:
+#     image_project: cirrus-images
+#     image: family/docker-builder
+#     platform: linux
+#     cpu: 8
+#     memory: 8G
+#   env:
+#     VENV_ROOT: ${HOME}/venv-cibuildwheel
+#     PATH: ${VENV_ROOT}/bin:${PATH}
+#   install_pre_requirements_script:
+#     - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
+#     - add-apt-repository -y ppa:deadsnakes/ppa
+#     - apt-get update
+#     - apt-get install -y python3.12-venv
+#     - python3.12 -m venv ${VENV_ROOT}
+#   <<: *RUN_TESTS
 
-linux_aarch64_task:
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder-arm64
-    architecture: arm64
-    platform: linux
-    cpu: 4
-    memory: 4G
-  env:
-    VENV_ROOT: ${HOME}/venv-cibuildwheel
-    PATH: ${VENV_ROOT}/bin:${PATH}
-  install_pre_requirements_script:
-    - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
-    - add-apt-repository -y ppa:deadsnakes/ppa
-    - apt-get update
-    - apt-get install -y python3.12-venv
-    - python3.12 -m venv ${VENV_ROOT}
-  <<: *RUN_TESTS
+# linux_aarch64_task:
+#   compute_engine_instance:
+#     image_project: cirrus-images
+#     image: family/docker-builder-arm64
+#     architecture: arm64
+#     platform: linux
+#     cpu: 4
+#     memory: 4G
+#   env:
+#     VENV_ROOT: ${HOME}/venv-cibuildwheel
+#     PATH: ${VENV_ROOT}/bin:${PATH}
+#   install_pre_requirements_script:
+#     - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
+#     - add-apt-repository -y ppa:deadsnakes/ppa
+#     - apt-get update
+#     - apt-get install -y python3.12-venv
+#     - python3.12 -m venv ${VENV_ROOT}
+#   <<: *RUN_TESTS
 
 windows_x86_task:
   # The task takes ~55 minutes while the timeout happens
@@ -60,29 +60,29 @@ windows_x86_task:
     - echo PATH=%PATH% >> "%CIRRUS_ENV%"
   <<: *RUN_TESTS
 
-macos_arm64_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
-  env:
-    VENV_ROOT: ${HOME}/venv-cibuildwheel
-    PATH: ${VENV_ROOT}/bin:${PATH}
-  install_pre_requirements_script:
-    - brew install python@3.12
-    - python3.12 -m venv ${VENV_ROOT}
-  <<: *RUN_TESTS
+# macos_arm64_task:
+#   macos_instance:
+#     image: ghcr.io/cirruslabs/macos-runner:sequoia
+#   env:
+#     VENV_ROOT: ${HOME}/venv-cibuildwheel
+#     PATH: ${VENV_ROOT}/bin:${PATH}
+#   install_pre_requirements_script:
+#     - brew install python@3.12
+#     - python3.12 -m venv ${VENV_ROOT}
+#   <<: *RUN_TESTS
 
-macos_arm64_cp38_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
-  env:
-    VENV_ROOT: ${HOME}/venv-cibuildwheel
-    PATH: ${VENV_ROOT}/bin:${PATH}
-    PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto or test_dummy_serial'
-  install_pre_requirements_script:
-    - brew install python@3.12
-    - python3.12 -m venv ${VENV_ROOT}
-    - curl -fsSLO https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
-    - sudo installer -pkg python-3.8.10-macos11.pkg -target /
-    - rm python-3.8.10-macos11.pkg
-    - sh "/Applications/Python 3.8/Install Certificates.command"
-  <<: *RUN_TESTS
+# macos_arm64_cp38_task:
+#   macos_instance:
+#     image: ghcr.io/cirruslabs/macos-runner:sequoia
+#   env:
+#     VENV_ROOT: ${HOME}/venv-cibuildwheel
+#     PATH: ${VENV_ROOT}/bin:${PATH}
+#     PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto or test_dummy_serial'
+#   install_pre_requirements_script:
+#     - brew install python@3.12
+#     - python3.12 -m venv ${VENV_ROOT}
+#     - curl -fsSLO https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
+#     - sudo installer -pkg python-3.8.10-macos11.pkg -target /
+#     - rm python-3.8.10-macos11.pkg
+#     - sh "/Applications/Python 3.8/Install Certificates.command"
+#   <<: *RUN_TESTS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,45 +5,45 @@ run_tests: &RUN_TESTS
     - python -m pip install dependency-groups
     - python -m dependency_groups test | xargs python -m pip install -e.
   run_cibuildwheel_tests_script:
-    - pytest test -k test_abi3
+    - python ./bin/run_tests.py
 
-# linux_x86_task:
-#   timeout_in: 120m
-#   compute_engine_instance:
-#     image_project: cirrus-images
-#     image: family/docker-builder
-#     platform: linux
-#     cpu: 8
-#     memory: 8G
-#   env:
-#     VENV_ROOT: ${HOME}/venv-cibuildwheel
-#     PATH: ${VENV_ROOT}/bin:${PATH}
-#   install_pre_requirements_script:
-#     - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
-#     - add-apt-repository -y ppa:deadsnakes/ppa
-#     - apt-get update
-#     - apt-get install -y python3.12-venv
-#     - python3.12 -m venv ${VENV_ROOT}
-#   <<: *RUN_TESTS
+linux_x86_task:
+  timeout_in: 120m
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
+    cpu: 8
+    memory: 8G
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
+  install_pre_requirements_script:
+    - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
+    - add-apt-repository -y ppa:deadsnakes/ppa
+    - apt-get update
+    - apt-get install -y python3.12-venv
+    - python3.12 -m venv ${VENV_ROOT}
+  <<: *RUN_TESTS
 
-# linux_aarch64_task:
-#   compute_engine_instance:
-#     image_project: cirrus-images
-#     image: family/docker-builder-arm64
-#     architecture: arm64
-#     platform: linux
-#     cpu: 4
-#     memory: 4G
-#   env:
-#     VENV_ROOT: ${HOME}/venv-cibuildwheel
-#     PATH: ${VENV_ROOT}/bin:${PATH}
-#   install_pre_requirements_script:
-#     - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
-#     - add-apt-repository -y ppa:deadsnakes/ppa
-#     - apt-get update
-#     - apt-get install -y python3.12-venv
-#     - python3.12 -m venv ${VENV_ROOT}
-#   <<: *RUN_TESTS
+linux_aarch64_task:
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+    memory: 4G
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
+  install_pre_requirements_script:
+    - docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
+    - add-apt-repository -y ppa:deadsnakes/ppa
+    - apt-get update
+    - apt-get install -y python3.12-venv
+    - python3.12 -m venv ${VENV_ROOT}
+  <<: *RUN_TESTS
 
 windows_x86_task:
   # The task takes ~55 minutes while the timeout happens
@@ -60,29 +60,29 @@ windows_x86_task:
     - echo PATH=%PATH% >> "%CIRRUS_ENV%"
   <<: *RUN_TESTS
 
-# macos_arm64_task:
-#   macos_instance:
-#     image: ghcr.io/cirruslabs/macos-runner:sequoia
-#   env:
-#     VENV_ROOT: ${HOME}/venv-cibuildwheel
-#     PATH: ${VENV_ROOT}/bin:${PATH}
-#   install_pre_requirements_script:
-#     - brew install python@3.12
-#     - python3.12 -m venv ${VENV_ROOT}
-#   <<: *RUN_TESTS
+macos_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
+  install_pre_requirements_script:
+    - brew install python@3.12
+    - python3.12 -m venv ${VENV_ROOT}
+  <<: *RUN_TESTS
 
-# macos_arm64_cp38_task:
-#   macos_instance:
-#     image: ghcr.io/cirruslabs/macos-runner:sequoia
-#   env:
-#     VENV_ROOT: ${HOME}/venv-cibuildwheel
-#     PATH: ${VENV_ROOT}/bin:${PATH}
-#     PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto or test_dummy_serial'
-#   install_pre_requirements_script:
-#     - brew install python@3.12
-#     - python3.12 -m venv ${VENV_ROOT}
-#     - curl -fsSLO https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
-#     - sudo installer -pkg python-3.8.10-macos11.pkg -target /
-#     - rm python-3.8.10-macos11.pkg
-#     - sh "/Applications/Python 3.8/Install Certificates.command"
-#   <<: *RUN_TESTS
+macos_arm64_cp38_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
+  env:
+    VENV_ROOT: ${HOME}/venv-cibuildwheel
+    PATH: ${VENV_ROOT}/bin:${PATH}
+    PYTEST_ADDOPTS: --run-cp38-universal2 -k 'test_cp38_arm64_testing_universal2_installer or test_arch_auto or test_dummy_serial'
+  install_pre_requirements_script:
+    - brew install python@3.12
+    - python3.12 -m venv ${VENV_ROOT}
+    - curl -fsSLO https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
+    - sudo installer -pkg python-3.8.10-macos11.pkg -target /
+    - rm python-3.8.10-macos11.pkg
+    - sh "/Applications/Python 3.8/Install Certificates.command"
+  <<: *RUN_TESTS

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Usage
 | Travis CI       | ✅    |       | ✅      | ✅        |           |             |     |
 | CircleCI        | ✅    | ✅    |         | ✅        | ✅        |             | ✅³  |
 | Gitlab CI       | ✅    | ✅    | ✅      | ✅¹       | ✅        |             | ✅³  |
-| Cirrus CI       | ✅    | ✅    | ✅      | ✅        | ✅        |             | ✅³  |
+| Cirrus CI       | ✅    | ✅    | ✅      | ✅        | ✅        |             |      |
 
 <sup>¹ [Requires emulation](https://cibuildwheel.pypa.io/en/stable/faq/#emulation), distributed separately. Other services may also support Linux ARM through emulation or third-party build hosts, but these are not tested in our CI.</sup><br>
 <sup>² [Uses cross-compilation](https://cibuildwheel.pypa.io/en/stable/faq/#windows-arm64). It is not possible to test `arm64` on this CI platform.</sup><br>

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -366,6 +366,7 @@ def setup_python(
             text=True,
             env=env,
         )
+        print("vcvars", vcvars)
         env.update(json.loads(vcvars))
 
     return base_python, env

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -375,7 +375,6 @@ def setup_python(
         )
         with open(vcvars_file, encoding="utf-8") as f:
             vcvars = json.load(f)
-        print("vcvars", vcvars)
         env.update(vcvars)
 
     return base_python, env

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -336,41 +336,31 @@ def setup_python(
         # variables. Adapted from
         # https://github.com/microsoft/vswhere/wiki/Start-Developer-Command-Prompt
         # Remove when https://github.com/oracle/graalpython/issues/492 is fixed.
-        vcpath = subprocess.check_output(
-            [
-                Path(os.environ["PROGRAMFILES(X86)"])
-                / "Microsoft Visual Studio"
-                / "Installer"
-                / "vswhere.exe",
-                "-products",
-                "*",
-                "-latest",
-                "-property",
-                "installationPath",
-            ],
-            text=True,
+        vcpath = call(
+            Path(os.environ["PROGRAMFILES(X86)"])
+            / "Microsoft Visual Studio"
+            / "Installer"
+            / "vswhere.exe",
+            "-products",
+            "*",
+            "-latest",
+            "-property",
+            "installationPath",
+            capture_stdout=True,
         ).strip()
         log.notice(f"Discovering Visual Studio for GraalPy at {vcpath}")
         vcvars_file = tmp / "vcvars.json"
-        subprocess.check_output(
-            [
-                f"{vcpath}\\Common7\\Tools\\vsdevcmd.bat",
-                "-no_logo",
-                "-arch=amd64",
-                "-host_arch=amd64",
-                "&&",
-                "python",
-                "-c",
-                textwrap.dedent("""\
-                    import sys, json, os
-                    env = dict(os.environ)
-                    outfile = sys.argv[1]
-                    with open(outfile, 'w', encoding='utf-8') as f:
-                        json.dump(env, f)
-                """),
-                vcvars_file,
-            ],
-            shell=True,
+        call(
+            f"{vcpath}\\Common7\\Tools\\vsdevcmd.bat",
+            "-no_logo",
+            "-arch=amd64",
+            "-host_arch=amd64",
+            "&&",
+            "python",
+            "-c",
+            # this command needs to be one line for Windows reasons
+            "import sys, json, pathlib, os; pathlib.Path(sys.argv[1]).write_text(json.dumps(dict(os.environ)))",
+            vcvars_file,
             env=env,
         )
         with open(vcvars_file, encoding="utf-8") as f:

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -8,6 +8,8 @@ import textwrap
 
 import pytest
 
+from cibuildwheel.ci import CIProvider, detect_ci_provider
+
 from . import test_projects, utils
 
 basic_project_files = {
@@ -21,6 +23,19 @@ class TestPlatform(TestCase):
 
 """
 }
+
+
+def skip_if_ios_testing_not_supported() -> None:
+    """Skip the test if iOS testing is not supported on this machine."""
+    if utils.get_platform() != "macos":
+        pytest.skip("this test can only run on macOS")
+    if utils.get_xcode_version() < (13, 0):
+        pytest.skip("this test only works with Xcode 13.0 or greater")
+    if detect_ci_provider() == CIProvider.cirrus_ci:
+        pytest.skip(
+            "iOS testing not currently supported on Cirrus CI due to a failure "
+            "to start the simulator."
+        )
 
 
 # iOS tests shouldn't be run in parallel, because they're dependent on calling
@@ -39,10 +54,7 @@ class TestPlatform(TestCase):
     ],
 )
 def test_ios_platforms(tmp_path, build_config, monkeypatch, capfd):
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     # Create a temporary "bin" directory, symlink a tool that we know eixsts
     # (/usr/bin/true) into that location under a name that should be unique,
@@ -93,10 +105,7 @@ def test_ios_platforms(tmp_path, build_config, monkeypatch, capfd):
 
 def test_no_test_sources(tmp_path, capfd):
     """Build will fail if test-sources isn't defined."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
     basic_project = test_projects.new_c_project()
@@ -120,10 +129,7 @@ def test_no_test_sources(tmp_path, capfd):
 
 def test_missing_xbuild_tool(tmp_path, capfd):
     """Build will fail if xbuild-tools references a non-existent tool."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
     basic_project = test_projects.new_c_project()
@@ -148,10 +154,7 @@ def test_missing_xbuild_tool(tmp_path, capfd):
 
 def test_no_xbuild_tool_definition(tmp_path, capfd):
     """Build will succeed with a warning if there is no xbuild-tools definition."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
     basic_project = test_projects.new_c_project()
@@ -185,10 +188,7 @@ def test_no_xbuild_tool_definition(tmp_path, capfd):
 
 def test_empty_xbuild_tool_definition(tmp_path, capfd):
     """Build will succeed with no warning if there is an empty xbuild-tools definition."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
     basic_project = test_projects.new_c_project()
@@ -220,10 +220,7 @@ def test_empty_xbuild_tool_definition(tmp_path, capfd):
 @pytest.mark.serial
 def test_ios_test_command_without_python_dash_m(tmp_path, capfd):
     """pytest should be able to run without python -m, but it should warn."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
 
@@ -261,10 +258,7 @@ def test_ios_test_command_without_python_dash_m(tmp_path, capfd):
 
 def test_ios_test_command_invalid(tmp_path, capfd):
     """Test command should raise an error if it's clearly invalid."""
-    if utils.get_platform() != "macos":
-        pytest.skip("this test can only run on macOS")
-    if utils.get_xcode_version() < (13, 0):
-        pytest.skip("this test only works with Xcode 13.0 or greater")
+    skip_if_ios_testing_not_supported()
 
     project_dir = tmp_path / "project"
     basic_project = test_projects.new_c_project()


### PR DESCRIPTION
Fix the build on `main`. 

## Disables iOS testing on Cirrus.

Cirrus has a problem running the simulator, see a recent build on main, for example:

https://cirrus-ci.com/task/6394806932340736?logs=run_cibuildwheel_tests#L1832

I've removed the support tick from cirrus in the readme too, until/unless we can figure this out. 

cc @freakboy3742

## Fixes a bug with the GraalPy build

Sometimes vsdevcmd can print an error to console while it works. This messed up the environment JSON blob, so it's saved to a file instead.
