### PR TITLE
fix: enable `all`  shall not enable `cpython-experimental-riscv64`

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -665,7 +665,7 @@ class Options:
             build_config = args.only
             skip_config = ""
             architectures = Architecture.all_archs(self.platform)
-            enable |= set(EnableGroup) - {EnableGroup.CPythonExperimentalRiscV64}
+            enable |= EnableGroup.all_groups()
 
         build_selector = BuildSelector(
             build_config=build_config,

--- a/cibuildwheel/selector.py
+++ b/cibuildwheel/selector.py
@@ -39,7 +39,7 @@ class EnableGroup(StrEnum):
 
     @classmethod
     def all_groups(cls) -> frozenset["EnableGroup"]:
-        return frozenset(cls)
+        return frozenset(set(cls) - {cls.CPythonExperimentalRiscV64})
 
     @classmethod
     def parse_option_value(cls, value: str) -> frozenset["EnableGroup"]:

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -188,6 +188,24 @@ def test_riscv64_no_warning(monkeypatch, capsys, tmp_path):
     assert "'cpython-experimental-riscv64' enable is deprecated" not in err
 
 
+@pytest.mark.usefixtures("platform", "intercepted_build_args")
+def test_riscv64_no_warning2(monkeypatch, capsys, tmp_path):
+    local_path = tmp_path / "tmp_project"
+    os.mkdir(local_path)  # noqa:PTH102 Path.mkdir has been monkeypatched already
+    local_path.joinpath("setup.py").touch()
+
+    monkeypatch.setattr(
+        sys, "argv", ["cibuildwheel", "--only", "cp313-manylinux_riscv64", str(local_path)]
+    )
+    monkeypatch.setenv("CIBW_ENABLE", "all")
+
+    main()
+
+    _, err = capsys.readouterr()
+    print(err)
+    assert "'cpython-experimental-riscv64' enable is deprecated" not in err
+
+
 @pytest.mark.parametrize(
     ("architecture", "image", "full_image"),
     [


### PR DESCRIPTION
follow-up on #2526 which fails on main