### PR TITLE
fix: pyodide missing some logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Linters (mypy, flake8, etc.)
+    name: Linters (mypy, ruff, etc.)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import time
-from typing import IO, AnyStr, Final
+from typing import IO, AnyStr, Final, Literal
 
 from .ci import CIProvider, detect_ci_provider
 
@@ -70,7 +70,7 @@ class Symbols:
 
 
 class Logger:
-    fold_mode: str
+    fold_mode: Literal["azure", "github", "travis", "disabled"]
     colors_enabled: bool
     unicode_enabled: bool
     active_build_identifier: str | None = None

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -3,6 +3,7 @@ import functools
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tomllib
 import typing
@@ -445,6 +446,7 @@ def build(options: Options, tmp_path: Path) -> None:
                         dest_dir=repaired_wheel_dir,
                     )
                     shell(repair_command_prepared, env=env)
+                    log.step_end()
                 else:
                     shutil.move(str(built_wheel), repaired_wheel_dir)
 
@@ -546,6 +548,8 @@ def build(options: Options, tmp_path: Path) -> None:
                         f"{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
                     )
                 built_wheels.append(output_wheel)
+            log.build_end()
 
-    finally:
-        pass
+    except subprocess.CalledProcessError as error:
+        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
+        raise errors.FatalError(msg) from error


### PR DESCRIPTION
Fixes pulled out of #2469. Pyodide was missing some logging constructs. (This is one reason to prefer context managers, much harder to forget to close them!)
