### PR TITLE
feat: add support for manylinux_2_34 i686 image

### DIFF
--- a/bin/update_docker.py
+++ b/bin/update_docker.py
@@ -59,7 +59,17 @@ images = [
     PyPAImage("manylinux_2_31", ["armv7l"]),
     # manylinux_2_34 images
     PyPAImage(
-        "manylinux_2_34", ["x86_64", "aarch64", "ppc64le", "s390x", "pypy_x86_64", "pypy_aarch64"]
+        "manylinux_2_34",
+        [
+            "x86_64",
+            "i686",
+            "aarch64",
+            "ppc64le",
+            "s390x",
+            "pypy_x86_64",
+            "pypy_i686",
+            "pypy_aarch64",
+        ],
     ),
     # musllinux_1_2 images
     PyPAImage("musllinux_1_2", ["x86_64", "i686", "aarch64", "ppc64le", "s390x", "armv7l"]),

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,49 +1,51 @@
 [x86_64]
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2025.07.14-5
 
 [i686]
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2025.07.14-5
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2025.07.14-5
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_ppc64le:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_ppc64le:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2025.07.14-5
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_s390x:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_s390x:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2025.07.14-5
 
 [pypy_x86_64]
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.07.14-5
 
 [pypy_i686]
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.07.14-5
 
 [pypy_aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.07.12-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.07.12-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.07.12-1
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.07.14-5
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.07.14-5
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.07.14-5
 
 [armv7l]
-manylinux_2_31 = quay.io/pypa/manylinux_2_31_armv7l:2025.07.12-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_armv7l:2025.07.12-1
+manylinux_2_31 = quay.io/pypa/manylinux_2_31_armv7l:2025.07.14-5
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_armv7l:2025.07.14-5
 
 [riscv64]
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1029,7 +1029,6 @@ The available options are:
 Set the Docker image to be used for building [manylinux / musllinux](https://github.com/pypa/manylinux) wheels.
 
 For `manylinux-*-image`, except `manylinux-armv7l-image`, the value of this option can either be set to `manylinux2014`, `manylinux_2_28` or `manylinux_2_34` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name.
-`manylinux_2_34` is not supported for `i686` architecture.
 
 For `manylinux-armv7l-image`, the value of this option can either be set to `manylinux_2_31` or a custom image. Support is experimental for now. The `manylinux_2_31` value is only available for `armv7`.
 

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -64,8 +64,6 @@ project_with_manylinux_symbols = test_projects.new_c_project(
 def test(manylinux_image, tmp_path):
     if utils.get_platform() != "linux":
         pytest.skip("the container image test is only relevant to the linux build")
-    elif manylinux_image == "manylinux_2_34" and platform.machine() == "i686":
-        pytest.skip(f"{manylinux_image} doesn't exist for i686 architecture")
 
     project_dir = tmp_path / "project"
     project_with_manylinux_symbols.generate(project_dir)
@@ -85,9 +83,6 @@ def test(manylinux_image, tmp_path):
         "CIBW_MANYLINUX_PYPY_AARCH64_IMAGE": manylinux_image,
         "CIBW_MANYLINUX_PYPY_I686_IMAGE": manylinux_image,
     }
-    if manylinux_image == "manylinux_2_34" and platform.machine() == "x86_64":
-        # We don't have a manylinux_2_34+ image for i686
-        add_env["CIBW_ARCHS"] = "x86_64"
     if platform.machine() == "aarch64":
         # We just have a manylinux_2_31 image for armv7l
         add_env["CIBW_ARCHS"] = "aarch64"
@@ -103,10 +98,6 @@ def test(manylinux_image, tmp_path):
         manylinux_versions=platform_tag_map.get(manylinux_image, [manylinux_image]),
         musllinux_versions=[],
     )
-
-    if manylinux_image == "manylinux_2_34" and platform.machine() == "x86_64":
-        # We don't have a manylinux_2_34+ image for i686
-        expected_wheels = [w for w in expected_wheels if "i686" not in w]
 
     if platform.machine() == "aarch64":
         # We just have a manylinux_2_31 image for armv7l


### PR DESCRIPTION
The GHA cache limits issue for manylinux mentioned in #2480 has been fixed. The manylinux_2_34 i686 image is now available.