### PR TITLE
Revert to macOS-14 image for ARM64 iOS testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         - os: macos-13
           python_version: '3.13'
           test_select: ios
-        - os: macos-15
+        - os: macos-14  # 20250811 macos-15 update caused havoc with iOS simulators
           python_version: '3.13'
           test_select: ios
         - os: macos-13
@@ -104,11 +104,6 @@ jobs:
           /usr/local/lib/node_modules /usr/local/share/chromium \
           /usr/local/share/powershell
         df -h
-
-    - name: Set up Xcode
-      if: startsWith(matrix.os, 'macos-')
-      run: |
-        sudo xcode-select --switch /Applications/Xcode_${{ matrix.os == 'macos-13' && '15.2' || '16.4' }}.app
 
     # https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
     - name: Enable KVM for Android emulator


### PR DESCRIPTION
In an attempt to conserve disk space, GitHub Actions has stopped consistently providing iOS simulator images. See
https://github.com/actions/runner-images/issues/12541 and https://github.com/actions/runner-images/issues/12751 for discussion of this transition.

This means the "default" configuration no longer works for iOS simulation. This PR reverts to using the `macos-14` image  for now, to restore iOS CI to a working state.

(A previous version of this PR tried to fix the problem by explicitly setting the Xcode version; although that approach is what GitHub recommends, at the current time their simulator images are... not working, so `macos-14` is the working option option)