### PR TITLE
fix: error on CIBW_FREE_THREADED_SUPPORT set

### DIFF
--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -16,6 +16,18 @@ from cibuildwheel.util.packaging import DependencyConstraints
 # CIBW_PLATFORM is tested in main_platform_test.py
 
 
+def test_old_free_threaded(monkeypatch, capsys):
+    monkeypatch.setenv("CIBW_FREE_THREADED_SUPPORT", "ON")
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert (
+        "CIBW_FREE_THREADED_SUPPORT environment variable is no longer supported."
+        in capsys.readouterr().err
+    )
+
+
 @pytest.mark.usefixtures("platform")
 def test_output_dir(intercepted_build_args, monkeypatch):
     OUTPUT_DIR = Path("some_output_dir")


### PR DESCRIPTION
Error on `CIBW_FREE_THREADED_SUPPORT` being set. From comments on the cibuildwheel channel on Discord.

I started this with https://mini-swe-agent.com/latest/quickstart/ and this prompt:

```
 I’d like to add an error when the prevously removed CIBW_FREE_THREADED_SUPPORT environment variable is set. The error should point to tool.cibuildwheel.enable = [“cpython-freethreading”] in pyproject.toml, or setting the CIBW_ENABLE environment variable to cpython-freethreading as replacements. I think a good place for this would be cibuildwheel.__main__, probably similar to the detect_warnings function. The error should be logged with our logging system before stopping the run.
```

And it produced this:

```diff
 def detect_warnings(*, options: Options, identifiers: Iterable[str]) -> list[str]:
     warnings = []

+    # Check for deprecated CIBW_FREE_THREADED_SUPPORT environment variable
+    if "CIBW_FREE_THREADED_SUPPORT" in os.environ:
+        msg = (
+            "CIBW_FREE_THREADED_SUPPORT environment variable is no longer supported. "
+            "Use tool.cibuildwheel.enable = [\"cpython-freethreading\"] in pyproject.toml "
+            "or set CIBW_ENABLE=cpython-freethreading instead."
+        )
+        log.error(msg)
+        raise errors.ConfigurationError(msg)
+
```

But I went of on a different direction, refactoring the functions.
