### PR TITLE
Add FAQ section on caching cibuildwheel's downloaded tools

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,7 +135,7 @@ Set the `CIBW_CACHE_PATH` environment variable to point cibuildwheel at a differ
 #### Persisting the cache on GitHub Actions
 
 ```yaml
-- uses: actions/cache@v4
+- uses: actions/cache@v5
   with:
     path: .cibw-cache
     key: cibw-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,6 +114,48 @@ Meson generally works well with cibuildwheel, but there are a few things to be a
 
 -   If you need to build 32-bit Windows wheels, you need to activate a 32-bit compiler toolchain before starting cibuildwheel. Many users use [ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) for this purpose.
 
+### Caching cibuildwheel's downloaded tools {: #caching}
+
+To speed up builds, cibuildwheel caches the tools it downloads — CPython/PyPy installers, [`virtualenv`][virtualenv], [python-build-standalone][pbs] archives used on Android/iOS, etc. The active cache folder is printed in the preamble of every run:
+
+```
+Cache folder: /Users/Matt/Library/Caches/cibuildwheel
+```
+
+By default it lives under the OS user-cache directory:
+
+| Platform     | Default cache folder                          |
+| ------------ | --------------------------------------------- |
+| Linux        | `~/.cache/cibuildwheel`                       |
+| macOS / iOS  | `~/Library/Caches/cibuildwheel`               |
+| Windows      | `%LOCALAPPDATA%\pypa\cibuildwheel\Cache`      |
+
+Set the `CIBW_CACHE_PATH` environment variable to point cibuildwheel at a different folder. On CI you'll typically want a workspace-relative path so that the runner's cache action can persist it between runs.
+
+#### Persisting the cache on GitHub Actions
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: .cibw-cache
+    key: cibw-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+    restore-keys: |
+      cibw-${{ runner.os }}-
+
+- uses: pypa/cibuildwheel@v3.4.1
+  env:
+    CIBW_CACHE_PATH: ${{ github.workspace }}/.cibw-cache
+```
+
+The `restore-keys` fallback lets a slightly stale cache still be reused if `pyproject.toml` changes. Adjust the cache key to whatever set of inputs determines what cibuildwheel will download (e.g. include a hash of `pyproject.toml`'s `[tool.cibuildwheel]` section, or pin on a Python build-tools version).
+
+For platform-specific notes (e.g. caching the official python.org installers on macOS, or NuGet CPython downloads on Windows), see the [platforms documentation](platforms.md).
+
+If the cache becomes stale or corrupt, run `cibuildwheel --clean-cache` (or simply delete the folder) before re-running.
+
+[virtualenv]: https://virtualenv.pypa.io/
+[pbs]: https://gregoryszorc.com/docs/python-build-standalone/main/
+
 ### Automatic updates using Dependabot {: #automatic-updates}
 
 Selecting a moving target (like the latest release) is generally a bad idea in CI. If something breaks, you can't tell whether it was your code or an upstream update that caused the breakage, and in a worst-case scenario, it could occur during a release.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -130,21 +130,21 @@ By default it lives under the OS user-cache directory:
 | macOS / iOS  | `~/Library/Caches/cibuildwheel`               |
 | Windows      | `%LOCALAPPDATA%\pypa\cibuildwheel\Cache`      |
 
-Set the `CIBW_CACHE_PATH` environment variable to point cibuildwheel at a different folder. On CI you'll typically want a workspace-relative path so that the runner's cache action can persist it between runs.
+Set the `CIBW_CACHE_PATH` environment variable to point cibuildwheel at a different folder. On CI you'll typically want a workflow-defined path so that the runner's cache action can persist it between runs.
 
 #### Persisting the cache on GitHub Actions
 
 ```yaml
 - uses: actions/cache@v5
   with:
-    path: .cibw-cache
+    path: ${{ runner.temp }}/cibw-cache
     key: cibw-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
     restore-keys: |
       cibw-${{ runner.os }}-
 
 - uses: pypa/cibuildwheel@v3.4.1
   env:
-    CIBW_CACHE_PATH: ${{ github.workspace }}/.cibw-cache
+    CIBW_CACHE_PATH: ${{ runner.temp }}/cibw-cache
 ```
 
 The `restore-keys` fallback lets a slightly stale cache still be reused if `pyproject.toml` changes. Adjust the cache key to whatever set of inputs determines what cibuildwheel will download (e.g. include a hash of `pyproject.toml`'s `[tool.cibuildwheel]` section, or pin on a Python build-tools version).
@@ -152,6 +152,9 @@ The `restore-keys` fallback lets a slightly stale cache still be reused if `pypr
 For platform-specific notes (e.g. caching the official python.org installers on macOS, or NuGet CPython downloads on Windows), see the [platforms documentation](platforms.md).
 
 If the cache becomes stale or corrupt, run `cibuildwheel --clean-cache` (or simply delete the folder) before re-running.
+
+!!! warning "Cache poisoning security risk"
+    Use of caching in a release pipeline means the cache folder is now a possible security risk - an attacker could [poison the cache](https://hivesecurity.gitlab.io/blog/github-actions-cache-poisoning-supply-chain/) with executables they have compromised. If you use this for release builds, consider who has access to modify the cache. Specifically be careful if your repo has any workflows using `pull_request_target`, even if they appear unrelated.
 
 [virtualenv]: https://virtualenv.pypa.io/
 [pbs]: https://gregoryszorc.com/docs/python-build-standalone/main/


### PR DESCRIPTION
Closes #1585.

## Summary

Adds a Tips entry to `docs/faq.md` (placed right before the existing _Automatic updates using Dependabot_ section) covering:

- What cibuildwheel caches (CPython/PyPy installers, virtualenv, python-build-standalone archives used on Android/iOS) and the default per-OS cache folder.
- How to override the cache location with `CIBW_CACHE_PATH`.
- A worked GitHub Actions example pairing `actions/cache` with `CIBW_CACHE_PATH` so the cache survives between runs (with a `restore-keys` fallback so non-pyproject changes still hit a cache).
- A pointer to `cibuildwheel --clean-cache` for invalidating stale entries.
- A cross-link to the platforms doc for OS-specific notes.

## Scope

Per @joerick's reply on the issue ("A caching section in the FAQ would be great, if you can contribute it"), the scope is intentionally narrow — FAQ-level guidance only. The other two items in the original issue body — sharing artifacts between jobs and dispatching workflows across CI providers — are out of scope here:

- The artifact-reuse pattern is already shown in `examples/github-deploy.yml`, and per @joerick's comment, "I wouldn't want to go much further than this."
- Cross-CI dispatch (e.g. CircleCI from GitHub Actions) is wide enough that it deserves its own issue and probably belongs in `ci-services.md` rather than the FAQ.

## Overlap with #2839

PR #2839 (Windows NuGet caching, closes #1527) edits `docs/platforms.md` with platform-specific guidance. This PR sits one level higher — FAQ overview pointing readers at the platforms doc for the per-OS specifics. No file overlap.

## Test plan

- [x] `uv run --group docs mkdocs build --strict` — passes
- [x] `uv run --with prek prek run --files docs/faq.md` — passes (eof, line-endings, trailing whitespace, capitalization, codespell)
- [ ] Render preview will be on Read the Docs once the build kicks off