### PR TITLE
fix: test-sources should use project dir

### DIFF
--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -565,7 +565,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     if build_options.test_sources:
                         copy_test_sources(
                             build_options.test_sources,
-                            build_options.package_dir,
+                            Path.cwd(),
                             testbed_app_path,
                         )
                     else:

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -403,7 +403,7 @@ def build_in_container(
             if build_options.test_sources:
                 copy_test_sources(
                     build_options.test_sources,
-                    build_options.package_dir,
+                    Path.cwd(),
                     test_cwd,
                     copy_into=container.copy_into,
                 )

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -712,7 +712,7 @@ def build(options: Options, tmp_path: Path) -> None:
                             test_cwd.mkdir()
                             copy_test_sources(
                                 build_options.test_sources,
-                                build_options.package_dir,
+                                Path.cwd(),
                                 test_cwd,
                             )
                     else:

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -527,7 +527,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 if build_options.test_sources:
                     copy_test_sources(
                         build_options.test_sources,
-                        build_options.package_dir,
+                        Path.cwd(),
                         test_cwd,
                     )
                 else:

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -590,7 +590,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 if build_options.test_sources:
                     copy_test_sources(
                         build_options.test_sources,
-                        build_options.package_dir,
+                        Path.cwd(),
                         test_cwd,
                     )
                 else:

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -111,21 +111,21 @@ def copy_into_local(src: Path, dst: PurePath) -> None:
 
 def copy_test_sources(
     test_sources: list[str],
-    package_dir: Path,
+    project_dir: Path,
     test_dir: PurePath,
     copy_into: Callable[[Path, PurePath], None] = copy_into_local,
 ) -> None:
     """Copy the list of test sources from the package to the test directory.
 
-    :param test_sources: A list of test paths, relative to the package_dir.
-    :param package_dir: The root of the package directory.
+    :param test_sources: A list of test paths, relative to the project_dir.
+    :param package_dir: The root of the project.
     :param test_dir: The folder where test sources should be placed.
     :param copy_info: The copy function to use. By default, does a local
         filesystem copy; but an OCIContainer.copy_info method (or equivalent)
         can be provided.
     """
     for test_path in test_sources:
-        source = package_dir.resolve() / test_path
+        source = project_dir.resolve() / test_path
 
         if not source.exists():
             msg = f"Test source {test_path} does not exist."

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -118,9 +118,9 @@ def copy_test_sources(
     """Copy the list of test sources from the package to the test directory.
 
     :param test_sources: A list of test paths, relative to the project_dir.
-    :param package_dir: The root of the project.
+    :param project_dir: The root of the project.
     :param test_dir: The folder where test sources should be placed.
-    :param copy_info: The copy function to use. By default, does a local
+    :param copy_into: The copy function to use. By default, does a local
         filesystem copy; but an OCIContainer.copy_info method (or equivalent)
         can be provided.
     """


### PR DESCRIPTION
Critical fix before 3.0: test-sources should be relative to the project root, not the package directory. The package directory is always a subdirectory of the project directory, so this is more flexible.

By the way, on iOS, it might make sense to expand `{project}` to the relative path? While you normally do know it as well, I'm not sure what all the details are if you run directly on an SDist. (So test-sources work, `{project}`/`cwd()` should probably be the root of the SDist, would be good to verify)

No documentation change since this is how it's described in the docs already. :)

Fix #2436.
