### PR TITLE
fix: drop PYTHONSAFEPATH

### DIFF
--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -361,7 +361,6 @@ def build_in_container(
             virtualenv_env = env.copy()
             virtualenv_env["PATH"] = f"{venv_dir / 'bin'}:{virtualenv_env['PATH']}"
             virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
-            virtualenv_env["PYTHONSAFEPATH"] = "1"
             virtualenv_env = build_options.test_environment.as_dictionary(
                 prev_environment=virtualenv_env
             )

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -648,9 +648,6 @@ def build(options: Options, tmp_path: Path) -> None:
 
                     virtualenv_env["MACOSX_DEPLOYMENT_TARGET"] = get_test_macosx_deployment_target()
 
-                    # see https://github.com/pypa/cibuildwheel/issues/2358 for discussion
-                    virtualenv_env["PYTHONSAFEPATH"] = "1"
-
                     virtualenv_env = build_options.test_environment.as_dictionary(
                         prev_environment=virtualenv_env
                     )

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -484,8 +484,6 @@ def build(options: Options, tmp_path: Path) -> None:
                 )
                 virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
-                virtualenv_env["PYTHONSAFEPATH"] = "1"
-
                 virtualenv_env = build_options.test_environment.as_dictionary(
                     prev_environment=virtualenv_env
                 )

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -553,9 +553,6 @@ def build(options: Options, tmp_path: Path) -> None:
                     pip_version=pip_version,
                 )
 
-                # see https://github.com/pypa/cibuildwheel/issues/2358 for discussion
-                virtualenv_env["PYTHONSAFEPATH"] = "1"
-
                 virtualenv_env = build_options.test_environment.as_dictionary(
                     prev_environment=virtualenv_env
                 )

--- a/docs/options.md
+++ b/docs/options.md
@@ -1604,12 +1604,6 @@ A space-separated list of environment variables to set in the test environment.
 
 The syntax is the same as for [`environment`](#environment).
 
-cibuildwheel sets the variable
-[`PYTHONSAFEPATH`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSAFEPATH)
-to avoid picking up in-tree dependencies when running the tests - we want to
-test the installed wheel, not the in-tree version. However, this can be
-overridden by setting `PYTHONSAFEPATH` to an empty string.
-
 Platform-specific environment variables are also available:<br/>
 `CIBW_TEST_ENVIRONMENT_MACOS` | `CIBW_TEST_ENVIRONMENT_WINDOWS` | `CIBW_TEST_ENVIRONMENT_LINUX` | `CIBW_TEST_ENVIRONMENT_IOS` | `CIBW_TEST_ENVIRONMENT_PYODIDE`
 
@@ -1622,8 +1616,8 @@ Platform-specific environment variables are also available:<br/>
     # Set the environment variable MY_ENV_VAR to "my_value" in the test environment
     test-environment = { MY_ENV_VAR="my_value" }
 
-    # Unset PYTHONSAFEPATH in the test environment
-    test-environment = { PYTHONSAFEPATH="" }
+    # Set PYTHONSAFEPATH in the test environment
+    test-environment = { PYTHONSAFEPATH="1" }
     ```
 
 !!! tab examples "Environment variables"
@@ -1632,8 +1626,8 @@ Platform-specific environment variables are also available:<br/>
     # Set the environment variable MY_ENV_VAR to "my_value" in the test environment
     CIBW_TEST_ENVIRONMENT: MY_ENV_VAR=my_value
 
-    # Unset PYTHONSAFEPATH in the test environment
-    CIBW_TEST_ENVIRONMENT: PYTHONSAFEPATH=
+    # Set PYTHONSAFEPATH in the test environment
+    CIBW_TEST_ENVIRONMENT: PYTHONSAFEPATH=1
     ```
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -66,12 +66,6 @@ class TestSpam(TestCase):
         bits = struct.calcsize("P") * 8
         if bits == 32:
             self.assertIn(platform.machine(), ["i686", "armv7l","armv8l", "wasm32"])
-
-    def test_pythonsafepath(self):
-        # check that the PYTHONSAFEPATH environment variable is set
-        value = os.environ.get("PYTHONSAFEPATH")
-        self.assertIsNotNone(value)
-        self.assertNotEqual(value, "")
 '''
 
 
@@ -256,8 +250,8 @@ def test_test_environment(tmp_path):
     actual_wheels = utils.cibuildwheel_run(
         project_dir,
         add_env={
-            "CIBW_TEST_ENVIRONMENT": "MYVAR=somevalue PYTHONSAFEPATH=",
-            "CIBW_TEST_COMMAND": "python -c \"import os; assert os.environ.get('MYVAR') == 'somevalue'; assert os.environ.get('PYTHONSAFEPATH') == ''\"",
+            "CIBW_TEST_ENVIRONMENT": "MYVAR=somevalue PYTHONSAFEPATH=1",
+            "CIBW_TEST_COMMAND": "python -c \"import os; assert os.environ.get('MYVAR') == 'somevalue'; assert os.environ.get('PYTHONSAFEPATH') == '1'\"",
         },
     )
     # also check that we got the right wheels


### PR DESCRIPTION
Not really needed now. This doesn't remove the test-environment, just PYTHONSAFEPATH.
