### PR TITLE
chore: add Python 3.15 to CI test matrix and classifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           python_version: '3.11'
         # Max Python
         - os: ubuntu-latest
-          python_version: '3.14'
+          python_version: '3.15'
         - os: ubuntu-latest
           python_version: '3.14'
           test_select: android

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Build Tools",
 ]


### PR DESCRIPTION
:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

## Summary

- Add `Programming Language :: Python :: 3.15` classifier to `pyproject.toml`
- Update the "Max Python" CI test job from 3.14 to 3.15 on `ubuntu-latest`

The job already has `allow-prereleases: true`, so Python 3.15 will be installable via `actions/setup-python`.

Assisted-by: OpenCode:GLM-5