### PR TITLE
fix: replace assert with proper exception in python_build_standalone

### DIFF
--- a/cibuildwheel/util/python_build_standalone.py
+++ b/cibuildwheel/util/python_build_standalone.py
@@ -175,7 +175,9 @@ def create_python_build_standalone_environment(
     )
 
     python_base_dir = temp_dir / "pbs"
-    assert not python_base_dir.exists()
+    if python_base_dir.exists():
+        msg = f"python-build-standalone directory already exists: {python_base_dir}"
+        raise PythonBuildStandaloneError(msg)
     extract_tar(archive_path, python_base_dir)
 
     return _find_python_executable(python_base_dir)


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/issues/2854.

:robot: *Human triggered, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Replaces `assert not python_base_dir.exists()` in `cibuildwheel/util/python_build_standalone.py:178` with an explicit check that raises `PythonBuildStandaloneError`. Assert statements are skipped under `python -O`, making them unsuitable for runtime validation.

Identified in #2854 ("Uses assert for runtime validation — It is skipped with `python -O`").

Assisted-by: OpenCode:glm-5