### PR TITLE
Pin the actions/setup-python for the externally used action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ branding:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       id: python
       with:
         python-version: "3.11 - 3.14"


### PR DESCRIPTION
Minimal variation on #2744 by @agriyakhetarpal

I'm working on a project that has ["Require actions to be pinned to a full-length commit SHA"](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#:~:text=Require%20actions%20to%20be%20pinned%20to%20a%20full%2Dlength%20commit%20SHA) enabled. I've used cibuildwheel on other projects and it's been really useful, thanks! Unfortunately the requirement for SHA pining then blocks using the cibuildwheel.

I saw on #2744 there's concerns about pinning everything, but potentially willing to pin the release part.

While I can use my fork in the project it'd be great to get this focused change in to reduce complications for folks with that setting on.