### PR TITLE
ci: use uv python for docs (binary b1)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,7 @@ version: 2
 build:
   os: ubuntu-24.04
   commands:
-    - asdf install python 3.14-dev
-    - asdf global python 3.14-dev
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - NO_COLOR=1 uv run --no-dev --group docs mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html
+    - NO_COLOR=1 uv run --python 3.14 --managed-python --no-dev --group docs mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
There's now a binary (of b1, not b2, but that works), which downloads in a few seconds instead of building.
