### PR TITLE
docs: fix broken TOML links in options.md

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -618,7 +618,7 @@ Platform-specific environment variables are also available:<br/>
     SAMPLE_TEXT = "sample text"
     ```
 
-    In configuration files, you can use a [TOML][] table instead of a raw string as shown above.
+    In configuration files, you can use a [TOML](https://toml.io) table instead of a raw string as shown above.
 
 !!! tab examples "Environment variables"
 
@@ -679,7 +679,7 @@ To specify more than one environment variable, separate the variable names by sp
     environment-pass = ["BUILD_TIME", "SAMPLE_TEXT"]
     ```
 
-    In configuration files, you can use a [TOML][] list instead of a raw string as shown above.
+    In configuration files, you can use a [TOML](https://toml.io) list instead of a raw string as shown above.
 
 !!! tab examples "Environment variables"
 


### PR DESCRIPTION
## Summary

Fixes broken TOML links in `docs/options.md` where `[TOML][]` (reference-style link with empty reference) was used instead of a proper link.

## Changes

- Replaced `[TOML][]` with `[TOML](https://toml.io)` on lines 621 and 682
- This matches the style used in `docs/configuration.md` (line 71)

## Testing

The fix is a simple markdown link correction. No code changes.

Fixes #2725