### PR TITLE
fix: pyodide build fails when dependency-versions is set

### DIFF
--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -284,9 +284,8 @@ def setup_python(
         "pip",
         "install",
         "--upgrade",
-        "auditwheel-emscripten",
-        "build[virtualenv]",
         "pyodide-build",
+        "build[virtualenv]",
         *constraint_flags(constraints_path),
         env=env,
     )


### PR DESCRIPTION
Fix the pyodide failures on main.

auditwheel-emscripten is already a dep of pyodide-build, and cibuildwheel doesn't use it directly. But by listing it in this "pip install" command, it was causing the resolver to backtrack to 0.25.0 of pyodide-build, because more recent versions of pyodide-build pin auditwheel-emscripten.

Pyodide folks, does that sound right to you?

