### PR TITLE
fix: add patchelf requirement for android

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dependencies = [
     "filelock",
     "humanize",
     "packaging>=20.9",
+    # patchelf is used for Android
+    "patchelf; (sys_platform == 'linux' or sys_platform == 'darwin') and (platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64')",
     "platformdirs",
     "pyelftools>=0.29",
     "wheel>=0.33.6",


### PR DESCRIPTION
This adds `"patchelf"` on platforms where Android wheels can be built, since it's required. It's not added on platforms where a binary isn't available, which shouldn't be building Android wheels either.

The alternative is to just require users to pre-install it, which isn't bad, but I think this is nicer?

See https://github.com/pybind/pybind11/pull/5714#discussion_r2265401851.
