### PR TITLE
fix: support Docker 29

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -113,14 +113,13 @@ class OCIContainerEngineConfig:
 DEFAULT_ENGINE = OCIContainerEngineConfig("docker")
 
 
-def lower_dict(inp: list[tuple[str, object]]) -> dict[str, object]:
-    return {k.lower(): v for k, v in inp}
-
-
 def _check_engine_version(engine: OCIContainerEngineConfig) -> None:
     try:
         version_string = call(engine.name, "version", "-f", "{{json .}}", capture_stdout=True)
-        version_info = json.loads(version_string.strip(), object_pairs_hook=lower_dict)
+        # We are using lowercase keys for all dicts so we are not affected by casing of keys
+        version_info = json.loads(
+            version_string.strip(), object_pairs_hook=lambda inp: {k.lower(): v for k, v in inp}
+        )
         match engine.name:
             case "docker":
                 client_api_version = FlexibleVersion(version_info["client"]["apiversion"])

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -630,7 +630,7 @@ def test_multiarch_image(container_engine, platform):
         ),
         (
             "docker",
-            '{"Client":{"Version":"24.0.0","APIVersion":"1.43"},"Server":{"ApiVersion":"1.43"}}',
+            '{"Client":{"Version":"29.0.0","ApiVersion":"1.52"},"Server":{"APIVersion":"1.52"}}',
             nullcontext(),
         ),
         (


### PR DESCRIPTION
Lowering the case of the keys when reading the json file to support arbitrary `Api`/`API` changes. Fix #2659.
