### PR TITLE
docs: fix broken TOML reference links in options.md

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -618,7 +618,7 @@ Platform-specific environment variables are also available:<br/>
     SAMPLE_TEXT = "sample text"
     ```
 
-    In configuration files, you can use a [TOML][] table instead of a raw string as shown above.
+    In configuration files, you can use a [TOML](https://toml.io) table instead of a raw string as shown above.
 
 !!! tab examples "Environment variables"
 
@@ -679,7 +679,7 @@ To specify more than one environment variable, separate the variable names by sp
     environment-pass = ["BUILD_TIME", "SAMPLE_TEXT"]
     ```
 
-    In configuration files, you can use a [TOML][] list instead of a raw string as shown above.
+    In configuration files, you can use a [TOML](https://toml.io) list instead of a raw string as shown above.
 
 !!! tab examples "Environment variables"
 


### PR DESCRIPTION
## Summary

- Fixes broken `[TOML][]` markdown reference links in `docs/options.md`
- Replaces with inline links `[TOML](https://toml.io)` to match the style in `configuration.md`
- Fixes links on lines 621 and 682 that rendered incorrectly due to missing reference definition

## Changes

The markdown syntax `[TOML][]` was used but there was no corresponding reference-style link definition in the document. This PR converts them to inline links pointing to the official TOML website, consistent with how TOML is linked in `docs/configuration.md`.

Fixes #2725

## Test plan

- [x] Verified markdown renders correctly (no `[]` brackets showing)
- [x] Confirmed link points to https://toml.io
- [x] Codespell passes with no issues

---

This PR was generated with AI assistance (Claude claude-opus-4-5).