### PR TITLE
Allow installation of extras in GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Build a specific wheel only. No need for arch/platform if this is set'
     required: false
     default: ''
+  extras:
+    description: 'Comma-separated list of extras to install'
+    required: false
+    default: ''
 branding:
   icon: package
   color: yellow
@@ -42,6 +46,10 @@ runs:
         from pathlib import Path
         from subprocess import run
 
+        EXTRAS = set(e.strip() for e in "${{ inputs.extras }}".split(",") if e.strip())
+        if sys.platform == "linux":
+            EXTRAS.discard("uv")
+
 
         class EnvBuilder(venv.EnvBuilder):
             def __init__(self):
@@ -53,7 +61,10 @@ runs:
             def post_setup(self, context):
                 super().post_setup(context)
                 self.bin_path = Path(context.env_exe).parent
-                run([sys.executable, "-m", "pip", "--python", context.env_exe, "install", r"${{ github.action_path }}"], check=True)
+                install_spec = r"${{ github.action_path }}"
+                if EXTRAS:
+                    install_spec += f"[{','.join(sorted(EXTRAS))}]"
+                run([sys.executable, "-m", "pip", "--python", context.env_exe, "install", install_spec], check=True)
 
 
         print("::group::Install cibuildwheel")
@@ -62,30 +73,47 @@ runs:
             shutil.rmtree(venv_path)
         builder = EnvBuilder()
         builder.create(venv_path)
-        cibw_path = [path for path in builder.bin_path.glob("cibuildwheel*") if path.stem == "cibuildwheel"][0]
+        exposed_binaries = {"cibuildwheel"}
+        if "uv" in EXTRAS:
+            exposed_binaries.add("uv")
+        clean_bin_path = builder.bin_path.parent / f"{builder.bin_path.name}.clean"
+        clean_bin_path.mkdir()
+        for path in list(builder.bin_path.iterdir()):
+            if path.stem in exposed_binaries:
+                try:
+                    os.symlink(path, clean_bin_path / path.name)
+                except OSError:
+                    import shutil
+
+                    shutil.copy2(path, clean_bin_path / path.name)
+        full_path = f"{clean_bin_path}{os.pathsep}{os.environ['PATH']}"
         with open(os.environ["GITHUB_OUTPUT"], "at") as f:
-            f.write(f"cibw-path={cibw_path}\n")
+            f.write(f"updated-path={full_path}\n")
         print("::endgroup::")
         EOF
       shell: bash
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
-        "${{ steps.cibw.outputs.cibw-path }}"
+        cibuildwheel
         "${{ inputs.package-dir }}"
         ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
         ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
         ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
         2>&1
+      env:
+        PATH: "${{ steps.cibw.outputs.updated-path }}"
       shell: bash
       if: runner.os != 'Windows'
 
     # Windows needs powershell to interact nicely with Meson
     - run: >
-        & "${{ steps.cibw.outputs.cibw-path }}"
+        cibuildwheel
         "${{ inputs.package-dir }}"
         ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
         ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
         ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
+      env:
+        PATH: "${{ steps.cibw.outputs.updated-path }}"
       shell: pwsh
       if: runner.os == 'Windows'

--- a/docs/ci-services.md
+++ b/docs/ci-services.md
@@ -23,7 +23,9 @@ To build Linux, macOS, and Windows wheels using GitHub Actions, create a `.githu
 
     Use `env:` to pass [build options](options.md) and `with:` to set
     `package-dir: .`, `output-dir: wheelhouse` and `config-file: ''`
-    locations (those values are the defaults).
+    locations (those values are the defaults). You can also pass a
+    comma-separated list of extras to install additional packages.
+    For example, `extras: "uv"` to install UV into the virtual environment.
 
 !!! tab "pipx"
     The GitHub Actions runners have pipx installed, so you can easily build in

--- a/docs/options.md
+++ b/docs/options.md
@@ -470,14 +470,16 @@ Default: `build`
 
 Choose which build frontend to use.
 
-You can use "build\[uv\]", which will use an external [uv][] everywhere
+You can use "build\[uv\]", which will use an external [UV][] everywhere
 possible, both through `--installer=uv` passed to build, as well as when making
 all build and test environments. This will generally speed up cibuildwheel.
-Make sure you have an external uv on Windows and macOS, either by
-pre-installing it, or installing cibuildwheel with the uv extra,
-`cibuildwheel[uv]`. uv currently does not support Windows on ARM,
-musllinux on s390x, Android, or iOS. Legacy dependencies like
-setuptools on Python < 3.12 and pip are not installed if using uv.
+Make sure you have an external UV on Windows and macOS, either by
+pre-installing it, or installing cibuildwheel with the `uv` extra, which is
+possible by manually passing `cibuildwheel[uv]` to installers or by using the
+`extras` option in the [cibuildwheel action](ci-services.md#github-actions).
+UV currently does not support Android, iOS nor musllinux on s390x. Legacy
+dependencies like setuptools on Python < 3.12 and pip are not installed if
+using UV.
 
 On Android and Pyodide, only "build" is supported.
 


### PR DESCRIPTION
When setting the [build-frontend](https://cibuildwheel.pypa.io/en/stable/options/#build-frontend) to `build[uv]` one must manually make UV globally available on Windows and macOS. This leads to conditional execution as seen in this snippet of real CI configuration:

```yaml
    - name: Download source distribution
      uses: actions/download-artifact@v4
      with:
        name: artifact-sdist
        path: dist

    - name: Install UV
      if: runner.os != 'Linux'
      uses: astral-sh/setup-uv@v6

    - name: Build wheels
      uses: pypa/cibuildwheel@v3.2.1
      with:
        package-dir: dist/${{ needs.sdist.outputs.sdist-name }}
```

Such an option would allow for removing the middle step:

```yaml
    - name: Download source distribution
      uses: actions/download-artifact@v4
      with:
        name: artifact-sdist
        path: dist

    - name: Build wheels
      uses: pypa/cibuildwheel
      with:
        extras: uv
        package-dir: dist/${{ needs.sdist.outputs.sdist-name }}
```

Here's a [PR](https://github.com/ofek/dotslash-python/pull/4) to showcase this change being successfully used.