### PR TITLE
Use `python -V -V` for Windows build diagnostics

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -229,7 +229,10 @@ def setup_env(
                 f"or insert {command} above it."
             )
             raise errors.FatalError(msg)
-        call(command, "--version", env=build_env)
+        if command == "python":
+            call(command, "-V", "-V", env=build_env)
+        else:
+            call(command, "--version", env=build_env)
 
     # Construct an altered environment which simulates running on Android.
     android_env = setup_android_env(config, python_dir, venv_dir, build_env)

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -355,7 +355,7 @@ def setup_python(
             "entry or insert python above it."
         )
         raise errors.FatalError(msg)
-    call("python", "--version", env=env)
+    call("python", "-V", "-V", env=env)
 
     # Check what pip version we're on
     assert (venv_bin_path / "pip").exists()

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -237,6 +237,7 @@ def build_in_container(
         if PurePosixPath(which_python) != python_bin / "python":
             msg = "python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
             raise errors.FatalError(msg)
+        container.call(["python", "-V", "-V"], env=env)
 
         if use_uv:
             which_uv = container.call(["which", "uv"], env=env, capture_output=True).strip()

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -270,7 +270,7 @@ def setup_python(
     if which_python != str(venv_bin_path / "python"):
         msg = "python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
         raise errors.FatalError(msg)
-    call("python", "--version", env=env)
+    call("python", "-V", "-V", env=env)
 
     # check what pip version we're on
     if not use_uv:

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -271,7 +271,7 @@ def setup_python(
     if which_python != str(venv_bin_path / "python"):
         msg = "python available on PATH doesn't match our venv instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
         raise errors.FatalError(msg)
-    call("python", "--version", env=env)
+    call("python", "-V", "-V", env=env)
 
     # check what pip version we're on
     assert (venv_bin_path / "pip").exists()

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -306,7 +306,7 @@ def setup_python(
     if where_python != str(venv_path / "Scripts" / "python.exe"):
         msg = "python available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert python above it."
         raise errors.FatalError(msg)
-    call("python", "--version", env=env)
+    call("python", "-V", "-V", env=env)
     call("python", "-c", "\"import struct; print(struct.calcsize('P') * 8)\"", env=env)
 
     # check what pip version we're on


### PR DESCRIPTION
Fixes #1218.

This changes the Windows setup logging from `python --version` to `python -V -V` so the log includes the extra build/compiler details when Python provides them.

Checked with:
- `uv run --with ruff ruff check cibuildwheel/platforms/windows.py`
- `uv run --group test pytest unit_test/get_platform_test.py -q`