### PR TITLE
docs: remove outdated numpy info

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -51,20 +51,7 @@ myextension = Extension(
 
 ### Building with NumPy
 
-If using NumPy, there are a couple of things that can help.
-
-First, if you require the `numpy` package at build-time (some binding tools, like `pybind11` and `nanobind`, do not), then the backward compatibility for your `build-backend.build-requires` is a little complicated for Python <3.9:
-
-* NumPy <1.25: You must build with the oldest version of NumPy you want to support at runtime.
-* NumPy 1.25 and 1.26: Anything you build will be compatible with 1.19+ by default, and you can set the minimum target to, for example, 1.22 with `#define NPY_TARGET_VERSION NPY_1_22_API_VERSION`.
-* NumPy 2.x: You must build with NumPy 2 to support NumPy 2; otherwise the same as 1.25+.
-
-So the rule is:
-
-* Python <3.8: Use the oldest supported NumPy (via helper `oldest-supported-numpy` if you want)
-* Python 3.9+: Use latest supported NumPy (2+).
-
-Second, there might be platforms you want to ship for that NumPy (or some other scientific Python libraries) are not shipping yet for. This is often true for beta candidates of new Python releases, for example. To work with this, you can use the Scientific Python Nightly wheels. Here's an example, depending on what frontend you use:
+If using NumPy, there might be platforms you want to ship for that NumPy (or some other scientific Python libraries) are not shipping yet for. This is often true for beta candidates of new Python releases, for example. To work with this, you can use the Scientific Python Nightly wheels. Here's an example, depending on what frontend you use:
 
 !!! tab "pip based"
     For frontends like `build` (the default) and `pip`:


### PR DESCRIPTION
Noticed in #2854 due to old Python mention. Not needed anymore for 3.9+.

