### PR TITLE
feat: riscv64 builds are now enabled by default

### DIFF
--- a/cibuildwheel/selector.py
+++ b/cibuildwheel/selector.py
@@ -93,10 +93,6 @@ class BuildSelector:
             return False
         if EnableGroup.PyPyEoL not in self.enable and fnmatch(build_id, "pp3?-*"):
             return False
-        if EnableGroup.CPythonExperimentalRiscV64 not in self.enable and fnmatch(
-            build_id, "*_riscv64"
-        ):
-            return False
         if EnableGroup.GraalPy not in self.enable and fnmatch(build_id, "gp*"):
             return False
         # TODO: Re-enable this when we have Pyodide prereleases again (e.g., 0.29.0a1+)

--- a/docs/options.md
+++ b/docs/options.md
@@ -71,7 +71,6 @@ The list of supported and currently selected build identifiers can also be retri
 The format is `python_tag-platform_tag`, with tags similar to those in [PEP 425](https://www.python.org/dev/peps/pep-0425/#details).
 
 Windows arm64 platform support is experimental.
-Linux riscv64 platform support is experimental and requires an explicit opt-in through [`enable`](#enable).
 
 See the [cibuildwheel 2 documentation](https://cibuildwheel.pypa.io/en/2.x/) for past end-of-life versions of Python.
 
@@ -200,8 +199,6 @@ Options:
 - `all` : expands to all the architectures supported on this OS. You may want
   to use [`build`](#build-skip) with this option to target specific
   architectures via build selectors.
-
-Linux riscv64 platform support is experimental and requires an explicit opt-in through [`enable`](#enable).
 
 Default: `auto`
 
@@ -356,9 +353,6 @@ values are:
   free-threaded builds are no longer experimental, so this enable is not needed.
 - `pypy`: Enable PyPy.
 - `pypy-eol`: Enable PyPy versions that have passed end of life (if still available).
-- `cpython-experimental-riscv64`: Enable experimental riscv64 builds. Those builds
-  are disabled by default as they can't be uploaded to PyPI and a PEP will most likely
-  be required before this can happen.
 - `graalpy`: Enable GraalPy.
 - `pyodide-prerelease`: Pyodide versions that haven't released yet, if one is
   available. Safe if you are shipping a site with an early build, not for

--- a/test/utils.py
+++ b/test/utils.py
@@ -51,7 +51,7 @@ def get_platform() -> str:
         raise Exception(msg)
 
 
-DEFAULT_CIBW_ENABLE = "cpython-freethreading cpython-prerelease cpython-experimental-riscv64"
+DEFAULT_CIBW_ENABLE = "cpython-freethreading cpython-prerelease"
 
 
 def get_enable_groups() -> frozenset[EnableGroup]:

--- a/unit_test/build_selector_test.py
+++ b/unit_test/build_selector_test.py
@@ -217,15 +217,6 @@ def test_build_free_threaded_python():
     assert build_selector("cp313t-manylinux_x86_64")
 
 
-def test_build_riscv64_enable():
-    build_selector = BuildSelector(build_config="*", skip_config="")
-    assert not build_selector("cp313-manylinux_riscv64")
-    build_selector = BuildSelector(
-        build_config="*", skip_config="", enable=frozenset([EnableGroup.CPythonExperimentalRiscV64])
-    )
-    assert build_selector("cp313-manylinux_riscv64")
-
-
 def test_testing_selector():
     # This is not a global import to keep pytest from collecting it as a test
     test_selector = cibuildwheel.selector.TestSelector(skip_config="cp36-*")


### PR DESCRIPTION
PyPI now accepts `riscv64` uploads for manylinux/musllinux.
Those builds do not require an opt-in anymore.

The enable is still defined and present in the schema not to break users that have it set but it's not used anymore.
It probably should be deprecated (now or later ?) then removed in a future version.