### PR TITLE
chore: remove dependency workaround for mkdocs-macro-plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,13 +79,10 @@ bin = [
 docs = [
     "jinja2>=3.1.2",
     "mkdocs-include-markdown-plugin==6.2.2",
-    "mkdocs-macros-plugin",
+    "mkdocs-macros-plugin>=1.4.1",
     "mkdocs==1.6.1",
     "pymdown-extensions",
     "rich",
-    # transitive dep of mkdocs-macros-plugin
-    # https://github.com/fralau/mkdocs-macros-plugin/issues/269
-    "requests",
 ]
 test = [
     "build",


### PR DESCRIPTION
This issue has since been fixed.

https://github.com/fralau/mkdocs-macros-plugin/issues/269#issuecomment-3446656751