### PR TITLE
Drop explicit `build` and `virtualenv` installation from Pyodide build tools

### DIFF
--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -285,7 +285,6 @@ def setup_python(
         "install",
         "--upgrade",
         "pyodide-build",
-        "build[virtualenv]",
         *constraint_flags(constraints_path),
         env=env,
     )


### PR DESCRIPTION
See [`0911b78` (#2775)](https://github.com/pypa/cibuildwheel/pull/2775/commits/0911b78ff7c94d38c01fdcbad2651a38969ec624) and https://github.com/pypa/cibuildwheel/pull/2775#issuecomment-4067444018: it is better that we remove `build[virtualenv]` from the top-level install command entirely. `pyodide-build` already declares `build~=1.2.0` and `virtualenv` as direct dependencies, so they'll come in transitively at the right versions. `cibuildwheel` shouldn't be separately requesting `build[virtualenv]` for the Pyodide platform.

Perhaps, at some later point, we should vendor `build` into `pyodide-build` and drop the pins. I briefly recall some conversations about this with @ryanking13 (not sure where that was?).