### PR TITLE
chore: minor fixups across errors, oci_container, and options

### DIFF
--- a/cibuildwheel/errors.py
+++ b/cibuildwheel/errors.py
@@ -76,7 +76,7 @@ class RepairStepProducedNoWheelError(FatalError):
             Build failed because the repair step completed successfully but
             did not produce a wheel.
 
-            Your `repair-wheel-command` is expected to place the repaired
+            Your `repair-wheel-command` must place the repaired
             wheel in the {dest_dir} directory. See the documentation for
             example configurations:
 
@@ -94,7 +94,7 @@ class RepairStepProducedMultipleWheelsError(FatalError):
             Build failed because the repair step completed successfully but
             produced multiple wheels: {wheels}
 
-            Your `repair-wheel-command` is expected to place one repaired
+            Your `repair-wheel-command` must place exactly one repaired
             wheel in the {{dest_dir}} directory. See the documentation for
             example configurations:
 

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -525,13 +525,12 @@ class OCIContainer:
         return self.call(command, env=environment, capture_output=True)
 
     def debug_info(self) -> str:
+        command = [self.engine.name, "info"]
         if self.engine.name == "podman":
-            command = f"{self.engine.name} info --debug"
-        else:
-            command = f"{self.engine.name} info"
+            command.append("--debug")
+
         completed = subprocess.run(
             command,
-            shell=True,
             check=True,
             cwd=self.cwd,
             stdin=subprocess.PIPE,

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -708,11 +708,13 @@ class Options:
 
     def _check_pinned_image(self, value: str, pinned_images: Mapping[str, str]) -> None:
         error_set = {"manylinux1", "manylinux2010", "manylinux_2_24", "musllinux_1_1"}
-        warning_set: set[str] = set()
+        warning_set: set[str] = (
+            set()
+        )  # Currently no warnings, next: https://github.com/pypa/manylinux/issues/1925
 
         if value in error_set:
             msg = (
-                f"cibuildwheel 3.x does not support the image {value!r}. Either upgrade to a "
+                f"cibuildwheel 4.x does not support the image {value!r}. Either upgrade to a "
                 "supported image or continue using the image by pinning it directly with"
                 " its full OCI registry '<name>{:<tag>|@<digest>}'."
             )

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -708,9 +708,8 @@ class Options:
 
     def _check_pinned_image(self, value: str, pinned_images: Mapping[str, str]) -> None:
         error_set = {"manylinux1", "manylinux2010", "manylinux_2_24", "musllinux_1_1"}
-        warning_set: set[str] = (
-            set()
-        )  # Currently no warnings, next: https://github.com/pypa/manylinux/issues/1925
+        # Currently no warnings, next: https://github.com/pypa/manylinux/issues/1925
+        warning_set: set[str] = set()
 
         if value in error_set:
             msg = (


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Minor fixups across three files:

- **`errors.py`**: Strengthen error message wording in `FailedWheelRepairError` and `FailedWheelRepairMultipleError` — "is expected to" → "must" / "must place exactly one".
- **`oci_container.py`**: Remove `shell=True` from `subprocess.run` in `debug_info()`, passing the command as a list instead of a string.
- **`options.py`**: Update pinned image error message from "cibuildwheel 3.x" to "cibuildwheel 4.x" and add a comment about the next warning candidate.

Assisted-by: OpenCode:glm-5