### PR TITLE
fix: never call pip directly

### DIFF
--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -143,6 +143,8 @@ def virtualenv(
     venv_env["VIRTUAL_ENV"] = str(venv_path)
     if not use_uv and pip_version == "embed":
         call(
+            "python",
+            "-m",
             "pip",
             "install",
             "--upgrade",


### PR DESCRIPTION
You can't change the running process in Windows. In pip 25.2, the format of the generated file changes, so this now breaks if you try to update to the latest pip (which can happen if deps are unpinned).

See #2536.