### PR TITLE
Support new graalpy asset names that include Python version.

### DIFF
--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -124,14 +124,20 @@ class GraalPyVersions:
         response.raise_for_status()
 
         releases = response.json()
-        gp_version_re = re.compile(r"-(\d+\.\d+\.\d+)$")
+        gp_asset_re = re.compile(r"^(graalpy(\d+\.\d+)?-(\d+\.\d+\.\d+))-")
         cp_version_re = re.compile(r"Python (\d+\.\d+(?:\.\d+)?)")
         for release in releases:
-            m = gp_version_re.search(release["tag_name"])
-            if m:
-                release["graalpy_version"] = Version(m.group(1))
-            m = cp_version_re.search(release["body"])
-            if m:
+            for asset in release["assets"]:
+                m = gp_asset_re.match(asset["name"])
+                if m:
+                    release["asset_prefix"] = m.group(1)
+                    release["graalpy_version"] = Version(m.group(3))
+                    if m.group(2):
+                        release["python_version"] = Version(m.group(2))
+                    break
+            if "python_version" not in release and (
+                m := cp_version_re.search(release["body"] or "")
+            ):
                 release["python_version"] = Version(m.group(1))
 
         self.releases = [r for r in releases if "graalpy_version" in r and "python_version" in r]
@@ -172,12 +178,11 @@ class GraalPyVersions:
         ext = "zip" if "win" in identifier else "tar.gz"
         for release in reversed(releases):
             version = release["python_version"]
-            gpversion = release["graalpy_version"]
             urls = [
                 rf["browser_download_url"]
                 for rf in release["assets"]
                 if rf["name"].endswith(f"{platform}-{arch}.{ext}")
-                and rf["name"].startswith(f"graalpy-{gpversion.major}")
+                and rf["name"].startswith(release["asset_prefix"])
             ]
             if not urls:
                 continue

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -124,16 +124,18 @@ class GraalPyVersions:
         response.raise_for_status()
 
         releases = response.json()
-        gp_asset_re = re.compile(r"^(graalpy(\d+\.\d+)?-(\d+\.\d+\.\d+))-")
+        gp_asset_re = re.compile(
+            r"^(?P<prefix>graalpy(?P<cpython>\d+\.\d+)?-(?P<graalpy>\d+\.\d+\.\d+))-"
+        )
         cp_version_re = re.compile(r"Python (\d+\.\d+(?:\.\d+)?)")
         for release in releases:
             for asset in release["assets"]:
                 m = gp_asset_re.match(asset["name"])
                 if m:
-                    release["asset_prefix"] = m.group(1)
-                    release["graalpy_version"] = Version(m.group(3))
-                    if m.group(2):
-                        release["python_version"] = Version(m.group(2))
+                    release["asset_prefix"] = m.group("prefix")
+                    release["graalpy_version"] = Version(m.group("graalpy"))
+                    if m.group("cpython"):
+                        release["python_version"] = Version(m.group("cpython"))
                     break
             if "python_version" not in release and (
                 m := cp_version_re.search(release["body"] or "")


### PR DESCRIPTION
With https://github.com/oracle/graalpython/pull/810 we will slightly alter upcoming GraalPy release artifact naming. The name will now include the compatible CPython version name in the filename. This change adapts the metadata script to support both the older and newer format. We can drop the older one once support for GraalPy versions older than 25.1 is removed.

/cc @msimacek
Related:  https://github.com/oracle/graalpython/issues/623, https://github.com/pypa/manylinux/pull/1944
