### PR TITLE
Android test updates

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -578,7 +578,7 @@ def test_wheel(state: BuildState, wheel: Path) -> None:
         site_packages_dir,
         f"{wheel}{state.options.test_extras}",
         *state.options.test_requires,
-        env=state.build_env,
+        env=state.android_env,
     )
 
     # Copy test-sources.

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -630,6 +630,7 @@ def test_wheel(state: BuildState, wheel: Path) -> None:
         site_packages_dir,
         "--cwd",
         cwd_dir,
+        *(["-v"] if state.options.build_verbosity > 0 else []),
         *test_args,
         env=state.build_env,
     )

--- a/docs/options.md
+++ b/docs/options.md
@@ -1724,6 +1724,9 @@ Settings that are not supported for a specific frontend will log a warning.
 The default build frontend is `build`, which does show build backend output by
 default.
 
+On Android and iOS, a positive verbosity level will also show more detailed logs from
+the test harness.
+
 Platform-specific environment variables are also available:<br/>
 `CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX` | `CIBW_BUILD_VERBOSITY_ANDROID` | `CIBW_BUILD_VERBOSITY_IOS` | `CIBW_BUILD_VERBOSITY_PYODIDE`
 

--- a/test/test_android.py
+++ b/test/test_android.py
@@ -356,6 +356,32 @@ def test_environment_markers(tmp_path):
 
 
 @needs_emulator
+def test_verbosity(tmp_path, capfd):
+    new_c_project().generate(tmp_path)
+    test_env = {
+        **cp313_env,
+        "CIBW_TEST_COMMAND": """python -c 'print("Hello world")'""",
+    }
+    verbose_lines = [
+        "> Task :app:packageDebug",  # Gradle
+        "I/TestRunner: run started: 1 tests",  # Logcat
+    ]
+
+    cibuildwheel_run(tmp_path, add_env=test_env)
+    stdout = capfd.readouterr().out
+    for line in verbose_lines:
+        assert line not in stdout
+
+    cibuildwheel_run(
+        tmp_path,
+        add_env={**test_env, "CIBW_BUILD_VERBOSITY": "1"},
+    )
+    stdout = capfd.readouterr().out
+    for line in verbose_lines:
+        assert line in stdout
+
+
+@needs_emulator
 def test_api_level(tmp_path, capfd):
     project = new_c_project()
     project.files["pyproject.toml"] = dedent(


### PR DESCRIPTION
* Use Android environment markers when installing the test environment – see [pybind11#5809](https://github.com/pybind/pybind11/pull/5809#issuecomment-3215219502).

* Pass the `build-verbosity` setting through to the test runner.

* I thought I'd need to add support for `test-groups`, but it turns out this already works ([#2574](https://github.com/pypa/cibuildwheel/pull/2574)).