### PR TITLE
tests: add flaky test handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ test = [
     "jinja2",
     "pytest-timeout",
     "pytest-xdist",
+    "pytest-rerunfailures",
     "pytest>=6",
     "setuptools",
     "tomli_w",

--- a/test/test_android.py
+++ b/test/test_android.py
@@ -90,6 +90,8 @@ def test_android_home(tmp_path, capfd):
     assert "ANDROID_HOME environment variable is not set" in capfd.readouterr().err
 
 
+# Can fail to setup
+@pytest.mark.flaky(reruns=2)
 def test_frontend_good(tmp_path):
     new_c_project().generate(tmp_path)
     wheels = cibuildwheel_run(

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -49,7 +49,9 @@ def skip_if_ios_testing_not_supported() -> None:
 # it's easy to overload the CI machine if there are multiple test processes
 # running multithreaded processes. Therefore, they're put in the serial group,
 # which is guaranteed to run single-process.
+# This can also fail the first time sometimes.
 @pytest.mark.serial
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "build_config",
     [


### PR DESCRIPTION
Adding a marker on the iOS test that flakes out sometimes.

I went with pytest-rerunfailures as it seems to be better maintained and gets about 5x the downloads vs. flaky. They are conflicting (same marker name), so you have to pick just one.