### PR TITLE
docs: fix TOML reference links

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -627,7 +627,7 @@ Platform-specific environment variables are also available:<br/>
     SAMPLE_TEXT = "sample text"
     ```
 
-    In configuration files, you can use a [TOML] table instead of a raw string as shown above.
+    In configuration files, you can use a [TOML][] table instead of a raw string as shown above.
 
 [TOML]: https://toml.io/en/
 
@@ -690,7 +690,7 @@ To specify more than one environment variable, separate the variable names by sp
     environment-pass = ["BUILD_TIME", "SAMPLE_TEXT"]
     ```
 
-    In configuration files, you can use a [TOML] list instead of a raw string as shown above.
+    In configuration files, you can use a [TOML][] list instead of a raw string as shown above.
 
 !!! tab examples "Environment variables"
 


### PR DESCRIPTION
Fixes #2725.

The options docs referenced TOML using `[TOML][]`, but the reference definition was missing, so the site rendered broken links.

- Switch to `[TOML]` and add a `[TOML]: https://toml.io/en/` definition in `docs/options.md`.
