### PR TITLE
Added more infos about muslinux support of uv in options.md

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -478,8 +478,6 @@ pre-installing it, or installing cibuildwheel with the `uv` extra, which is
 possible by manually passing `cibuildwheel[uv]` to installers or by using the
 `extras` option in the [cibuildwheel action](ci-services.md#github-actions).
 uv currently does not support iOS or musllinux on s390x, ppc64le and riscv64.
-Legacy dependencies like setuptools on Python < 3.12 and pip are not
-installed if using uv.
 
 On Android and Pyodide, the "pip" frontend is not supported.
 


### PR DESCRIPTION
uv doesn't support also ppc64le and riscv64 for muslinux