### PR TITLE
chore: bump to Pyodide 0.28.2

### DIFF
--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -221,7 +221,7 @@ python_configurations = [
 [pyodide]
 python_configurations = [
   { identifier = "cp312-pyodide_wasm32", version = "3.12", default_pyodide_version = "0.27.7", node_version = "v22" },
-  { identifier = "cp313-pyodide_wasm32", version = "3.13", default_pyodide_version = "0.28.1", node_version = "v22" },
+  { identifier = "cp313-pyodide_wasm32", version = "3.13", default_pyodide_version = "0.28.2", node_version = "v22" },
 ]
 
 [android]


### PR DESCRIPTION
See https://github.com/pyodide/pyodide/releases/tag/0.28.2; needs pyodide/pyodide#5846 ~to be deployed~ (edit: done!).