### PR TITLE
Clarify language around Python requirements for local `cibuildwheel` usage

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ cibuildwheel
 !!!tip
     You can pass the `--platform linux` option to cibuildwheel to build Linux wheels, even if you're not on Linux. On most machines, the easiest builds to try are the Linux builds. You don't need any software installed except a Docker daemon, such as [Docker Desktop](https://www.docker.com/get-started/). Each platform that cibuildwheel supports has its own system requirements and platform-specific behaviors. See the [platforms page](platforms.md) for details.
 
-    When building locally for macOS or iOS, regardless of the Python you use to invoke cibuildwheel, you'll need [official Python.org](https://www.python.org/downloads/) installations on your machine. `cibuildwheel` won't perform the build using unofficial Python installations such as from `brew` or `uv`. 
+    When building locally for macOS or iOS, regardless of the Python you use to invoke cibuildwheel, you'll need [official Python.org](https://www.python.org/downloads/) installations on your machine. `cibuildwheel` won't perform the build using unofficial Python installations such as from `brew` or `uv`.
 
 You should see the builds taking place. You can experiment with [options](options.md) using pyproject.toml or environment variables.
 


### PR DESCRIPTION
First attempt to close #2502.

Clarify that Python installation on Mac and Windows requires needs to be installed directly from https://python.org/downloads and not through other sources like `uv`.

Similarly, it might make sense to have the example usage include a flag that ultimately builds using a container so avoid a similar problem, though I have no strong feelings either way.

Proposed updated quickstart example:
```
# run using uv
uvx cibuildwheel --only cp314-manylinux_x86_64
```