### PR TITLE
Switch Azure Pipelines iOS image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         - os: macos-13
           python_version: '3.13'
           test_select: ios
-        - os: macos-14  # 20250811 macos-15 update caused havoc with iOS simulators
+        - os: macos-14  # See https://github.com/actions/runner-images/issues/12777
           python_version: '3.13'
           test_select: ios
         - os: macos-13

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Usage
 
 |                 | Linux | macOS | Windows | Linux ARM | macOS ARM | Windows ARM | Android | iOS |
 |-----------------|-------|-------|---------|-----------|-----------|-------------|---------|-----|
-| GitHub Actions  | ✅    | ✅    | ✅       | ✅        | ✅        | ✅²         | ✅⁴      | ✅³  |
-| Azure Pipelines | ✅    | ✅    | ✅       |           | ✅        | ✅²         | ✅⁴      | ✅³  |
+| GitHub Actions  | ✅    | ✅    | ✅       | ✅        | ✅        | ✅²         | ✅⁴      | ✅³⁵ |
+| Azure Pipelines | ✅    | ✅    | ✅       |           | ✅        | ✅²         | ✅⁴      | ✅³⁵ |
 | Travis CI       | ✅    |       | ✅      | ✅        |           |             | ✅⁴      |     |
 | CircleCI        | ✅    | ✅    |         | ✅        | ✅        |             | ✅⁴      | ✅³  |
 | Gitlab CI       | ✅    | ✅    | ✅      | ✅¹       | ✅        |             | ✅⁴      | ✅³  |
@@ -67,8 +67,10 @@ Usage
 
 <sup>¹ [Requires emulation](https://cibuildwheel.pypa.io/en/stable/faq/#emulation), distributed separately. Other services may also support Linux ARM through emulation or third-party build hosts, but these are not tested in our CI.</sup><br>
 <sup>² [Uses cross-compilation](https://cibuildwheel.pypa.io/en/stable/faq/#windows-arm64). It is not possible to test `arm64` on this CI platform.</sup><br>
-<sup>³ Requires a macOS runner; runs tests on the simulator for the runner's architecture.</sup><br>
+<sup>³ Requires a macOS runner; runs tests on the simulator for the runner's architecture. </sup><br>
 <sup>⁴ Building for Android requires the runner to be Linux x86_64, macOS ARM64 or macOS x86_64. Testing has [additional requirements](https://cibuildwheel.pypa.io/en/stable/platforms/#android).</sup><br>
+<sup>⁵ The `macos-15` and `macos-latest` images are [incompatible with cibuildwheel at this time](platforms/#ios-system-requirements)</sup><br>
+
 <!--intro-end-->
 
 Example setup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
         pythonVersion: "3.11"
         testSelect: "native"
       ios_311:
-        imageName: "macos-latest"
+        imageName: "macos-14"  # See https://github.com/actions/runner-images/issues/12777
         pythonVersion: "3.11"
         testSelect: "ios"
       android_macos_311:

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -253,11 +253,14 @@ to one of the following URLs:
 
 ## iOS {: #ios}
 
-### System requirements
+### System requirements {: #ios-system-requirements}
 
 You must be building on a macOS machine, with Xcode installed. The Xcode installation must have an iOS SDK available, with all license agreements agreed to by the user. To check if an iOS SDK is available, open the Xcode settings panel, and check the Platforms tab. This will also ensure that license agreements have been acknowledged.
 
 Building iOS wheels also requires a working macOS Python installation. See the notes on [macOS builds](#macos) for details about configuration of the macOS environment.
+
+!!! note
+    If you are running cibuildwheel on GitHub Actions or Azure runners, you should avoid the `macos-15` and `macos-latest` images. The [20250811 image update](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250811.2170) made some [significant changes](https://github.com/actions/runner-images/issues/12541) that are [incompatible with CPython's iOS test runner](https://github.com/actions/runner-images/issues/12777). At this time, Microsoft's advice is to use the `macos-14` image instead.
 
 ### Specifying an iOS build
 


### PR DESCRIPTION
The 20250811 `macos-15` image update published by Microsoft has [caused problems with the CPython iOS testbed running on GitHub Actions and Azure runners](https://github.com/actions/runner-images/issues/12777). At this time, Microsoft's advice is "use `macos-14` instead". 

Unless Microsoft makes a configuration change that resolves/reverts the problem, this will require an update to CPython itself (see python/cpython#137973).

This PR switches the Azure runner image, and adds documentation warnings about the current state of macos-15 image support.
