### PR TITLE
chore: fix update script to handle pymanager addition to page

### DIFF
--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -280,8 +280,12 @@ class CPythonVersions:
 
         self.versions_dict: dict[Version, int] = {}
         for release in releases_info:
-            # Removing the prefix, Python 3.9 would use: release["name"].removeprefix("Python ")
-            version = Version(release["name"][7:])
+            # Skip the pymanager releases
+            if not release["slug"].startswith("python"):
+                continue
+
+            # Removing the prefix
+            version = Version(release["name"].removeprefix("Python "))
 
             uri = int(release["resource_uri"].rstrip("/").split("/")[-1])
             self.versions_dict[version] = uri


### PR DESCRIPTION
The new Windows Python install manager was added to this page:

https://www.python.org/api/v2/downloads/release/?is_published=true

Which breaks our script. While we wait for beta 2 in manylinux, let's fix this. :)
