### PR TITLE
feat: include free-threaded 3.14 by default

### DIFF
--- a/cibuildwheel/selector.py
+++ b/cibuildwheel/selector.py
@@ -85,7 +85,7 @@ class BuildSelector:
                 return False
 
         # filter out groups that are not enabled
-        if EnableGroup.CPythonFreeThreading not in self.enable and fnmatch(build_id, "cp3??t-*"):
+        if EnableGroup.CPythonFreeThreading not in self.enable and fnmatch(build_id, "cp313t-*"):
             return False
         if EnableGroup.CPythonPrerelease not in self.enable and fnmatch(build_id, "cp314*"):
             return False

--- a/docs/options.md
+++ b/docs/options.md
@@ -348,9 +348,10 @@ values are:
 - `cpython-freethreading`: [PEP 703](https://www.python.org/dev/peps/pep-0703)
   introduced variants of CPython that can be built without the Global
   Interpreter Lock (GIL).  Those variants are also known as free-threaded /
-  no-gil. This will enable building these wheels while they are experimental.
-  The build identifiers for those variants have a `t` suffix in their
-  `python_tag` (e.g. `cp313t-manylinux_x86_64`).
+  no-gil. This will enable building these wheels for 3.13, which was considered
+  experimental.  The build identifiers for those variants have a `t` suffix in
+  their `python_tag` (e.g. `cp313t-manylinux_x86_64`). Starting in 3.14,
+  free-threaded builds are no longer experimental, so this enable is not needed.
 - `pypy`: Enable PyPy.
 - `pypy-eol`: Enable PyPy versions that have passed end of life (if still available).
 - `cpython-experimental-riscv64`: Enable experimental riscv64 builds. Those builds
@@ -371,7 +372,7 @@ values are:
     that version of Python will become available without this flag.
 
 !!! note
-    Free threading is experimental: [What’s New In Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython)
+    Free threading was experimental in 3.13: [What’s New In Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython)
 
 Default: empty.
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -280,8 +280,7 @@ def _expected_wheels(
 
         if EnableGroup.CPythonPrerelease in enable_groups:
             python_abi_tags.append("cp314-cp314")
-            if EnableGroup.CPythonFreeThreading in enable_groups:
-                python_abi_tags.append("cp314-cp314t")
+            python_abi_tags.append("cp314-cp314t")
 
         if EnableGroup.PyPyEoL in enable_groups:
             python_abi_tags += [


### PR DESCRIPTION
This is no longer experimental in 3.13 beta 3, so we don't need an enable for it anymore. Someone can skip expliclity with `'cp31?t-*'` if they really don't want free-threaded wheels.

