### PR TITLE
fix: consistently use find_uv for our usage of uv

### DIFF
--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -5,7 +5,7 @@ import platform as platform_module
 import shutil
 import subprocess
 import textwrap
-from collections.abc import MutableMapping, Set
+from collections.abc import MutableMapping, Sequence, Set
 from functools import cache
 from pathlib import Path
 from typing import assert_never
@@ -588,7 +588,12 @@ def build(options: Options, tmp_path: Path) -> None:
                     )
                     shell(before_test_prepared, env=virtualenv_env)
 
-                pip = ["uv", "pip"] if use_uv else ["pip"]
+                pip: Sequence[Path | str]
+                if use_uv:
+                    assert uv_path is not None
+                    pip = [uv_path, "pip"]
+                else:
+                    pip = ["pip"]
 
                 # install the wheel
                 call(

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -108,7 +108,9 @@ def virtualenv(
     assert python.exists()
 
     if use_uv:
-        call("uv", "venv", venv_path, "--python", python)
+        uv_path = find_uv()
+        assert uv_path is not None
+        call(uv_path, "venv", venv_path, "--python", python)
     else:
         virtualenv_app, virtualenv_version = _ensure_virtualenv(version)
         if pip_version is None:


### PR DESCRIPTION
This ensures we always use `find_uv` to find uv, rather than sometimes assuming it is on the path, and sometimes using `find_uv`. If a user wants to use `uv`, they still need it on the path on non-linux, but we should be consistent in our usage.
