### PR TITLE
fix: always expose `uv` in `PATH`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,47 +71,30 @@ runs:
             shutil.rmtree(venv_path)
         builder = EnvBuilder()
         builder.create(venv_path)
-        exposed_binaries = {"cibuildwheel"}
-        if "uv" in EXTRAS:
-            exposed_binaries.add("uv")
-        clean_bin_path = builder.bin_path.parent / f"{builder.bin_path.name}.clean"
-        clean_bin_path.mkdir()
-        for path in list(builder.bin_path.iterdir()):
-            if path.stem in exposed_binaries:
-                try:
-                    os.symlink(path, clean_bin_path / path.name)
-                except OSError:
-                    import shutil
-
-                    shutil.copy2(path, clean_bin_path / path.name)
-        full_path = f"{clean_bin_path}{os.pathsep}{os.environ['PATH']}"
+        cibw_path = [path for path in builder.bin_path.glob("cibuildwheel*") if path.stem == "cibuildwheel"][0]
         with open(os.environ["GITHUB_OUTPUT"], "at") as f:
-            f.write(f"updated-path={full_path}\n")
+            f.write(f"cibw-path={cibw_path}\n")
         print("::endgroup::")
         EOF
       shell: bash
 
     # Redirecting stderr to stdout to fix interleaving issue in Actions.
     - run: >
-        cibuildwheel
+        "${{ steps.cibw.outputs.cibw-path }}"
         "${{ inputs.package-dir }}"
         ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
         ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
         ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
         2>&1
-      env:
-        PATH: "${{ steps.cibw.outputs.updated-path }}"
       shell: bash
       if: runner.os != 'Windows'
 
     # Windows needs powershell to interact nicely with Meson
     - run: >
-        cibuildwheel
+        & "${{ steps.cibw.outputs.cibw-path }}"
         "${{ inputs.package-dir }}"
         ${{ inputs.output-dir != ''  && format('--output-dir "{0}"', inputs.output-dir) || ''}}
         ${{ inputs.config-file != '' && format('--config-file "{0}"', inputs.config-file) || ''}}
         ${{ inputs.only != ''        && format('--only "{0}"', inputs.only) || ''}}
-      env:
-        PATH: "${{ steps.cibw.outputs.updated-path }}"
       shell: pwsh
       if: runner.os == 'Windows'

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -34,7 +34,7 @@ from ..util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
 from ..util.helpers import prepare_command
 from ..util.packaging import find_compatible_wheel
 from ..util.python_build_standalone import create_python_build_standalone_environment
-from ..venv import constraint_flags, find_uv, virtualenv
+from ..venv import constraint_flags, virtualenv
 
 ANDROID_TRIPLET = {
     "arm64_v8a": "aarch64-linux-android",
@@ -191,11 +191,7 @@ def setup_env(
     log.step("Setting up build environment...")
     build_frontend = build_options.build_frontend.name
     use_uv = build_frontend == "build[uv]"
-    uv_path = find_uv()
-    if use_uv and uv_path is None:
-        msg = "uv not found"
-        raise AssertionError(msg)
-    pip = ["pip"] if not use_uv else [str(uv_path), "pip"]
+    pip = ["pip"] if not use_uv else ["uv", "pip"]
 
     # Create virtual environment
     python_exe = create_python_build_standalone_environment(
@@ -609,11 +605,7 @@ def test_wheel(state: BuildState, wheel: Path, *, build_frontend: str) -> None:
 
     log.step("Testing wheel...")
     use_uv = build_frontend == "build[uv]"
-    uv_path = find_uv()
-    if use_uv and uv_path is None:
-        msg = "uv not found"
-        raise AssertionError(msg)
-    pip = ["pip"] if not use_uv else [str(uv_path), "pip"]
+    pip = ["pip"] if not use_uv else ["uv", "pip"]
 
     native_arch = arch_synonym(platform.machine(), platforms.native_platform(), "android")
     if state.config.arch != native_arch:

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -33,7 +33,7 @@ from ..util.file import (
 )
 from ..util.helpers import prepare_command, unwrap
 from ..util.packaging import find_compatible_wheel, get_pip_version
-from ..venv import constraint_flags, find_uv, virtualenv
+from ..venv import constraint_flags, virtualenv
 
 
 @functools.cache
@@ -217,7 +217,6 @@ def setup_python(
     environment: ParsedEnvironment,
     build_frontend: BuildFrontendName,
 ) -> tuple[Path, dict[str, str]]:
-    uv_path = find_uv()
     use_uv = build_frontend == "build[uv]"
 
     tmp.mkdir()
@@ -370,14 +369,13 @@ def setup_python(
                 env=env,
             )
         case "build[uv]":
-            assert uv_path is not None
             call(
-                uv_path,
+                "uv",
                 "pip",
                 "install",
                 "--upgrade",
                 "delocate",
-                "build[virtualenv, uv]",
+                "build",
                 *constraint_flags(dependency_constraint),
                 env=env,
             )
@@ -414,11 +412,7 @@ def build(options: Options, tmp_path: Path) -> None:
             build_options = options.build_options(config.identifier)
             build_frontend = build_options.build_frontend
             use_uv = build_frontend.name == "build[uv]"
-            uv_path = find_uv()
-            if use_uv and uv_path is None:
-                msg = "uv not found"
-                raise AssertionError(msg)
-            pip = ["pip"] if not use_uv else [str(uv_path), "pip"]
+            pip = ["pip"] if not use_uv else ["uv", "pip"]
             log.build_start(config.identifier)
 
             identifier_tmp_dir = tmp_path / config.identifier

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -24,7 +24,7 @@ from ..util.cmd import call, shell
 from ..util.file import CIBW_CACHE_PATH, copy_test_sources, download, extract_zip, move_file
 from ..util.helpers import prepare_command, unwrap
 from ..util.packaging import find_compatible_wheel, get_pip_version
-from ..venv import constraint_flags, find_uv, virtualenv
+from ..venv import constraint_flags, virtualenv
 
 
 def get_nuget_args(
@@ -272,7 +272,6 @@ def setup_python(
         build_frontend = "build"
 
     use_uv = build_frontend == "build[uv]"
-    uv_path = find_uv()
 
     log.step("Setting up build environment...")
     venv_path = tmp / "venv"
@@ -323,13 +322,12 @@ def setup_python(
                 env=env,
             )
         case "build[uv]":
-            assert uv_path is not None
             call(
-                uv_path,
+                "uv",
                 "pip",
                 "install",
                 "--upgrade",
-                "build[virtualenv]",
+                "build",
                 *constraint_flags(dependency_constraint),
                 env=env,
             )


### PR DESCRIPTION
This PR changes the way `uv` is used in cibuildwheel for direct invocations.
At the moment, there's a mixed usage of direct invocations (assumed in `PATH`) & `find_uv()` path invocations.
#2690 has been opened to always use `find_uv()` but this is not really compatible with `build` unless it's installed with the `uv` extra.
In order not to install `build`'s `uv` extra, `find_uv` is updated to symlink/copy `uv` in a temporary directory. This temporary directory is added to build/test virtual environments `PATH` which removes the need to install `build`'s `uv` extra when using `cibuildwheel`'s `uv` extra.

close #2690
close #2673