### PR TITLE
fix: remove pinning constraints from test installs on Linux

### DIFF
--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -6,7 +6,7 @@ import textwrap
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Sequence, Set
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, assert_never
+from typing import assert_never
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
@@ -19,9 +19,6 @@ from cibuildwheel.util import resources
 from cibuildwheel.util.file import copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel
-
-if TYPE_CHECKING:
-    from cibuildwheel.typing import PathOrStr
 
 ARCHITECTURE_OCI_PLATFORM_MAP = {
     Architecture.x86_64: OCIPlatform.AMD64,
@@ -212,7 +209,6 @@ def build_in_container(
 
         log.step("Setting up build environment...")
 
-        dependency_constraint_flags: list[PathOrStr] = []
         local_constraints_file = build_options.dependency_constraints.get_for_python_version(
             version=config.version,
             tmp_dir=local_identifier_tmp_dir,
@@ -220,7 +216,6 @@ def build_in_container(
         if local_constraints_file:
             container_constraints_file = PurePosixPath("/constraints.txt")
             container.copy_into(local_constraints_file, container_constraints_file)
-            dependency_constraint_flags = ["-c", container_constraints_file]
 
         env = container.get_environment()
         env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
@@ -378,9 +373,7 @@ def build_in_container(
             # set up a virtual environment to install and test from, to make sure
             # there are no dependencies that were pulled in at build time.
             if not use_uv:
-                container.call(
-                    ["pip", "install", "virtualenv", *dependency_constraint_flags], env=env
-                )
+                container.call(["pip", "install", "virtualenv"], env=env)
 
             testing_temp_dir = PurePosixPath(
                 container.call(["mktemp", "-d"], capture_output=True).strip()


### PR DESCRIPTION
Fix #2822.

:robot: *Human triggered, AI assisted PR. AI text below.* :robot:

## Summary

Removes the build dependency constraint flags from the `pip install virtualenv` call inside the Linux test setup.

## Details

The `dependency_constraint_flags` variable (containing `-c /constraints.txt`) was being unpacked into the command that installs `virtualenv` when setting up the test environment in `cibuildwheel/platforms/linux.py`. These constraints are intended for **build** dependencies only — they pin versions of packages like `delocate`, `build`, `pip`, etc. They should not restrict package versions when installing `virtualenv` for test execution.

macOS, Windows, iOS, Pyodide, and Android were already passing `None` for the dependency constraint when creating test virtualenvs. Linux was the only outlier.

## Change

- Removed the `dependency_constraint_flags` variable and its usage from the test virtualenv setup in `linux.py`.
- Build dependency constraints are still applied to build tool installations as before.

Assisted-by: OpenCode:Kimi-K2.6