### PR TITLE
fix: set `UV_PYTHON` for `before_build` on Linux when using `uv`

### DIFF
--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -264,7 +264,15 @@ def build_in_container(
                     project=container_project_path,
                     package=container_package_dir,
                 )
-                container.call(["sh", "-c", before_build_prepared], env=env)
+                before_build_env = env.copy()
+                if use_uv:
+                    # On Linux, no virtualenv is created for the build environment
+                    # (unlike macOS/Windows, where one is set up before before_build
+                    # runs). uv requires either an active venv or UV_SYSTEM_PYTHON=1
+                    # to install packages. Set it here so that `uv pip install` works
+                    # in before_build without requiring users to pass --system.
+                    before_build_env.setdefault("UV_SYSTEM_PYTHON", "1")
+                container.call(["sh", "-c", before_build_prepared], env=before_build_env)
 
             log.step("Building wheel...")
 

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -268,10 +268,11 @@ def build_in_container(
                 if use_uv:
                     # On Linux, no virtualenv is created for the build environment
                     # (unlike macOS/Windows, where one is set up before before_build
-                    # runs). uv requires either an active venv or UV_SYSTEM_PYTHON=1
-                    # to install packages. Set it here so that `uv pip install` works
-                    # in before_build without requiring users to pass --system.
-                    before_build_env.setdefault("UV_SYSTEM_PYTHON", "1")
+                    # runs). uv requires either an active venv or an explicit Python
+                    # target to install packages. Pin UV_PYTHON to the exact interpreter
+                    # for this build so that `uv pip install` works in before_build
+                    # without requiring users to pass --system.
+                    before_build_env["UV_PYTHON"] = str(python_bin / "python")
                 container.call(["sh", "-c", before_build_prepared], env=before_build_env)
 
             log.step("Building wheel...")


### PR DESCRIPTION
Fixes #1955. On Linux, we do not create a virtualenv for the build environment, unlike macOS and Windows which call `virtualenv()` before `before_build` runs. This means `uv pip install` in `before_build` fails with `error: No virtual environment found` when using the `build[uv]` as the build frontend, regardless of whether build isolation is disabled. 

We can set `UV_SYSTEM_PYTHON=1` to allow uv to install directly into the container's Python. The build-step environment can be left unchanged, so that isolated builds continue to manage their own internal venvs as usual.

I am unsure how to add a test for this, so I haven't added one.