### PR TITLE
tests: use pytest 9+ and modern config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ test = [
     "pytest-timeout",
     "pytest-xdist",
     "pytest-rerunfailures!=16.0",
-    "pytest>=6",
+    "pytest>=9",
     "setuptools",
     "tomli_w",
     "validate-pyproject",
@@ -103,11 +103,11 @@ dev = [
 ]
 
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "--xdoctest", "--ignore-glob=*venv*"]
+[tool.pytest]
+minversion = "9.0"
+addopts = ["-ra", "--showlocals", "--xdoctest", "--ignore-glob=*venv*"]
+strict = true
 junit_family = "xunit2"
-xfail_strict = true
 filterwarnings = ["error"]
 log_level = "INFO"
 markers = [
@@ -116,6 +116,7 @@ markers = [
     "android: tests that run on Android",
     "pyodide: tests that run on Pyodide",
 ]
+required_plugins = ["pytest-rerunfailures"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
Using modern config in pytest 9+. It requires 3.10+, but we are 3.11+ so we are fine.
