### PR TITLE
fix: support only one output wheel from repair

### DIFF
--- a/cibuildwheel/errors.py
+++ b/cibuildwheel/errors.py
@@ -85,3 +85,21 @@ class RepairStepProducedNoWheelError(FatalError):
         )
         super().__init__(message)
         self.return_code = 8
+
+
+class RepairStepProducedMultipleWheelsError(FatalError):
+    def __init__(self, wheels: list[str]) -> None:
+        message = textwrap.dedent(
+            f"""
+            Build failed because the repair step completed successfully but
+            produced multiple wheels: {wheels}
+
+            Your `repair-wheel-command` is expected to place one repaired
+            wheel in the {{dest_dir}} directory. See the documentation for
+            example configurations:
+
+            https://cibuildwheel.pypa.io/en/stable/options/#repair-wheel-command
+            """
+        )
+        super().__init__(message)
+        self.return_code = 8


### PR DESCRIPTION
This removes the ability to pick up multiple output wheels from the linux repair step, brining it into line with the other operating systems. Auditwheel has, as far as I can tell, switched some time ago to just using multiple tags, not outputting multiple wheels. This will simplify #2469. If it's not true, then I can add multiple wheel outputs to that PR instead, but I think this is the cleaner solution.
