### PR TITLE
Add Cirrus macOS as a runner that supports building for Android but not testing

### DIFF
--- a/test/test_android.py
+++ b/test/test_android.py
@@ -28,12 +28,10 @@ if (platform.system(), platform.machine()) not in [
     )
 
 # Detect CI services which have the Android SDK pre-installed.
-ci_supports_build = any(
-    key in os.environ
-    for key in [
-        "GITHUB_ACTIONS",
-        "TF_BUILD",  # Azure Pipelines
-    ]
+ci_supports_build = (
+    ("CIRRUS_CI" in os.environ and platform.system() == "Darwin")
+    or "GITHUB_ACTIONS" in os.environ
+    or "TF_BUILD" in os.environ  # Azure Pipelines
 )
 
 if "ANDROID_HOME" not in os.environ:


### PR DESCRIPTION
This should prevent failures like [this one](https://cirrus-ci.com/task/6086399490785280).