### PR TITLE
Welcome to our new platform maintainers!

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+cibuildwheel/platforms/ios.py         @freakboy3742
+cibuildwheel/platforms/pyodide.py     @hoodmane @ryanking13 @agriyakhetarpal

--- a/README.md
+++ b/README.md
@@ -314,11 +314,21 @@ Everyone interacting with the cibuildwheel project via codebase, issue tracker, 
 Maintainers
 -----------
 
+Core:
+
 - Joe Rickerby [@joerick](https://github.com/joerick)
 - Yannick Jadoul [@YannickJadoul](https://github.com/YannickJadoul)
 - Matthieu Darbois [@mayeut](https://github.com/mayeut)
 - Henry Schreiner [@henryiii](https://github.com/henryiii)
 - Grzegorz Bokota [@Czaki](https://github.com/Czaki)
+
+Platform maintainers:
+
+- Russell Keith-Magee [@freakboy3742](https://github.com/freakboy3742) (iOS)
+- Agriya Khetarpal [@agriyakhetarpal](https://github.com/agriyakhetarpal) (Pyodide)
+- Hood Chatham [@hoodmane](https://github.com/hoodmane) (Pyodide)
+- Gyeongjae Choi [@ryanking13](https://github.com/ryanking13) (Pyodide)
+- Tim Felgentreff [@timfel](https://github.com/timfel) (GraalPy)
 
 Credits
 -------


### PR DESCRIPTION
I'd like to welcome a new team of platform maintainers to the cibuildwheel project! They are-

### iOS

Russell Keith-Magee @freakboy3742 

### Pyodide

Agriya Khetarpal @agriyakhetarpal 
Hood Chatham @hoodmane 
Gyeongjae Choi @ryanking13

### GraalPy

Tim Felgentreff @timfel 

---

The platform maintainer team is a new initiative we've come up with. As cibuildwheel broadens its support into wider reaches of the ecosystem, we thought the project would benefit from a bit more specific expertise. So we're very pleased to be bringing in this talented bunch :) 
