### PR TITLE
Don't constrain `build-system.requires` with our `dependency-versions`

### DIFF
--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -33,7 +33,6 @@ from ..util.file import (
 )
 from ..util.helpers import prepare_command, unwrap_preserving_paragraphs
 from ..util.packaging import (
-    combine_constraints,
     find_compatible_wheel,
     get_pip_version,
 )
@@ -491,8 +490,6 @@ def build(options: Options, tmp_path: Path) -> None:
 
                 build_env = env.copy()
                 build_env["VIRTUALENV_PIP"] = pip_version
-                if constraints_path:
-                    combine_constraints(build_env, constraints_path, None)
 
                 match build_frontend.name:
                     case "pip":

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -32,7 +32,7 @@ from ..util.file import (
     move_file,
 )
 from ..util.helpers import prepare_command, unwrap
-from ..util.packaging import combine_constraints, find_compatible_wheel, get_pip_version
+from ..util.packaging import find_compatible_wheel, get_pip_version
 from ..venv import constraint_flags, find_uv, virtualenv
 
 
@@ -463,10 +463,6 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_env = env.copy()
                 if pip_version is not None:
                     build_env["VIRTUALENV_PIP"] = pip_version
-                if constraints_path:
-                    combine_constraints(
-                        build_env, constraints_path, identifier_tmp_dir if use_uv else None
-                    )
 
                 match build_frontend.name:
                     case "pip":

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -32,7 +32,7 @@ from ..util.file import (
     move_file,
 )
 from ..util.helpers import prepare_command, unwrap, unwrap_preserving_paragraphs
-from ..util.packaging import combine_constraints, find_compatible_wheel, get_pip_version
+from ..util.packaging import find_compatible_wheel, get_pip_version
 from ..util.python_build_standalone import (
     PythonBuildStandaloneError,
     create_python_build_standalone_environment,
@@ -420,8 +420,6 @@ def build(options: Options, tmp_path: Path) -> None:
                 )
 
                 build_env = env.copy()
-                if constraints_path:
-                    combine_constraints(build_env, constraints_path, identifier_tmp_dir)
                 build_env["VIRTUALENV_PIP"] = pip_version
                 call(
                     "pyodide",

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -23,7 +23,7 @@ from ..util import resources
 from ..util.cmd import call, shell
 from ..util.file import CIBW_CACHE_PATH, copy_test_sources, download, extract_zip, move_file
 from ..util.helpers import prepare_command, unwrap
-from ..util.packaging import combine_constraints, find_compatible_wheel, get_pip_version
+from ..util.packaging import find_compatible_wheel, get_pip_version
 from ..venv import constraint_flags, find_uv, virtualenv
 
 
@@ -464,9 +464,6 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_env = env.copy()
                 if pip_version is not None:
                     build_env["VIRTUALENV_PIP"] = pip_version
-
-                if constraints_path:
-                    combine_constraints(build_env, constraints_path, identifier_tmp_dir)
 
                 match build_frontend.name:
                     case "pip":

--- a/cibuildwheel/util/packaging.py
+++ b/cibuildwheel/util/packaging.py
@@ -1,5 +1,5 @@
 import shlex
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 from typing import Any, Literal, Self, TypeVar
@@ -178,30 +178,3 @@ def find_compatible_wheel(wheels: Sequence[T], identifier: str) -> T | None:
             return wheel
 
     return None
-
-
-def combine_constraints(
-    env: MutableMapping[str, str], /, constraints_path: Path, tmp_dir: Path | None
-) -> None:
-    """
-    This will workaround a bug in pip<=21.1.1 or uv<=0.2.0 if a tmp_dir is given.
-    If set to None, this will use the modern URI method.
-    """
-
-    if tmp_dir:
-        if " " in str(constraints_path):
-            assert " " not in str(tmp_dir)
-            tmp_file = tmp_dir / "constraints.txt"
-            tmp_file.write_bytes(constraints_path.read_bytes())
-            constraints_path = tmp_file
-        our_constraints = str(constraints_path)
-    else:
-        our_constraints = (
-            constraints_path.as_uri() if " " in str(constraints_path) else str(constraints_path)
-        )
-
-    user_constraints = env.get("PIP_CONSTRAINT")
-
-    env["UV_CONSTRAINT"] = env["PIP_CONSTRAINT"] = " ".join(
-        c for c in [our_constraints, user_constraints] if c
-    )


### PR DESCRIPTION
Fix #2570.

Don't constrain the versions installed during the package build using `dependency-versions`. See #2570 for full discussion. AI summary of the change below

---

This change stops cibuildwheel's dependency-versions from being applied as constraints within the isolated build environment used for the package build. This resolves an issue where conflicts between cibuildwheel's internal requirements and a project's build-system.requires would cause cryptic build failures.

**The Problem**
Currently, on macOS, Windows, and Pyodide platforms, cibuildwheel injects its own dependency constraints (from CIBW_DEPENDENCY_VERSIONS or the defaults) into the isolated environment where a project's build-time dependencies are installed.

This leads to an issue: if a project specifies a build requirement in pyproject.toml (e.g., conan) that has a dependency conflict with cibuildwheel's constraints (e.g., on urllib3), the build fails with an unhelpful subprocess.CalledProcessError traceback.

This behaviour is also inconsistent, as it does not occur on Linux, which invokes the build without injecting these internal constraints.

**The Solution**
Remove the logic that sets the PIP_CONSTRAINT and UV_CONSTRAINT environment variables on the build_env before invoking the build frontend (`pip wheel` or `build`).

The effect is:

- The user's project's build-time dependencies are now resolved independently, without interference from cibuildwheel's toolchain constraints.

- The build process behaviour is now the same across all platforms (Linux, macOS, Windows, and Pyodide)
