### PR TITLE
Set CMAKE_OSX_ARCHITECTURES for macOS builds

### DIFF
--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -205,6 +205,25 @@ def install_graalpy(tmp: Path, url: str) -> Path:
     return installation_path / "bin" / "graalpy"
 
 
+def _setup_arch_environment(python_identifier: str, env: dict[str, str]) -> None:
+    if python_identifier.endswith("arm64"):
+        # macOS 11 is the first OS with arm64 support, so the wheels
+        # have that as a minimum.
+        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-11.0-arm64")
+        env.setdefault("ARCHFLAGS", "-arch arm64")
+        env.setdefault("CMAKE_OSX_ARCHITECTURES", "arm64")
+    elif python_identifier.endswith("universal2"):
+        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-universal2")
+        env.setdefault("ARCHFLAGS", "-arch arm64 -arch x86_64")
+        env.setdefault("CMAKE_OSX_ARCHITECTURES", "arm64;x86_64")
+    elif python_identifier.endswith("x86_64"):
+        # even on the macos11.0 Python installer, on the x86_64 side it's
+        # compatible back to 10.9.
+        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-x86_64")
+        env.setdefault("ARCHFLAGS", "-arch x86_64")
+        env.setdefault("CMAKE_OSX_ARCHITECTURES", "x86_64")
+
+
 def setup_python(
     tmp: Path,
     python_configuration: PythonConfiguration,
@@ -311,19 +330,7 @@ def setup_python(
         )
         env["MACOSX_DEPLOYMENT_TARGET"] = default_target
 
-    if config_is_arm64:
-        # macOS 11 is the first OS with arm64 support, so the wheels
-        # have that as a minimum.
-        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-11.0-arm64")
-        env.setdefault("ARCHFLAGS", "-arch arm64")
-    elif config_is_universal2:
-        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-universal2")
-        env.setdefault("ARCHFLAGS", "-arch arm64 -arch x86_64")
-    elif python_configuration.identifier.endswith("x86_64"):
-        # even on the macos11.0 Python installer, on the x86_64 side it's
-        # compatible back to 10.9.
-        env.setdefault("_PYTHON_HOST_PLATFORM", "macosx-10.9-x86_64")
-        env.setdefault("ARCHFLAGS", "-arch x86_64")
+    _setup_arch_environment(python_configuration.identifier, env)
 
     building_arm64 = config_is_arm64 or config_is_universal2
     if building_arm64 and get_macos_version() < (10, 16) and "SDKROOT" not in env:

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -128,6 +128,25 @@ On GitHub Actions, `macos-14` runners are `arm64`, and `macos-15-intel` runners 
 
 If your CI provider doesn't offer arm64 runners yet, or you want to create `universal2`, you'll have to cross-compile. Cross-compilation can be enabled by adding extra archs to the [`CIBW_ARCHS_MACOS` option](options.md#archs) - e.g. `CIBW_ARCHS_MACOS="x86_64 universal2"`. Cross-compilation is provided by Xcode toolchain v12.2+.
 
+If your build backend needs an explicit macOS target architecture, use [configuration overrides](configuration.md#overrides) to set it from the build identifier:
+
+```toml
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64", "universal2"]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+environment = { CMAKE_OSX_ARCHITECTURES = "x86_64" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+environment = { CMAKE_OSX_ARCHITECTURES = "arm64" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_universal2"
+environment = { CMAKE_OSX_ARCHITECTURES = "x86_64;arm64" }
+```
+
 Regarding testing,
 
 - On an arm64 runner, it is possible to test `x86_64` wheels and both parts of a `universal2` wheel using Rosetta 2 emulation.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -128,25 +128,6 @@ On GitHub Actions, `macos-14` runners are `arm64`, and `macos-15-intel` runners 
 
 If your CI provider doesn't offer arm64 runners yet, or you want to create `universal2`, you'll have to cross-compile. Cross-compilation can be enabled by adding extra archs to the [`CIBW_ARCHS_MACOS` option](options.md#archs) - e.g. `CIBW_ARCHS_MACOS="x86_64 universal2"`. Cross-compilation is provided by Xcode toolchain v12.2+.
 
-If your build backend needs an explicit macOS target architecture, use [configuration overrides](configuration.md#overrides) to set it from the build identifier:
-
-```toml
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64", "universal2"]
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_x86_64"
-environment = { CMAKE_OSX_ARCHITECTURES = "x86_64" }
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_arm64"
-environment = { CMAKE_OSX_ARCHITECTURES = "arm64" }
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_universal2"
-environment = { CMAKE_OSX_ARCHITECTURES = "x86_64;arm64" }
-```
-
 Regarding testing,
 
 - On an arm64 runner, it is possible to test `x86_64` wheels and both parts of a `universal2` wheel using Rosetta 2 emulation.

--- a/unit_test/macos_environment_test.py
+++ b/unit_test/macos_environment_test.py
@@ -1,0 +1,46 @@
+import pytest
+
+from cibuildwheel.platforms.macos import _setup_arch_environment
+
+
+@pytest.mark.parametrize(
+    ("identifier", "host_platform", "archflags", "cmake_archs"),
+    [
+        ("cp314-macosx_arm64", "macosx-11.0-arm64", "-arch arm64", "arm64"),
+        (
+            "cp314-macosx_universal2",
+            "macosx-10.9-universal2",
+            "-arch arm64 -arch x86_64",
+            "arm64;x86_64",
+        ),
+        ("cp314-macosx_x86_64", "macosx-10.9-x86_64", "-arch x86_64", "x86_64"),
+    ],
+)
+def test_setup_arch_environment(
+    identifier: str, host_platform: str, archflags: str, cmake_archs: str
+) -> None:
+    env: dict[str, str] = {}
+
+    _setup_arch_environment(identifier, env)
+
+    assert env == {
+        "_PYTHON_HOST_PLATFORM": host_platform,
+        "ARCHFLAGS": archflags,
+        "CMAKE_OSX_ARCHITECTURES": cmake_archs,
+    }
+
+
+def test_setup_arch_environment_keeps_existing_values() -> None:
+    env = {
+        "_PYTHON_HOST_PLATFORM": "custom-platform",
+        "ARCHFLAGS": "-arch custom",
+        "CMAKE_OSX_ARCHITECTURES": "custom-arch",
+    }
+
+    _setup_arch_environment("cp314-macosx_arm64", env)
+
+    assert env == {
+        "_PYTHON_HOST_PLATFORM": "custom-platform",
+        "ARCHFLAGS": "-arch custom",
+        "CMAKE_OSX_ARCHITECTURES": "custom-arch",
+    }


### PR DESCRIPTION
Refs #1190.

This sets `CMAKE_OSX_ARCHITECTURES` in the macOS build environment for `x86_64`, `arm64`, and `universal2` builds, alongside the existing `ARCHFLAGS` setup. It uses `setdefault`, so projects that already set `CMAKE_OSX_ARCHITECTURES` keep their explicit value.

Checked with:
- `.\.venv\Scripts\python.exe -m pytest unit_test\macos_environment_test.py -q`
- `uv run --with ruff ruff check cibuildwheel\platforms\macos.py unit_test\macos_environment_test.py`
- `git diff --check`