### PR TITLE
fix: show options for --only

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -26,6 +26,7 @@ from cibuildwheel.selector import BuildSelector, EnableGroup, selector_matches
 from cibuildwheel.typing import PLATFORMS, PlatformName
 from cibuildwheel.util.file import CIBW_CACHE_PATH
 from cibuildwheel.util.helpers import strtobool
+from cibuildwheel.util.resources import read_all_configs
 
 
 @dataclasses.dataclass
@@ -132,6 +133,8 @@ def main_inner(global_options: GlobalOptions) -> None:
     parser.add_argument(
         "--only",
         default=None,
+        choices=[v["identifier"] for vv in read_all_configs().values() for v in vv],
+        metavar="IDENTIFIER",
         help="""
             Force a single wheel build when given an identifier. Overrides
             CIBW_BUILD/CIBW_SKIP. --platform and --arch cannot be specified

--- a/cibuildwheel/util/resources.py
+++ b/cibuildwheel/util/resources.py
@@ -22,8 +22,11 @@ TEST_FAIL_CWD_FILE: Final[Path] = PATH / "testing_temp_dir_file.py"
 
 # this value is cached because it's used a lot in unit tests
 @functools.cache
-def read_python_configs(config: PlatformName) -> list[dict[str, str]]:
+def read_all_configs() -> dict[str, list[dict[str, str]]]:
     with BUILD_PLATFORMS.open("rb") as f:
         loaded_file = tomllib.load(f)
-    results: list[dict[str, str]] = list(loaded_file[config]["python_configurations"])
-    return results
+    return {k: list[dict[str, str]](v["python_configurations"]) for k, v in loaded_file.items()}
+
+
+def read_python_configs(config: PlatformName) -> list[dict[str, str]]:
+    return read_all_configs()[config]


### PR DESCRIPTION
Looks like this:

```console
$ uv run cibuildwheel --only cp313t-maylinux_x86_64
usage: cibuildwheel [-h] [--platform {auto,linux,macos,windows,pyodide,ios}] [--archs ARCHS] [--enable GROUP] [--only IDENTIFIER] [--output-dir OUTPUT_DIR]
                    [--config-file CONFIG_FILE] [--print-build-identifiers] [--allow-empty] [--debug-traceback]
                    [PACKAGE]
cibuildwheel: error: argument --only: invalid choice: 'cp313t-maylinux_x86_64', maybe you meant 'cp313t-manylinux_x86_64'? (choose from cp38-manylinux_x86_64, cp39-manylinux_x86_64, cp310-manylinux_x86_64, cp311-manylinux_x86_64, cp312-manylinux_x86_64, cp313-manylinux_x86_64, cp313t-manylinux_x86_64, cp314-manylinux_x86_64, cp314t-manylinux_x86_64, cp38-manylinux_i686, cp39-manylinux_i686, cp310-manylinux_i686, cp311-manylinux_i686, cp312-manylinux_i686, cp313-manylinux_i686, cp313t-manylinux_i686, cp314-manylinux_i686, cp314t-manylinux_i686, pp38-manylinux_x86_64, pp39-manylinux_x86_64, pp310-manylinux_x86_64, pp311-manylinux_x86_64, gp311_242-manylinux_x86_64, cp38-manylinux_aarch64, cp39-manylinux_aarch64, cp310-manylinux_aarch64, cp311-manylinux_aarch64, cp312-manylinux_aarch64, cp313-manylinux_aarch64, cp313t-manylinux_aarch64, cp314-manylinux_aarch64, cp314t-manylinux_aarch64, cp38-manylinux_ppc64le, cp39-manylinux_ppc64le, cp310-manylinux_ppc64le, cp311-manylinux_ppc64le, cp312-manylinux_ppc64le, cp313-manylinux_ppc64le, cp313t-manylinux_ppc64le, cp314-manylinux_ppc64le, cp314t-manylinux_ppc64le, cp38-manylinux_s390x, cp39-manylinux_s390x, cp310-manylinux_s390x, cp311-manylinux_s390x, cp312-manylinux_s390x, cp313-manylinux_s390x, cp313t-manylinux_s390x, cp314-manylinux_s390x, cp314t-manylinux_s390x, cp38-manylinux_armv7l, cp39-manylinux_armv7l, cp310-manylinux_armv7l, cp311-manylinux_armv7l, cp312-manylinux_armv7l, cp313-manylinux_armv7l, cp313t-manylinux_armv7l, cp314-manylinux_armv7l, cp314t-manylinux_armv7l, cp38-manylinux_riscv64, cp39-manylinux_riscv64, cp310-manylinux_riscv64, cp311-manylinux_riscv64, cp312-manylinux_riscv64, cp313-manylinux_riscv64, cp313t-manylinux_riscv64, cp314-manylinux_riscv64, cp314t-manylinux_riscv64, pp38-manylinux_aarch64, pp39-manylinux_aarch64, pp310-manylinux_aarch64, pp311-manylinux_aarch64, gp311_242-manylinux_aarch64, pp38-manylinux_i686, pp39-manylinux_i686, pp310-manylinux_i686, pp311-manylinux_i686, cp38-musllinux_x86_64, cp39-musllinux_x86_64, cp310-musllinux_x86_64, cp311-musllinux_x86_64, cp312-musllinux_x86_64, cp313-musllinux_x86_64, cp313t-musllinux_x86_64, cp314-musllinux_x86_64, cp314t-musllinux_x86_64, cp38-musllinux_i686, cp39-musllinux_i686, cp310-musllinux_i686, cp311-musllinux_i686, cp312-musllinux_i686, cp313-musllinux_i686, cp313t-musllinux_i686, cp314-musllinux_i686, cp314t-musllinux_i686, cp38-musllinux_aarch64, cp39-musllinux_aarch64, cp310-musllinux_aarch64, cp311-musllinux_aarch64, cp312-musllinux_aarch64, cp313-musllinux_aarch64, cp313t-musllinux_aarch64, cp314-musllinux_aarch64, cp314t-musllinux_aarch64, cp38-musllinux_ppc64le, cp39-musllinux_ppc64le, cp310-musllinux_ppc64le, cp311-musllinux_ppc64le, cp312-musllinux_ppc64le, cp313-musllinux_ppc64le, cp313t-musllinux_ppc64le, cp314-musllinux_ppc64le, cp314t-musllinux_ppc64le, cp38-musllinux_s390x, cp39-musllinux_s390x, cp310-musllinux_s390x, cp311-musllinux_s390x, cp312-musllinux_s390x, cp313-musllinux_s390x, cp313t-musllinux_s390x, cp314-musllinux_s390x, cp314t-musllinux_s390x, cp38-musllinux_armv7l, cp39-musllinux_armv7l, cp310-musllinux_armv7l, cp311-musllinux_armv7l, cp312-musllinux_armv7l, cp313-musllinux_armv7l, cp313t-musllinux_armv7l, cp314-musllinux_armv7l, cp314t-musllinux_armv7l, cp38-musllinux_riscv64, cp39-musllinux_riscv64, cp310-musllinux_riscv64, cp311-musllinux_riscv64, cp312-musllinux_riscv64, cp313-musllinux_riscv64, cp313t-musllinux_riscv64, cp314-musllinux_riscv64, cp314t-musllinux_riscv64, cp38-macosx_x86_64, cp38-macosx_arm64, cp38-macosx_universal2, cp39-macosx_x86_64, cp39-macosx_arm64, cp39-macosx_universal2, cp310-macosx_x86_64, cp310-macosx_arm64, cp310-macosx_universal2, cp311-macosx_x86_64, cp311-macosx_arm64, cp311-macosx_universal2, cp312-macosx_x86_64, cp312-macosx_arm64, cp312-macosx_universal2, cp313-macosx_x86_64, cp313-macosx_arm64, cp313-macosx_universal2, cp313t-macosx_x86_64, cp313t-macosx_arm64, cp313t-macosx_universal2, cp314-macosx_x86_64, cp314-macosx_arm64, cp314-macosx_universal2, cp314t-macosx_x86_64, cp314t-macosx_arm64, cp314t-macosx_universal2, pp38-macosx_x86_64, pp38-macosx_arm64, pp39-macosx_x86_64, pp39-macosx_arm64, pp310-macosx_x86_64, pp310-macosx_arm64, pp311-macosx_x86_64, pp311-macosx_arm64, gp311_242-macosx_x86_64, gp311_242-macosx_arm64, cp38-win32, cp38-win_amd64, cp39-win32, cp39-win_amd64, cp310-win32, cp310-win_amd64, cp311-win32, cp311-win_amd64, cp312-win32, cp312-win_amd64, cp313-win32, cp313t-win32, cp313-win_amd64, cp313t-win_amd64, cp314-win32, cp314t-win32, cp314-win_amd64, cp314t-win_amd64, cp39-win_arm64, cp310-win_arm64, cp311-win_arm64, cp312-win_arm64, cp313-win_arm64, cp313t-win_arm64, cp314-win_arm64, cp314t-win_arm64, pp38-win_amd64, pp39-win_amd64, pp310-win_amd64, pp311-win_amd64, gp311_242-win_amd64, cp312-pyodide_wasm32, cp313-pyodide_wasm32, cp313-ios_arm64_iphoneos, cp313-ios_x86_64_iphonesimulator, cp313-ios_arm64_iphonesimulator, cp314-ios_arm64_iphoneos, cp314-ios_x86_64_iphonesimulator, cp314-ios_arm64_iphonesimulator)
```
