### PR TITLE
ci: rework tests to break out ios/android tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,18 +47,44 @@ jobs:
       run: pipx run --python "${{ steps.python.outputs.python-path }}" nox -s pylint -- --output-format=github
 
   test:
-    name: Test on ${{ matrix.os }} (${{ matrix.python_version }})
+    name: Test on ${{ matrix.os }} (${{ matrix.python_version }}) ${{ matrix.platform }}
     needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-15]
-        python_version: ['3.13']
         include:
+        # Min Python
         - os: ubuntu-latest
           python_version: '3.11'
+        # Max Python
         - os: ubuntu-latest
           python_version: '3.14'
+        - os: ubuntu-latest
+          python_version: '3.13'
+          platform: android
+        - os: ubuntu-24.04-arm
+          python_version: '3.13'
+        - os: windows-latest
+          python_version: '3.13'
+        - os: windows-11-arm
+          python_version: '3.13'
+        - os: macos-13
+          python_version: '3.13'
+        - os: macos-15
+          python_version: '3.13'
+        - os: macos-13
+          python_version: '3.13'
+          platform: ios
+        - os: macos-15
+          python_version: '3.13'
+          platform: ios
+        - os: macos-13
+          python_version: '3.13'
+          platform: android
+        - os: macos-15
+          python_version: '3.13'
+          platform: android
     timeout-minutes: 180
     steps:
     - uses: actions/checkout@v4
@@ -97,6 +123,7 @@ jobs:
         uv sync --no-dev --group test
 
     - uses: joerick/pr-labels-action@v1.0.9
+
     - name: Set CIBW_ENABLE
       shell: bash
       run: |
@@ -128,9 +155,11 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
         CIBW_BUILD_FRONTEND: 'build[uv]'
+        CIBW_PLATFORM: ${{ matrix.platform }}
 
     - name: Run a sample build (GitHub Action, only)
       uses: ./
+      if: matrix.platform == ''
       with:
         package-dir: sample_proj
         output-dir: wheelhouse_only
@@ -150,6 +179,8 @@ jobs:
 
     - name: Run a sample build (GitHub Action, config-file)
       uses: ./
+      env:
+        CIBW_PLATFORM: ${{ matrix.platform }}
       with:
         package-dir: sample_proj
         output-dir: wheelhouse_config_file
@@ -168,6 +199,8 @@ jobs:
         path: wheelhouse/*.whl
 
     - name: Test cibuildwheel
+      env:
+        CIBW_PLATFORM: ${{ matrix.platform }}
       run: |
         uv run --no-sync bin/run_tests.py ${{ (runner.os == 'Linux' && runner.arch == 'X64') && '--run-podman' || '' }}
 

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -62,6 +62,14 @@ if __name__ == "__main__":
         "test",
         "-vv",
     ]
+    match os.environ.get("CIBW_PLATFORM", "native"):
+        case "":
+            serial_integration_test_args += ["-m not pyodide", "-m not android", "-m not ios"]
+        case "native":
+            pass
+        case platform:
+            serial_integration_test_args += ["-m {platform}"]
+
     print(
         "\n\n=========================== SERIAL INTEGRATION TESTS ===========================",
         flush=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ filterwarnings = ["error"]
 log_cli_level = "INFO"
 markers = [
     "serial: tests that must *not* be run in parallel (deselect with '-m \"not serial\"')",
+    "ios: tests that run on iOS",
+    "android: tests that run on Android",
+    "pyodide: tests that run on Pyodide",
 ]
 
 [tool.mypy]

--- a/test/test_android.py
+++ b/test/test_android.py
@@ -12,6 +12,9 @@ import pytest
 from .test_projects import new_c_project
 from .utils import cibuildwheel_run, expected_wheels
 
+pytestmark = pytest.mark.pyodide
+
+
 CIBW_PLATFORM = os.environ.get("CIBW_PLATFORM", "android")
 if CIBW_PLATFORM != "android":
     pytest.skip(f"{CIBW_PLATFORM=}", allow_module_level=True)

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -12,6 +12,12 @@ from cibuildwheel.ci import CIProvider, detect_ci_provider
 
 from . import test_projects, utils
 
+pytestmark = pytest.mark.ios
+
+CIBW_PLATFORM = os.environ.get("CIBW_PLATFORM", "ios")
+if CIBW_PLATFORM != "ios":
+    pytest.skip(f"{CIBW_PLATFORM=}", allow_module_level=True)
+
 basic_project_files = {
     "tests/test_platform.py": f"""
 import platform

--- a/test/test_pyodide.py
+++ b/test/test_pyodide.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import subprocess
 import sys
 import textwrap
@@ -8,6 +9,12 @@ import pytest
 from cibuildwheel.util.file import CIBW_CACHE_PATH
 
 from . import test_projects, utils
+
+pytestmark = pytest.mark.pyodide
+
+CIBW_PLATFORM = os.environ.get("CIBW_PLATFORM", "pyodide")
+if CIBW_PLATFORM != "pyodide":
+    pytest.skip(f"{CIBW_PLATFORM=}", allow_module_level=True)
 
 basic_project = test_projects.new_c_project()
 basic_project.files["check_node.py"] = r"""


### PR DESCRIPTION
Fail fast disabled, and trying to split out the android/ios runs.
