### PR TITLE
Document platform-specific before-build config

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -793,6 +793,9 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific environment variables are also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX` | `CIBW_BEFORE_BUILD_ANDROID` | `CIBW_BEFORE_BUILD_IOS` | `CIBW_BEFORE_BUILD_PYODIDE`
 
+In configuration files, use platform tables like `[tool.cibuildwheel.macos]`,
+rather than platform-suffixed option names like `before-build-macos`.
+
 #### Examples
 
 !!! tab examples "pyproject.toml"
@@ -816,6 +819,13 @@ Platform-specific environment variables are also available:<br/>
 
     # If cibuildwheel is called with a package_dir argument, it's available as {package}
     before-build = "{package}/script/prepare_for_build.sh"
+
+    # Use a different command on a specific platform
+    [tool.cibuildwheel.linux]
+    before-build = "python scripts/install-linux-deps.py"
+
+    [tool.cibuildwheel.macos]
+    before-build = "python scripts/install-macos-deps.py"
     ```
 
     In configuration files, you can use a array, and the items will be joined

--- a/docs/options.md
+++ b/docs/options.md
@@ -845,6 +845,10 @@ In configuration files, use platform tables like `[tool.cibuildwheel.macos]`.
 
     # If cibuildwheel is called with a package_dir argument, it's available as {package}
     CIBW_BEFORE_BUILD: "{package}/script/prepare_for_build.sh"
+
+    # Use a different command on a specific platform
+    CIBW_BEFORE_BUILD_LINUX: python scripts/install-linux-deps.py
+    CIBW_BEFORE_BUILD_MACOS: python scripts/install-macos-deps.py
     ```
 
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -793,8 +793,7 @@ The command is run in a shell, so you can write things like `cmd1 && cmd2`.
 Platform-specific environment variables are also available:<br/>
  `CIBW_BEFORE_BUILD_MACOS` | `CIBW_BEFORE_BUILD_WINDOWS` | `CIBW_BEFORE_BUILD_LINUX` | `CIBW_BEFORE_BUILD_ANDROID` | `CIBW_BEFORE_BUILD_IOS` | `CIBW_BEFORE_BUILD_PYODIDE`
 
-In configuration files, use platform tables like `[tool.cibuildwheel.macos]`,
-rather than platform-suffixed option names like `before-build-macos`.
+In configuration files, use platform tables like `[tool.cibuildwheel.macos]`.
 
 #### Examples
 


### PR DESCRIPTION
Fixes #1578.

This adds a short note that pyproject.toml uses platform tables for platform-specific options, and includes efore-build examples for Linux and macOS.

Checked with:
- `git diff --check`
- `python -m cibuildwheel --help`

I also tried `mkdocs build --strict` on Windows, but the docs macro calls the `cibuildwheel` console script without `.exe`, and the local Windows subprocess lookup failed before rendering the page.