### PR TITLE
chore: Use the virtualenv release URL rather than the blob URL

### DIFF
--- a/cibuildwheel/resources/virtualenv.toml
+++ b/cibuildwheel/resources/virtualenv.toml
@@ -1,1 +1,1 @@
-default = { version = "20.33.1", url = "https://github.com/pypa/get-virtualenv/blob/20.33.1/public/virtualenv.pyz?raw=true" }
+default = { version = "20.34.0", url = "https://github.com/pypa/get-virtualenv/releases/download/20.34.0/virtualenv.pyz" }


### PR DESCRIPTION
See https://github.com/pypa/get-virtualenv/issues/51 for context.

Will hopefully be more robust.
