### PR TITLE
Add CMAKE_CROSSCOMPILING_EMULATOR to Android CMake toolchain

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -274,11 +274,15 @@ def create_cmake_toolchain(
                 set(CMAKE_SYSTEM_VERSION 1)
 
                 # Tell CMake where to look for headers and libraries.
-                list(INSERT CMAKE_FIND_ROOT_PATH 0 {python_dir}/prefix)
+                set(CMAKE_FIND_ROOT_PATH "{python_dir}/prefix")
                 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
                 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
                 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
                 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+
+                # Allow CMake to run Python in the simulated Android environment when
+                # policy CMP0190 is active.
+                set(CMAKE_CROSSCOMPILING_EMULATOR /bin/sh -c [["$0" "$@"]])
                 """
             ),
             file=toolchain_file,


### PR DESCRIPTION
See https://github.com/scikit-build/scikit-build-core/pull/1142#issuecomment-3288535561.

Since toolchain files can be executed multiple times during a single CMake run, I also changed CMAKE_FIND_ROOT_PATH from an `INSERT` to a `set`. I can't think of any reason why we'd need more than one element on this path.