### PR TITLE
Resolve issues with macOS-15 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,12 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
 
+    - name: Set up Xcode
+      if: ${{ startsWith(matrix.os, 'macos-15') }}
+      run: |
+        # GitHub recommends explicitly selecting the desired Xcode version:
+        sudo xcode-select --switch /Applications/Xcode_16.4.app
+
     - name: Install dependencies
       run: |
         uv sync --no-dev --group test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         - os: macos-15-intel
           python_version: '3.13'
           test_select: ios
-        - os: macos-14  # See https://github.com/actions/runner-images/issues/12777
+        - os: macos-15
           python_version: '3.13'
           test_select: ios
         - os: macos-15-intel

--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -239,10 +239,10 @@ python_configurations = [
 
 [ios]
 python_configurations = [
-  { identifier = "cp313-ios_arm64_iphoneos", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b10/Python-3.13-iOS-support.b10.tar.gz" },
-  { identifier = "cp313-ios_x86_64_iphonesimulator", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b10/Python-3.13-iOS-support.b10.tar.gz" },
-  { identifier = "cp313-ios_arm64_iphonesimulator", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b10/Python-3.13-iOS-support.b10.tar.gz" },
-  { identifier = "cp314-ios_arm64_iphoneos", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b6/Python-3.14-iOS-support.b6.tar.gz" },
-  { identifier = "cp314-ios_x86_64_iphonesimulator", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b6/Python-3.14-iOS-support.b6.tar.gz" },
-  { identifier = "cp314-ios_arm64_iphonesimulator", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b6/Python-3.14-iOS-support.b6.tar.gz" },
+  { identifier = "cp313-ios_arm64_iphoneos", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b10/Python-3.13-iOS-support.b11.tar.gz" },
+  { identifier = "cp313-ios_x86_64_iphonesimulator", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b11/Python-3.13-iOS-support.b11.tar.gz" },
+  { identifier = "cp313-ios_arm64_iphonesimulator", version = "3.13", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.13-b11/Python-3.13-iOS-support.b11.tar.gz" },
+  { identifier = "cp314-ios_arm64_iphoneos", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b7/Python-3.14-iOS-support.b7.tar.gz" },
+  { identifier = "cp314-ios_x86_64_iphonesimulator", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b7/Python-3.14-iOS-support.b7.tar.gz" },
+  { identifier = "cp314-ios_arm64_iphonesimulator", version = "3.14", url = "https://github.com/beeware/Python-Apple-support/releases/download/3.14-b7/Python-3.14-iOS-support.b7.tar.gz" },
 ]

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -262,9 +262,6 @@ You must be building on a macOS machine, with Xcode installed. The Xcode install
 
 Building iOS wheels also requires a working macOS Python installation. See the notes on [macOS builds](#macos) for details about configuration of the macOS environment.
 
-!!! note
-    If you are running cibuildwheel on GitHub Actions or Azure runners, you should avoid the `macos-15` and `macos-latest` images. The [20250811 image update](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250811.2170) made some [significant changes](https://github.com/actions/runner-images/issues/12541) that are [incompatible with CPython's iOS test runner](https://github.com/actions/runner-images/issues/12777). At this time, Microsoft's advice is to use the `macos-14` image instead.
-
 ### Specifying an iOS build
 
 iOS is effectively 2 platforms - physical devices, and simulators. While the API for these two platforms are identical, the ABI is not compatible, even when dealing with a device and simulator with the same CPU architecture. For this reason, the architecture specification for iOS builds includes *both* the CPU architecture *and* the ABI that is being targeted. There are three possible values for architecture on iOS; the values match those used by `sys.implementation._multiarch` when running on iOS (with hyphens replaced with underscores, matching wheel filename normalization):


### PR DESCRIPTION
Due to actions/runner-images#12777, the macOS-15 runner has been unstable for iOS test runs. This was reported to Python as python/cpython#137973; and corrected in python/cpython#138018.

This PR:
* Bumps the iOS support packages to versions that include this fix
* Restores the use of macOS-15 in CI environments
* Removes the documentation note about macOS 15 usage
* Forces the selection of Xcode 16.4 in macOS environments. This *should* be the default, but it appears explicitly selecting the Xcode version can have other effects that improve iOS simulator reliability.