### PR TITLE
chore: extend CODEOWNERS file to include platform-specific constraints files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
+# Specification files for platform maintainers
 cibuildwheel/platforms/ios.py         @freakboy3742
 cibuildwheel/platforms/pyodide.py     @hoodmane @ryanking13 @agriyakhetarpal
 cibuildwheel/platforms/android.py     @mhsmith
+
+# Constraints files
+# cibuildwheel/resources/constraints @pypa/cibuildwheel-maintainers
+cibuildwheel/resources/constraints-pyodide*.txt @hoodmane @ryanking13 @agriyakhetarpal


### PR DESCRIPTION
> [!NOTE]
> This PR is not intended to be merged in its current state, and exists solely to gather feedback.

I was wondering if we could extend the CODEOWNERS file established in #2481 a little more to include some more files – in specific, the constraints files in this PR. Platform-specific constraints files could be reviewed by the platform maintainers, and the rest would be reviewed by the core team.

The GitHub documentation mentions that [CODEOWNERS files accept glob patterns](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).