### PR TITLE
Update Python version range to 3.14 in Github Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - uses: actions/setup-python@v6
       id: python
       with:
-        python-version: "3.11 - 3.13"
+        python-version: "3.11 - 3.14"
         update-environment: false
 
     - id: cibw


### PR DESCRIPTION
Fix #2715. I think an upper bound makes sense here as it gives more chance that if a user is pinning an older version of cibuildwheel, it will work.