### PR TITLE
Docs fixes

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1791,6 +1791,7 @@ Some options support placeholders, like `{project}`, `{package}` or `{wheel}`, t
     padding-left: 10px;
     padding-right: 10px;
     line-height: normal;
+    overflow: visible;
   }
   .rst-content h3 .badges code.cmd-line:before, .rst-content h3 .badges code.toml:before, .rst-content h3 .badges code.env-var:before {
     content: ' ';

--- a/docs/theme_overrides/js/theme.js
+++ b/docs/theme_overrides/js/theme.js
@@ -126,6 +126,21 @@ function ThemeNav () {
             });
             link.prepend(expand);
         });
+
+        // EDIT by joerick
+        //
+        // workaround a bug with the site in safari. safari navigates to the
+        // anchor before the above code has run, specifically wrap with
+        // .wy-table-responsive activates css rules that change the size of
+        // tables, making anchor points move around.
+        console.log('Document ready, checking for anchor in URL');
+        const anchorEl = document.querySelector(window.location.hash);
+        anchorEl.getBoundingClientRect(); // Force layout to ensure scrollIntoView works correctly
+        if (anchorEl) {
+          console.log('Anchor element:', anchorEl);
+          anchorEl.scrollIntoView({ behavior: 'instant', block: 'start' });
+        }
+        // end edit by joerick
     };
 
     nav.reset = function () {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,9 +27,9 @@ nav:
     - faq.md
     - cpp_standards.md
   - Reference:
-    - platforms.md
-    - configuration.md
     - options.md
+    - configuration.md
+    - platforms.md
     - working-examples.md
   - About:
     - contributing.md


### PR DESCRIPTION
A few fixes to the docs.

cc @henryiii

The bug where the anchors are misaligned in safari is fixed.

A bug where scrollbars would appear on the options badges is fixed.

To make the 'Options' page more prominent, it is moved to the top of the Reference section. I tried adding a star symbol to it, but it seemed to add more visual confusion than was necessary here. I think we link to it enough so that users will find it.
