### PR TITLE
DOC: Document location in error message

### DIFF
--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -141,7 +141,8 @@ def install_cpython(_tmp: Path, version: str, url: str, free_threading: bool) ->
                 # let the user know & provide a link to the installer
                 msg = inspect.cleandoc(
                     f"""
-                        Error: CPython {version} is not installed.
+                        Framework CPython {version} not detected as installed in:
+                            {installation_path}
                         cibuildwheel will not perform system-wide installs when running outside of CI.
                         To build locally, install CPython {version} on this machine, or, disable this
                         version of Python using CIBW_SKIP=cp{version.replace(".", "")}-macosx_*


### PR DESCRIPTION
Consider this an PR-as-suggestion for discussion. Locally on my macOS machine where I use `conda` I just ran:
```
$ python --version
Python 3.13.5
$ CIBW_BUILD="cp313-*" cibuildwheel .
...
cibuildwheel: error: Error: CPython 3.13 is not installed.
cibuildwheel will not perform system-wide installs when running outside of CI.
...
```
I found this error message to be confusing, since I do have Python 3.13 installed. This PR suggests an update to the message to:
```
cibuildwheel: error: Framework CPython 3.13 not detected as installed in:
    /Library/Frameworks/Python.framework/Versions/3.13
cibuildwheel will not perform system-wide installs when running outside of CI.
...
```
This would have made it clear that my `conda`-provided 3.13 isn't sufficient, it needs to be a framework version. It also removes the duplicate `"Error: "`.