### PR TITLE
fix: always use `find_uv`

### DIFF
--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -329,7 +329,7 @@ def setup_python(
                 "pip",
                 "install",
                 "--upgrade",
-                "build[virtualenv]",
+                "build[virtualenv, uv]",
                 *constraint_flags(dependency_constraint),
                 env=env,
             )
@@ -575,7 +575,12 @@ def build(options: Options, tmp_path: Path) -> None:
                     )
                     shell(before_test_prepared, env=virtualenv_env)
 
-                pip = ["uv", "pip"] if use_uv else ["pip"]
+                if use_uv:
+                    uv_path = find_uv()
+                    assert uv_path is not None
+                    pip = [str(uv_path), "pip"]
+                else:
+                    pip = ["pip"]
 
                 # install the wheel
                 call(

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -108,7 +108,11 @@ def virtualenv(
     assert python.exists()
 
     if use_uv:
-        call("uv", "venv", venv_path, "--python", python)
+        uv_path = find_uv()
+        if uv_path is None:
+            msg = "Could not find 'uv' executable."
+            raise FileNotFoundError(msg)
+        call(uv_path, "venv", venv_path, "--python", python)
     else:
         virtualenv_app, virtualenv_version = _ensure_virtualenv(version)
         if pip_version is None:


### PR DESCRIPTION
This allows to use the `uv` extra without `uv` being added to `PATH` however it requires to install `build` with the `uv` extra. This was already done on macOS.
I'm not sure what's the correct way forward given this results in multiple `uv` installations.

towards #2673 