### PR TITLE
fix: use standard schema line

### DIFF
--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -21,7 +21,7 @@ parser.add_argument("--schemastore", action="store_true", help="Generate schema_
 args = parser.parse_args()
 
 starter = """
-$schema: http://json-schema.org/draft-07/schema
+$schema: http://json-schema.org/draft-07/schema#
 $id: https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json
 $defs:
   inherit:
@@ -365,7 +365,6 @@ schema["properties"] |= oses
 
 if args.schemastore:
     schema["$id"] = "https://json.schemastore.org/partial-cibuildwheel.json"
-    schema["$schema"] = "http://json-schema.org/draft-07/schema#"
     schema["description"] = (
         "cibuildwheel's toml file, generated with ./bin/generate_schema.py --schemastore from cibuildwheel."
     )

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/resources/cibuildwheel.schema.json",
   "$defs": {
     "inherit": {


### PR DESCRIPTION
This was a workaround for a bug in validate-pyproject, but that bug was fixed some time ago, so we can use the standard line here now. 3.0 seems like a good time to fix this.
