### PR TITLE
Replace the `macos-13` images with the `macos-15-intel` images (GHA)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,17 +69,17 @@ jobs:
           python_version: '3.13'
         - os: windows-11-arm
           python_version: '3.13'
-        - os: macos-13
+        - os: macos-15-intel
           python_version: '3.13'
         - os: macos-15
           python_version: '3.13'
-        - os: macos-13
+        - os: macos-15-intel
           python_version: '3.13'
           test_select: ios
         - os: macos-14  # See https://github.com/actions/runner-images/issues/12777
           python_version: '3.13'
           test_select: ios
-        - os: macos-13
+        - os: macos-15-intel
           python_version: '3.13'
           test_select: android
         - os: macos-15

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Usage
 <sup>² [Uses cross-compilation](https://cibuildwheel.pypa.io/en/stable/faq/#windows-arm64). It is not possible to test `arm64` on this CI platform.</sup><br>
 <sup>³ Requires a macOS runner; runs tests on the simulator for the runner's architecture. </sup><br>
 <sup>⁴ Building for Android requires the runner to be Linux x86_64, macOS ARM64 or macOS x86_64. Testing has [additional requirements](https://cibuildwheel.pypa.io/en/stable/platforms/#android).</sup><br>
-<sup>⁵ The `macos-15` and `macos-latest` images are [incompatible with cibuildwheel at this time](platforms/#ios-system-requirements)</sup><br>
+<sup>⁵ The `macos-15` and `macos-latest` images are [incompatible with cibuildwheel at this time](platforms/#ios-system-requirements)</sup><br> when building iOS wheels.
 
 <!--intro-end-->
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
 
     steps:
       - uses: actions/checkout@v5

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,7 +121,7 @@ See [GitHub issue 1333](https://github.com/pypa/cibuildwheel/issues/1333) for mo
 
 It's easiest to build `x86_64` wheels on `x86_64` runners, and `arm64` wheels on `arm64` runners.
 
-On GitHub Actions, `macos-14` runners are `arm64`, and `macos-13` runners are `x86_64`. So all you need to do is ensure both are in your build matrix.
+On GitHub Actions, `macos-14` runners are `arm64`, and `macos-15-intel` runners are `x86_64`. So all you need to do is ensure both are in your build matrix.
 
 #### Cross-compiling
 

--- a/examples/github-deploy.yml
+++ b/examples/github-deploy.yml
@@ -26,8 +26,8 @@ jobs:
           - os: windows-arm
             runs-on: windows-11-arm
           - os: macos-intel
-            # macos-13 was the last x86_64 runner
-            runs-on: macos-13
+            # macos-15-intel is the last x86_64 runner
+            runs-on: macos-15-intel
           - os: macos-arm
             # macos-14+ (including latest) are ARM64 runners
             runs-on: macos-latest

--- a/examples/github-minimal.yml
+++ b/examples/github-minimal.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
+        # macos-15-intel is an Intel runner, macos-14 is Apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-14]
 
     steps:
       - uses: actions/checkout@v5

--- a/examples/github-pipx.yml
+++ b/examples/github-pipx.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
+        # macos-15-intel is an Intel runner, macos-14 is Apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-14]
 
     steps:
       - uses: actions/checkout@v5

--- a/examples/github-with-qemu.yml
+++ b/examples/github-with-qemu.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
+        # macos-15-intel is an Intel runner, macos-14 is Apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-14]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/; we can replace `macos-13` images with the new `macos-15-intel` runners, which will be phased out in 2027.

The `macos-14` images continue to be used and are not changed here, as `macos-15` continues to be broken for iOS wheel support.