### PR TITLE
chore: avoid importing TYPE_CHECKING

### DIFF
--- a/cibuildwheel/_compat/tarfile.py
+++ b/cibuildwheel/_compat/tarfile.py
@@ -6,7 +6,6 @@ import sys
 import tarfile
 
 TYPE_CHECKING = False
-
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -11,12 +11,13 @@ import textwrap
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, AnyStr, Final, Literal
+from typing import IO, AnyStr, Final, Literal
 
 import humanize
 
 from cibuildwheel.ci import CIProvider, detect_ci_provider, filter_ansi_codes
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from cibuildwheel.options import Options
 

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -7,7 +7,7 @@ import textwrap
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Sequence, Set
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, assert_never
+from typing import assert_never
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
@@ -22,6 +22,7 @@ from cibuildwheel.util.file import copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from cibuildwheel.typing import PathOrStr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ flake8-annotations.mypy-init-return = true
 "typing.Iterator".msg = "Use collections.abc.Iterator instead."
 "typing.Sequence".msg = "Use collections.abc.Sequence instead."
 "typing.Set".msg = "Use collections.abc.Set instead."
+"typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
 
 [tool.ruff.lint.per-file-ignores]
 "unit_test/*" = ["PLC1901", "TID252"]

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -2,7 +2,6 @@ import contextlib
 import sys
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 import setuptools._distutils.util
@@ -10,6 +9,8 @@ import setuptools._distutils.util
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.errors import FatalError
 from cibuildwheel.platforms.windows import PythonConfiguration, setup_setuptools_cross_compile
+
+TYPE_CHECKING = False
 
 # monkeypatching os.name is too flaky. E.g. It works on my machine, but fails in pipeline
 if not sys.platform.startswith("win") and not TYPE_CHECKING:

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -3,7 +3,6 @@ import tomllib
 from collections.abc import Mapping
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -15,6 +14,7 @@ from cibuildwheel.selector import BuildSelector, EnableGroup
 from cibuildwheel.util import resources
 from cibuildwheel.util.packaging import DependencyConstraints
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from .conftest import ArgsInterceptor
 


### PR DESCRIPTION
This helps with #2797 and I think is the only typing change needed for that one.

Assisted-by: OpenCode:glm-5.1
