### PR TITLE
docs(project): add Falcon to working examples

### DIFF
--- a/docs/data/projects.yml
+++ b/docs/data/projects.yml
@@ -664,3 +664,10 @@
   os: [apple, linux, windows]
   pypi: streaming-form-data
   notes: Streaming parser for multipart/form-data written in Cython
+
+- name: falcon
+  gh: falconry/falcon
+  ci: [github]
+  os: [apple, linux, windows]
+  pypi: falcon
+  notes: Falcon is a no-magic ASGI/WSGI API and microservices framework; it uses cibuildwheel for (optional) Cython extensions.


### PR DESCRIPTION
[Falcon](https://github.com/falconry/falcon) is a no-magic ASGI/WSGI API and microservices framework.

It uses `cibuildwheel` for building (optional) Cython extensions; the wheels are primarily built in GitHub Actions CI using the following workflow: [`cibuildwheel.yaml`](https://github.com/falconry/falcon/blob/master/.github/workflows/cibuildwheel.yaml) (also includes other related chores such as building the _sdist_, and uploading w/ _Trusted Publishing_).