### PR TITLE
feat: add default riscv64 images

### DIFF
--- a/bin/update_docker.py
+++ b/bin/update_docker.py
@@ -71,8 +71,12 @@ images = [
             "pypy_aarch64",
         ],
     ),
+    # manylinux_2_39 images
+    PyPAImage("manylinux_2_39", ["riscv64"]),
     # musllinux_1_2 images
-    PyPAImage("musllinux_1_2", ["x86_64", "i686", "aarch64", "ppc64le", "s390x", "armv7l"]),
+    PyPAImage(
+        "musllinux_1_2", ["x86_64", "i686", "aarch64", "ppc64le", "s390x", "armv7l", "riscv64"]
+    ),
 ]
 
 config = configparser.ConfigParser()
@@ -135,9 +139,6 @@ for image in images:
         if image.use_platform_suffix:
             suffix = f"_{platform.removeprefix('pypy_')}"
         config[platform][image.manylinux_version] = f"{image.image_name}{suffix}:{tag_name}"
-
-if not config.has_section("riscv64"):
-    config["riscv64"] = {}
 
 with open(RESOURCES / "pinned_docker_images.cfg", "w") as f:
     config.write(f)

--- a/cibuildwheel/resources/defaults.toml
+++ b/cibuildwheel/resources/defaults.toml
@@ -36,7 +36,7 @@ manylinux-aarch64-image = "manylinux_2_28"
 manylinux-ppc64le-image = "manylinux_2_28"
 manylinux-s390x-image = "manylinux_2_28"
 manylinux-armv7l-image = "manylinux_2_31"
-manylinux-riscv64-image = "ghcr.io/pypa/cibuildwheel/no_default_image:please_use_override"
+manylinux-riscv64-image = "manylinux_2_39"
 manylinux-pypy_x86_64-image = "manylinux_2_28"
 manylinux-pypy_i686-image = "manylinux_2_28"
 manylinux-pypy_aarch64-image = "manylinux_2_28"
@@ -47,7 +47,7 @@ musllinux-aarch64-image = "musllinux_1_2"
 musllinux-ppc64le-image = "musllinux_1_2"
 musllinux-s390x-image = "musllinux_1_2"
 musllinux-armv7l-image = "musllinux_1_2"
-musllinux-riscv64-image = "ghcr.io/pypa/cibuildwheel/no_default_image:please_use_override"
+musllinux-riscv64-image = "musllinux_1_2"
 
 
 [tool.cibuildwheel.linux]

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -48,4 +48,6 @@ manylinux_2_31 = quay.io/pypa/manylinux_2_31_armv7l:2025.07.20-2
 musllinux_1_2 = quay.io/pypa/musllinux_1_2_armv7l:2025.07.20-2
 
 [riscv64]
+manylinux_2_39 = quay.io/pypa/manylinux_2_39_riscv64:2025.07.20-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_riscv64:2025.07.20-2
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1016,7 +1016,7 @@ The available options are:
 | `manylinux-ppc64le-image`      | [`manylinux_2_28`](https://quay.io/pypa/manylinux_2_28_ppc64le) |
 | `manylinux-s390x-image`        | [`manylinux_2_28`](https://quay.io/pypa/manylinux_2_28_s390x)   |
 | `manylinux-armv7l-image`       | [`manylinux_2_31`](https://quay.io/pypa/manylinux_2_31_armv7l)  |
-| `manylinux-riscv64-image`      | No default                                                      |
+| `manylinux-riscv64-image`      | [`manylinux_2_39`](https://quay.io/pypa/manylinux_2_39_riscv64) |
 | `manylinux-pypy_aarch64-image` | [`manylinux_2_28`](https://quay.io/pypa/manylinux_2_28_aarch64) |
 | `manylinux-pypy_i686-image`    | [`manylinux_2_28`](https://quay.io/pypa/manylinux_2_28_i686)    |
 | `musllinux_x86_64-image`       | [`musllinux_1_2`](https://quay.io/pypa/musllinux_1_2_x86_64)    |
@@ -1025,13 +1025,15 @@ The available options are:
 | `musllinux-ppc64le-image`      | [`musllinux_1_2`](https://quay.io/pypa/musllinux_1_2_ppc64le)   |
 | `musllinux-s390x-image`        | [`musllinux_1_2`](https://quay.io/pypa/musllinux_1_2_s390x)     |
 | `musllinux-armv7l-image`       | [`musllinux_1_2`](https://quay.io/pypa/musllinux_1_2_armv7l)    |
-| `musllinux-riscv64-image`      | No default                                                      |
+| `musllinux-riscv64-image`      | [`musllinux_1_2`](https://quay.io/pypa/musllinux_1_2_riscv64)   |
 
 Set the Docker image to be used for building [manylinux / musllinux](https://github.com/pypa/manylinux) wheels.
 
-For `manylinux-*-image`, except `manylinux-armv7l-image`, the value of this option can either be set to `manylinux2014`, `manylinux_2_28` or `manylinux_2_34` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name.
+For `manylinux-*-image`, except `manylinux-armv7l-image` and `manylinux-riscv64-image`, the value of this option can either be set to `manylinux2014`, `manylinux_2_28` or `manylinux_2_34` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name.
 
 For `manylinux-armv7l-image`, the value of this option can either be set to `manylinux_2_31` or a custom image. Support is experimental for now. The `manylinux_2_31` value is only available for `armv7`.
+
+For `manylinux-riscv64-image`, the value of this option can either be set to `manylinux_2_39` or a custom image. Support is experimental for now. The `manylinux_2_39` value is only available for `riscv64`.
 
 For `musllinux-*-image`, the value of this option can either be set to `musllinux_1_2` or a custom image.
 

--- a/test/test_emulation.py
+++ b/test/test_emulation.py
@@ -34,21 +34,14 @@ def test(tmp_path, request):
             "CIBW_TEST_REQUIRES": "pytest",
             "CIBW_TEST_COMMAND": "pytest {project}/test",
             "CIBW_ARCHS": archs,
-            # TODO remove me once proper support is added
-            "CIBW_MANYLINUX_RISCV64_IMAGE": "ghcr.io/mayeut/manylinux_2_35:2025.05.11-1",
-            "CIBW_SKIP": "*-musllinux_riscv64",
         },
     )
 
     # also check that we got the right wheels
-    expected_wheels = list(
-        itertools.chain.from_iterable(
-            utils.expected_wheels("spam", "0.1.0", machine_arch=arch, single_arch=True)
-            for arch in archs.split(" ")
-        )
+    expected_wheels = itertools.chain.from_iterable(
+        utils.expected_wheels("spam", "0.1.0", machine_arch=arch, single_arch=True)
+        for arch in archs.split(" ")
     )
-    # TODO remove me once proper support is added
-    expected_wheels = [wheel for wheel in expected_wheels if "musllinux_1_2_riscv64" not in wheel]
     assert set(actual_wheels) == set(expected_wheels)
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -254,7 +254,7 @@ def _expected_wheels(
             "armv7l": ["manylinux2014", "manylinux_2_17", "manylinux_2_31"],
             "i686": ["manylinux1", "manylinux_2_28", "manylinux_2_5"],
             "x86_64": ["manylinux1", "manylinux_2_28", "manylinux_2_5"],
-            "riscv64": ["manylinux_2_31", "manylinux_2_35"],
+            "riscv64": ["manylinux_2_31", "manylinux_2_39"],
         }.get(machine_arch, ["manylinux2014", "manylinux_2_17", "manylinux_2_28"])
 
     if musllinux_versions is None:


### PR DESCRIPTION
Images for RISC-V are now available in [pypa/manylinux](https://github.com/pypa/manylinux)
Wheels can't be pushed (yet) to PyPI so leaving the enable flag for now.