### PR TITLE
Add documentation for test dependency groups on mobile platforms.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1576,7 +1576,7 @@ tests. This can be used to avoid having to redefine test dependencies in
 `test-requires` if they are already defined in `pyproject.toml`.
 
 Platform-specific environment variables are also available:<br/>
-`CIBW_TEST_GROUPS_MACOS` | `CIBW_TEST_GROUPS_WINDOWS` | `CIBW_TEST_GROUPS_LINUX` | `CIBW_TEST_GROUPS_PYODIDE`
+`CIBW_TEST_GROUPS_MACOS` | `CIBW_TEST_GROUPS_WINDOWS` | `CIBW_TEST_GROUPS_LINUX` | `CIBW_TEST_GROUPS_ANDROID` | `CIBW_TEST_GROUPS_IOS` | `CIBW_TEST_GROUPS_PYODIDE`
 
 #### Examples
 


### PR DESCRIPTION
The documentation for test groups doesn't list configuration options for iOS or Android. 

It turns out that because of the way `test-groups` is handled (by rolling dependencies in to `test-requires`), it works fine on both iOS and Android, and the settings files are already populated. I can only assume this was an oversight on my part when I wrote the iOS docs, which @mhsmith inherited by doing a "search for _IOS and add the same change for Android" when he added Android support.

[This pull request](https://github.com/freakboy3742/pyspamsum/pull/78) proves that `test-groups` works on iOS and Android with cibuildwheel 3.1.4. 