### PR TITLE
feat: add manylinux_2_35

### DIFF
--- a/bin/update_docker.py
+++ b/bin/update_docker.py
@@ -71,6 +71,8 @@ images = [
             "pypy_aarch64",
         ],
     ),
+    # manylinux_2_35 images
+    PyPAImage("manylinux_2_35", ["armv7l"]),
     # manylinux_2_39 images
     PyPAImage("manylinux_2_39", ["riscv64"]),
     # musllinux_1_2 images

--- a/cibuildwheel/resources/pinned_docker_images.cfg
+++ b/cibuildwheel/resources/pinned_docker_images.cfg
@@ -1,53 +1,54 @@
 [x86_64]
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_x86_64:2025.11.09-2
 
 [i686]
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_i686:2025.11.09-2
 
 [aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_aarch64:2025.11.09-2
 
 [ppc64le]
-manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_ppc64le:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_ppc64le:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_ppc64le:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_ppc64le:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_ppc64le:2025.11.09-2
 
 [s390x]
-manylinux2014 = quay.io/pypa/manylinux2014_s390x:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_s390x:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_s390x:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_s390x:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_s390x:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_s390x:2025.11.09-2
 
 [pypy_x86_64]
-manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_x86_64:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_x86_64:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_x86_64:2025.11.09-2
 
 [pypy_i686]
-manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_i686:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_i686:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_i686:2025.11.09-2
 
 [pypy_aarch64]
-manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.11.02-1
-manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.11.02-1
-manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.11.02-1
+manylinux2014 = quay.io/pypa/manylinux2014_aarch64:2025.11.09-2
+manylinux_2_28 = quay.io/pypa/manylinux_2_28_aarch64:2025.11.09-2
+manylinux_2_34 = quay.io/pypa/manylinux_2_34_aarch64:2025.11.09-2
 
 [armv7l]
-manylinux_2_31 = quay.io/pypa/manylinux_2_31_armv7l:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_armv7l:2025.11.02-1
+manylinux_2_31 = quay.io/pypa/manylinux_2_31_armv7l:2025.11.09-2
+manylinux_2_35 = quay.io/pypa/manylinux_2_35_armv7l:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_armv7l:2025.11.09-2
 
 [riscv64]
-manylinux_2_39 = quay.io/pypa/manylinux_2_39_riscv64:2025.11.02-1
-musllinux_1_2 = quay.io/pypa/musllinux_1_2_riscv64:2025.11.02-1
+manylinux_2_39 = quay.io/pypa/manylinux_2_39_riscv64:2025.11.09-2
+musllinux_1_2 = quay.io/pypa/musllinux_1_2_riscv64:2025.11.09-2
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -760,9 +760,9 @@ Platform-specific environment variables also available:<br/>
     here.](https://yaml-multiline.info).
 
 
-Note that `manylinux_2_31` builds occur inside a Debian derivative docker
+Note that `manylinux_2_31`/`manylinux_2_35` builds occur inside a Debian derivative docker
 container, where `manylinux2014` builds occur inside a CentOS one. So for
-`manylinux_2_31` the `before-all` command must use `apt-get -y`
+`manylinux_2_31`/`manylinux_2_35` the `before-all` command must use `apt-get -y`
 instead.
 
 ### `before-build` {: #before-build env-var toml}
@@ -1037,7 +1037,7 @@ Set the Docker image to be used for building [manylinux / musllinux](https://git
 
 For `manylinux-*-image`, except `manylinux-armv7l-image` and `manylinux-riscv64-image`, the value of this option can either be set to `manylinux2014`, `manylinux_2_28` or `manylinux_2_34` to use a pinned version of the [official manylinux images](https://github.com/pypa/manylinux). Alternatively, set these options to any other valid Docker image name.
 
-For `manylinux-armv7l-image`, the value of this option can either be set to `manylinux_2_31` or a custom image. Support is experimental for now. The `manylinux_2_31` value is only available for `armv7`.
+For `manylinux-armv7l-image`, the value of this option can either be set to `manylinux_2_31`, `manylinux_2_35` or a custom image. Support is experimental for now. The `manylinux_2_31` and `manylinux_2_35` values are only available for `armv7`.
 
 For `manylinux-riscv64-image`, the value of this option can either be set to `manylinux_2_39` or a custom image. Support is experimental for now. The `manylinux_2_39` value is only available for `riscv64`.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -23,7 +23,7 @@ The only side effect to your system will be docker images being pulled.
 
 Linux wheels are built in [`manylinux`/`musllinux` containers](https://github.com/pypa/manylinux) to provide binary compatible wheels on Linux, according to [PEP 600](https://www.python.org/dev/peps/pep-0600/) / [PEP 656](https://www.python.org/dev/peps/pep-0656/). Because of this, when building with `cibuildwheel` on Linux, a few things should be taken into account:
 
--   Programs and libraries are not installed on the CI runner host, but rather should be installed inside the container - using `yum` for `manylinux2014`, `apt-get` for `manylinux_2_31`, `dnf` for `manylinux_2_28` and `apk` for `musllinux_1_1` or `musllinux_1_2`, or manually. The same goes for environment variables that are potentially needed to customize the wheel building.
+-   Programs and libraries are not installed on the CI runner host, but rather should be installed inside the container - using `yum` for `manylinux2014`, `apt-get` for `manylinux_2_31` or `manylinux_2_35`, `dnf` for `manylinux_2_28` and `apk` for `musllinux_1_1` or `musllinux_1_2`, or manually. The same goes for environment variables that are potentially needed to customize the wheel building.
 
     `cibuildwheel` supports this by providing the [`environment`](options.md#environment) and [`before-all`](options.md#before-all) options to setup the build environment inside the running container.
 

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -84,7 +84,7 @@ def test(manylinux_image, tmp_path):
         "CIBW_MANYLINUX_PYPY_I686_IMAGE": manylinux_image,
     }
     if platform.machine() == "aarch64":
-        # We just have a manylinux_2_31 image for armv7l
+        # We just have a manylinux_2_31/manylinux_2_35 image for armv7l
         add_env["CIBW_ARCHS"] = "aarch64"
 
     actual_wheels = utils.cibuildwheel_run(project_dir, add_env=add_env)
@@ -100,7 +100,7 @@ def test(manylinux_image, tmp_path):
     )
 
     if platform.machine() == "aarch64":
-        # We just have a manylinux_2_31 image for armv7l
+        # We just have a manylinux_2_31/manylinux_2_35 image for armv7l
         expected_wheels = [w for w in expected_wheels if "armv7l" not in w]
 
     assert set(actual_wheels) == set(expected_wheels)


### PR DESCRIPTION
pypa/manylinux now has a manylinux_2_35_armv7l image allowing for better C++20 support.

[piwheels](https://www.piwheels.org) is still building for Debian Bullseye so keeping manylinux_2_31 as the default image.
Ubuntu 20.04 has reached End Of Life (there are still ELTS updates until 02 April 2030)
Debian Bullseye Long Term Support will end on 31 Aug 2026 (ELTS until 31 Aug 2031)

see also https://github.com/pypa/cibuildwheel/discussions/2653#discussioncomment-14902331