### PR TITLE
fix: native ios includes device

### DIFF
--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -81,6 +81,8 @@ class Architecture(StrEnum):
                 native_arch = Architecture.native_arch(platform=platform)
                 if native_arch:
                     result.add(native_arch)
+                if native_arch == Architecture.arm64_iphonesimulator:
+                    result.add(Architecture.arm64_iphoneos)
             elif arch_str == "all":
                 result |= Architecture.all_archs(platform=platform)
             elif arch_str == "auto64":

--- a/docs/options.md
+++ b/docs/options.md
@@ -209,12 +209,15 @@ Default: `auto`
 | Runner | `native` | `auto` | `auto64` | `auto32` |
 |---|---|---|---|---|
 | Linux / Intel | `x86_64` | `x86_64` `i686` | `x86_64` | `i686` |
+| Linux / Arm | `aarch64` | `aarch64` `armv7l`* | `aarch64` | `armv7l`* |
 | Windows / Intel | `AMD64` | `AMD64` `x86` | `AMD64` | `x86` |
-| Windows / ARM64 | `ARM64` | `ARM64` | `ARM64` | |
+| Windows / Arm | `ARM64` | `ARM64` | `ARM64` | |
 | macOS / Intel | `x86_64` | `x86_64` | `x86_64` |  |
 | macOS / Apple Silicon | `arm64` | `arm64` | `arm64` |  |
 | iOS on macOS / Intel | `x86_64_iphonesimulator` | `x86_64_iphonesimulator` | `x86_64_iphonesimulator` |  |
 | iOS on macOS / Apple Silicon | `arm64_iphoneos` `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` | |
+
+> <sub>* `armv7l` is included in `auto` on Arm CPUs that support running it natively.</sub>
 
 If not listed above, `auto` is the same as `native`.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -192,14 +192,12 @@ Options:
 - Pyodide: `wasm32`
 - iOS: `arm64_iphoneos` `arm64_iphonesimulator` `x86_64_iphonesimulator`
 - `auto`: The default archs for your machine - see the table below.
-    - `auto64`: Just the 64-bit auto arch[^iosarch]
+    - `auto64`: Just the 64-bit auto arch
     - `auto32`: Just the 32-bit auto arch
-- `native`: the native arch of the build machine - Matches [`platform.machine()`](https://docs.python.org/3/library/platform.html#platform.machine).[^iosarch]
+- `native`: the native arch of the build machine - matches [`platform.machine()`](https://docs.python.org/3/library/platform.html#platform.machine). When building for iOS, this includes both the device and simulator architectures.
 - `all` : expands to all the architectures supported on this OS. You may want
   to use [`build`](#build-skip) with this option to target specific
   architectures via build selectors.
-
-[^iosarch]: For iOS, both `arm64_iphoneos` and `arm64_iphonesimulator` are built on `arm64`.
 
 Linux riscv64 platform support is experimental and requires an explicit opt-in through [`enable`](#enable).
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -192,16 +192,21 @@ Options:
 - Pyodide: `wasm32`
 - iOS: `arm64_iphoneos` `arm64_iphonesimulator` `x86_64_iphonesimulator`
 - `auto`: The default archs for your machine - see the table below.
-    - `auto64`: Just the 64-bit auto archs
-    - `auto32`: Just the 32-bit auto archs
-- `native`: the native arch of the build machine - Matches [`platform.machine()`](https://docs.python.org/3/library/platform.html#platform.machine).
+    - `auto64`: Just the 64-bit auto arch[^iosarch]
+    - `auto32`: Just the 32-bit auto arch
+- `native`: the native arch of the build machine - Matches [`platform.machine()`](https://docs.python.org/3/library/platform.html#platform.machine).[^iosarch]
 - `all` : expands to all the architectures supported on this OS. You may want
   to use [`build`](#build-skip) with this option to target specific
   architectures via build selectors.
 
+[^iosarch]: For iOS, both `arm64_iphoneos` and `arm64_iphonesimulator` are built on `arm64`.
+
 Linux riscv64 platform support is experimental and requires an explicit opt-in through [`enable`](#enable).
 
 Default: `auto`
+
+!!! warning
+    The `auto` option is the current default, but 32-bit Linux builds are deprecated and not available on modern manylinux images. Modern Windows (Windows 11) does not come in a 32-bit version either, so we may change the default to `native` in a future version. Please explicitly specify `auto` if you want to keep the 32-bit builds, or specify `auto64` or `native`.
 
 | Runner | `native` | `auto` | `auto64` | `auto32` |
 |---|---|---|---|---|
@@ -211,9 +216,12 @@ Default: `auto`
 | macOS / Intel | `x86_64` | `x86_64` | `x86_64` |  |
 | macOS / Apple Silicon | `arm64` | `arm64` | `arm64` |  |
 | iOS on macOS / Intel | `x86_64_iphonesimulator` | `x86_64_iphonesimulator` | `x86_64_iphonesimulator` |  |
-| iOS on macOS / Apple Silicon | `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` |
+| iOS on macOS / Apple Silicon | `arm64_iphoneos` `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` | `arm64_iphoneos` `arm64_iphonesimulator` | |
 
 If not listed above, `auto` is the same as `native`.
+
+!!! note
+    Pyodide ignores the architecture setting, as it always builds for `wasm32`.
 
 [setup-qemu-action]: https://github.com/docker/setup-qemu-action
 [binfmt]: https://hub.docker.com/r/tonistiigi/binfmt
@@ -223,6 +231,7 @@ Platform-specific environment variables are also available:<br/>
 
 This option can also be set using the [command-line option](#command-line)
 `--archs`. This option cannot be set in an `overrides` section in `pyproject.toml`.
+
 
 #### Examples
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ markdown_extensions:
       # use highlightjs - it's built-in to the theme
       use_pygments: False
   - pymdownx.superfences
+  - footnotes
 
 plugins:
   - include-markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ markdown_extensions:
       # use highlightjs - it's built-in to the theme
       use_pygments: False
   - pymdownx.superfences
-  - footnotes
 
 plugins:
   - include-markdown

--- a/unit_test/architecture_test.py
+++ b/unit_test/architecture_test.py
@@ -96,3 +96,10 @@ def test_arch_auto_no_aarch32(monkeypatch):
 
     arch_set = Architecture.parse_config("auto32", "linux")
     assert len(arch_set) == 0
+
+
+def test_arch_native_on_ios(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform_module, "machine", lambda: "arm64")
+    arch_set = Architecture.parse_config("native", platform="ios")
+    assert arch_set == {Architecture.arm64_iphonesimulator, Architecture.arm64_iphoneos}


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/issues/2451.

This adds the arm64 device "arch" to `native`. This isn't truly an `arch`, it just fit into this framework better than it did into `platform`, and it _is_ arm64. This means `native` is now is identical to `auto64` when running on a 64-bit system, and `auto32` when running on a 32-bit system (like it was before iOS was added). Practically, you almost never want _just_ built a simulator wheel (which is for testing) but not the device wheel. If you did want to split it up, there's no special term for the device wheel, so you could just use the exact arch name for the simulator wheel too.

This makes `native` a much nicer default in the future, as it's a logical default (don't build 32-bit on 64-bit), and keeps "auto" meaning the same thing (build as much as you can). I've just added a warning for 3.0 about it possibly changing in the future. I can weaken or strengthen the language, or we could even change the default now if everyone wants that.

I've also noted that pyodide ignores the arch and builds regardless of the setting.

CC @freakboy3742 