### PR TITLE
Move to the `OS-latest` image tags on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 jobs:
 - job: linux_311
   timeoutInMinutes: 180
-  pool: {vmImage: 'Ubuntu-22.04'}
+  pool: {vmImage: 'ubuntu-latest'}
   steps:
     - task: UsePythonVersion@0
       inputs:
@@ -25,7 +25,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: macos_311
-  pool: {vmImage: 'macOS-13'}
+  pool: {vmImage: 'macOS-latest'}
   timeoutInMinutes: 120
   steps:
     - task: UsePythonVersion@0
@@ -43,7 +43,7 @@ jobs:
         python ./bin/run_tests.py
 
 - job: windows_311
-  pool: {vmImage: 'windows-2019'}
+  pool: {vmImage: 'windows-latest'}
   timeoutInMinutes: 180
   steps:
     - task: UsePythonVersion@0

--- a/examples/azure-pipelines-minimal.yml
+++ b/examples/azure-pipelines-minimal.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: linux
-  pool: {vmImage: 'Ubuntu-20.04'}
+  pool: {vmImage: 'ubuntu-latest'}
   steps:
     - task: UsePythonVersion@0
     - bash: |
@@ -14,7 +14,7 @@ jobs:
       inputs: {pathtoPublish: 'wheelhouse'}
 
 - job: macos
-  pool: {vmImage: 'macOS-13'}
+  pool: {vmImage: 'macOS-latest'}
   steps:
     - task: UsePythonVersion@0
     - bash: |
@@ -28,7 +28,7 @@ jobs:
       inputs: {pathtoPublish: wheelhouse}
 
 - job: windows
-  pool: {vmImage: 'windows-2019'}
+  pool: {vmImage: 'windows-latest'}
   steps:
     - task: UsePythonVersion@0
     - bash: |


### PR DESCRIPTION
Fixes the CI failure seen in https://github.com/pypa/cibuildwheel/pull/2458 . The Windows-2019 image is deprecated and is being brownout'd. We recently switched to moving tags for Github, it makes sense to do the same on Azure IMO.
