### PR TITLE
chore: linting updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,9 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.12
+  rev: v0.13.0
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: ["--fix", "--show-fixes"]
   - id: ruff-format
 

--- a/bin/projects.py
+++ b/bin/projects.py
@@ -23,7 +23,7 @@ import textwrap
 import urllib.request
 import xml.dom.minidom
 from collections.abc import Iterable, Mapping, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 from typing import Any, Self, TextIO
@@ -77,7 +77,7 @@ class Project:
                     self.notes = notes
         else:
             self.num_stars = 0
-            self.pushed_at = datetime.utcnow()
+            self.pushed_at = datetime.now(UTC)
 
         name_len = len(self.name) + 4
         self.__class__.NAME = max(self.__class__.NAME, name_len)
@@ -124,7 +124,7 @@ class Project:
         return f"[{self.name}]: {self.url}"
 
     def info(self) -> str:
-        days = (datetime.utcnow() - self.pushed_at).days
+        days = (datetime.now(UTC) - self.pushed_at).days
         return f"<!-- {self.name}: {self.num_stars}, last pushed {days} days ago -->"
 
 

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -321,7 +321,7 @@ def test_ios_test_command_without_python_dash_m(tmp_path, capfd):
     )
     assert set(actual_wheels) == set(expected_wheels)
 
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert "iOS tests configured with a test command which doesn't start with 'python -m'" in err
 
@@ -345,5 +345,5 @@ def test_ios_test_command_invalid(tmp_path, capfd):
                 "CIBW_XBUILD_TOOLS": "",
             },
         )
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
     assert "iOS tests configured with a test command which doesn't start with 'python -m'" in err

--- a/test/test_pyodide.py
+++ b/test/test_pyodide.py
@@ -104,7 +104,7 @@ def test_pyodide_version_incompatible(tmp_path, capfd):
             },
         )
 
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert "is not compatible with the pyodide-build version" in err
 

--- a/unit_test/main_commands_test.py
+++ b/unit_test/main_commands_test.py
@@ -34,7 +34,7 @@ def test_clean_cache_when_cache_exists(tmp_path, monkeypatch, capfd):
 
     assert e.value.code == 0
 
-    out, err = capfd.readouterr()
+    out, _ = capfd.readouterr()
     assert f"Clearing cache directory: {fake_cache_dir}" in out
     assert "Cache cleared successfully." in out
     assert not fake_cache_dir.exists()
@@ -51,7 +51,7 @@ def test_clean_cache_when_cache_does_not_exist(tmp_path, monkeypatch, capfd):
 
     assert e.value.code == 0
 
-    out, err = capfd.readouterr()
+    out, _ = capfd.readouterr()
     assert f"Cache directory does not exist: {fake_cache_dir}" in out
 
 
@@ -101,7 +101,7 @@ def test_clean_cache_without_sentinel(tmp_path, monkeypatch, capfd):
 
     assert e.value.code == 1
 
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
     assert "does not appear to be a cibuildwheel cache directory" in err
     assert fake_cache_dir.exists()
 
@@ -122,6 +122,6 @@ def test_clean_cache_with_invalid_signature(tmp_path, monkeypatch, capfd):
 
     assert e.value.code == 1
 
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
     assert "does not contain a valid cache directory signature" in err
     assert fake_cache_dir.exists()


### PR DESCRIPTION
Some updates:

* `ruff-check` is the replacement for legacy `ruff` in pre-commit
* `nowutc` is deprecated (noticed when trying out `ty`)
* Bumped pre-commit, and fixed up the unused unpacking warnings
