### PR TITLE
Adding @mhsmith as platform maintainer for Android

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 cibuildwheel/platforms/ios.py         @freakboy3742
 cibuildwheel/platforms/pyodide.py     @hoodmane @ryanking13 @agriyakhetarpal
+cibuildwheel/platforms/android.py     @mhsmith

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Platform maintainers:
 - Hood Chatham [@hoodmane](https://github.com/hoodmane) (Pyodide)
 - Gyeongjae Choi [@ryanking13](https://github.com/ryanking13) (Pyodide)
 - Tim Felgentreff [@timfel](https://github.com/timfel) (GraalPy)
+- Malcolm Smith [@mhsmith](https://github.com/mhsmith) (Android)
 
 Credits
 -------


### PR DESCRIPTION
Welcome @mhsmith to our [platform maintainer team](https://github.com/pypa/cibuildwheel/pull/2481)!

@ewdurbin, would you mind to do the honors again to invite @mhsmith to the relevant committer team in github?
