### PR TITLE
chore: use `if TYPE_CHECKING:` blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: ^cibuildwheel/resources/android/android.patch$
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 6fec9b7edb08fd9989088709d864a7826dc74e80  # frozen: v0.15.12
+  rev: 0c7b6c989466a93942def1f84baf36ddfcd60c83  # frozen: v0.15.14
   hooks:
   - id: ruff-check
     args: ["--fix"]

--- a/bin/inspect_all_known_projects.py
+++ b/bin/inspect_all_known_projects.py
@@ -24,8 +24,9 @@ This will cache the results to all_known_setup.yaml; you can reprint
 the results without the `--online` setting.
 """
 
+from __future__ import annotations
+
 import ast
-from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import click
@@ -34,6 +35,10 @@ from github import Github, GithubException
 from rich import print
 
 from cibuildwheel.projectfiles import Analyzer
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 DIR = Path(__file__).parent.resolve()
 

--- a/bin/projects.py
+++ b/bin/projects.py
@@ -17,13 +17,14 @@ Suggested usage:
     git diff
 """
 
+from __future__ import annotations
+
 import builtins
 import functools
 import textwrap
 import urllib.error
 import urllib.request
 import xml.dom.minidom
-from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
@@ -32,6 +33,10 @@ from typing import Any, Self, TextIO
 import click
 import yaml
 from github import Auth, Github, GithubException
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
 
 ICONS = (
     "github",

--- a/bin/update_pythons.py
+++ b/bin/update_pythons.py
@@ -12,14 +12,13 @@
 # [tool.uv.sources]
 # cibuildwheel = { path = ".." }
 # ///
-
+from __future__ import annotations
 
 import difflib
 import logging
 import operator
 import re
 import tomllib
-from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from typing import Any, Final, Literal, TypedDict
 from xml.etree import ElementTree as ET
@@ -34,6 +33,10 @@ from rich.syntax import Syntax
 
 from cibuildwheel.extra import dump_python_configurations, get_pyodide_xbuildenv_info
 from cibuildwheel.platforms.android import android_triplet
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
 
 log = logging.getLogger("cibw")
 

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import contextlib
 import dataclasses
@@ -8,10 +10,8 @@ import sys
 import textwrap
 import traceback
 import typing
-from collections.abc import Generator, Iterable, Sequence
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any, Literal, TextIO
 
 import cibuildwheel
 from cibuildwheel import errors
@@ -26,6 +26,11 @@ from cibuildwheel.typing import PLATFORMS, PlatformName
 from cibuildwheel.util.file import CIBW_CACHE_PATH, ensure_cache_sentinel
 from cibuildwheel.util.helpers import strtobool
 from cibuildwheel.util.resources import read_all_configs
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+    from typing import Any, Literal, TextIO
 
 
 @dataclasses.dataclass

--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import platform as platform_module
 import re
 import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Set
 from enum import StrEnum, auto
-from typing import Final, Literal, Self
 
 from cibuildwheel import errors
-from cibuildwheel.typing import PlatformName
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+    from typing import Final, Literal, Self
+
+    from cibuildwheel.typing import PlatformName
 
 PRETTY_NAMES: Final[dict[PlatformName, str]] = {
     "linux": "Linux",

--- a/cibuildwheel/audit.py
+++ b/cibuildwheel/audit.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 from pathlib import Path
 
 from cibuildwheel import errors
 from cibuildwheel.logger import log
-from cibuildwheel.options import BuildOptions
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.helpers import prepare_command
 from cibuildwheel.util.packaging import is_abi3_wheel
 from cibuildwheel.venv import activate_virtualenv, find_uv, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cibuildwheel.options import BuildOptions
 
 
 def run_audit(

--- a/cibuildwheel/bashlex_eval.py
+++ b/cibuildwheel/bashlex_eval.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 import dataclasses
 import subprocess
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-    Sequence,
-)
 
 import bashlex
 
-# a function that takes a command and the environment, and returns the result
-EnvironmentExecutor = Callable[[list[str], dict[str, str]], str]
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+        Sequence,
+    )
+
+    # a function that takes a command and the environment, and returns the result
+    EnvironmentExecutor = Callable[[list[str], dict[str, str]], str]
 
 
 def local_environment_executor(command: Sequence[str], env: Mapping[str, str]) -> str:

--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 import dataclasses
-from collections.abc import Mapping, Sequence
-from typing import Any, Protocol
+from typing import Protocol
 
 import bashlex
 import bashlex.errors
 
 from cibuildwheel import bashlex_eval
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
 
 
 class EnvironmentParseError(Exception):

--- a/cibuildwheel/extra.py
+++ b/cibuildwheel/extra.py
@@ -2,16 +2,23 @@
 These are utilities for the `/bin` scripts, not for the `cibuildwheel` program.
 """
 
+from __future__ import annotations
+
 import json
 import time
 import typing
 import urllib.error
 import urllib.request
-from collections.abc import Mapping, Sequence
 from io import StringIO
-from typing import Any, NotRequired, Protocol
+from typing import NotRequired, Protocol
 
 from cibuildwheel import __version__ as cibw_version
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
+
 
 __all__ = ("Printable", "dump_python_configurations")
 

--- a/cibuildwheel/frontend.py
+++ b/cibuildwheel/frontend.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
 import dataclasses
 import shlex
 import typing
-from collections.abc import Sequence
-from typing import Literal, Self, get_args
+from typing import Literal, get_args
 
-from cibuildwheel.typing import PathOrStr
 from cibuildwheel.util.helpers import parse_key_value_string, prepare_command
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Self
+
+    from cibuildwheel.typing import PathOrStr
 
 BuildFrontendName = Literal["pip", "build", "build[uv]", "uv"]
 

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 import contextlib
 import dataclasses
@@ -9,9 +11,7 @@ import re
 import sys
 import textwrap
 import time
-from collections.abc import Generator
 from pathlib import Path
-from typing import IO, AnyStr, Final, Literal
 
 import humanize
 
@@ -19,9 +19,13 @@ from cibuildwheel.ci import CIProvider, detect_ci_provider, filter_ansi_codes
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import IO, AnyStr, Final, Literal
+
     from cibuildwheel.options import Options
 
-FoldPattern = tuple[str, str]
+    FoldPattern = tuple[str, str]
+
 DEFAULT_FOLD_PATTERN: Final[FoldPattern] = ("{name}", "")
 FOLD_PATTERNS: Final[dict[str, FoldPattern]] = {
     "azure": ("##[group]{name}", "##[endgroup]"),
@@ -235,7 +239,7 @@ class Logger:
             print(f"cibuildwheel: {c.bright_red}error{c.end}: {error}\n", file=sys.stderr)
 
     @contextlib.contextmanager
-    def print_summary(self, *, options: "Options") -> Generator[None, None, None]:
+    def print_summary(self, *, options: Options) -> Generator[None, None, None]:
         start = time.time()
         yield
         duration = time.time() - start
@@ -293,7 +297,7 @@ class Logger:
         # lowercase, shorten
         return identifier.lower()[:20]
 
-    def _github_step_summary(self, duration: float, options: "Options") -> str:
+    def _github_step_summary(self, duration: float, options: Options) -> str:
         """
         Returns the GitHub step summary, in markdown format.
         """

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import io
 import json
@@ -10,18 +12,24 @@ import sys
 import textwrap
 import typing
 import uuid
-from collections.abc import Mapping, Sequence
 from enum import Enum
-from pathlib import Path, PurePath, PurePosixPath
-from types import TracebackType
-from typing import IO, Literal, Self, assert_never
+from pathlib import PurePosixPath
+from typing import Literal, assert_never
 
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.errors import OCIEngineTooOldError
 from cibuildwheel.logger import log
-from cibuildwheel.typing import PathOrStr
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.helpers import FlexibleVersion, parse_key_value_string, strtobool
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path, PurePath
+    from types import TracebackType
+    from typing import IO, Self
+
+    from cibuildwheel.typing import PathOrStr
 
 ContainerEngineName = Literal["docker", "podman"]
 

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import configparser
 import contextlib
@@ -8,9 +10,9 @@ import functools
 import shlex
 import textwrap
 import tomllib
-from collections.abc import Callable, Generator, Iterable, Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Final, Literal, Self, assert_never
+from typing import assert_never
 
 from packaging.specifiers import SpecifierSet
 
@@ -26,6 +28,11 @@ from cibuildwheel.typing import PLATFORMS, PlatformName
 from cibuildwheel.util import resources
 from cibuildwheel.util.helpers import format_safe, parse_key_value_string, strtobool, unwrap
 from cibuildwheel.util.packaging import DependencyConstraints
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Set
+    from typing import Any, Final, Literal, Self
 
 MANYLINUX_ARCHS: Final[tuple[str, ...]] = (
     "x86_64",

--- a/cibuildwheel/platforms/__init__.py
+++ b/cibuildwheel/platforms/__init__.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
 import sys
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Final, Protocol
+from typing import Protocol
 
 from cibuildwheel import errors
-from cibuildwheel.architecture import Architecture
-from cibuildwheel.options import Options
 from cibuildwheel.platforms import android, ios, linux, macos, pyodide, windows
-from cibuildwheel.selector import BuildSelector
-from cibuildwheel.typing import GenericPythonConfiguration, PlatformName
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+    from typing import Final
+
+    from cibuildwheel.architecture import Architecture
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
+    from cibuildwheel.typing import GenericPythonConfiguration, PlatformName
 
 
 class PlatformModule(Protocol):

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import hashlib
 import os
@@ -7,7 +9,6 @@ import shlex
 import shutil
 import subprocess
 import sysconfig
-from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass
 from os.path import relpath
 from pathlib import Path
@@ -31,8 +32,6 @@ from cibuildwheel.frontend import (
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
-from cibuildwheel.options import BuildOptions, Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
@@ -41,8 +40,14 @@ from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.util.python_build_standalone import create_python_build_standalone_environment
 from cibuildwheel.venv import constraint_flags, find_uv, virtualenv
 
-RESOURCES_ANDROID = resources.PATH / "android"
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, MutableMapping
 
+    from cibuildwheel.options import BuildOptions, Options
+    from cibuildwheel.selector import BuildSelector
+
+RESOURCES_ANDROID = resources.PATH / "android"
 ANDROID_TRIPLET = {
     "arm64_v8a": "aarch64-linux-android",
     "x86_64": "x86_64-linux-android",

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import os
 import platform
@@ -6,31 +8,35 @@ import shutil
 import subprocess
 import sys
 import textwrap
-from collections.abc import Sequence, Set
 from pathlib import Path
 from typing import assert_never
 
 from filelock import FileLock
 
 from cibuildwheel import errors
-from cibuildwheel.architecture import Architecture
 from cibuildwheel.audit import run_audit
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import (
     BuildFrontendName,
     get_build_frontend_extra_flags,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
 from cibuildwheel.platforms.macos import install_cpython as install_build_cpython
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell, split_command
 from cibuildwheel.util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
 from cibuildwheel.util.helpers import prepare_command, unwrap_preserving_paragraphs
 from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.venv import constraint_flags, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence, Set
+
+    from cibuildwheel.architecture import Architecture
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import dataclasses
 import shutil
@@ -5,7 +7,6 @@ import subprocess
 import sys
 import textwrap
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Sequence, Set
 from pathlib import Path, PurePath, PurePosixPath
 from typing import assert_never
 
@@ -15,8 +16,6 @@ from cibuildwheel.audit import needs_audit, run_audit
 from cibuildwheel.frontend import get_build_frontend_extra_flags, prepare_config_settings
 from cibuildwheel.logger import log
 from cibuildwheel.oci_container import OCIContainer, OCIContainerEngineConfig, OCIPlatform
-from cibuildwheel.options import BuildOptions, Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.file import copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
@@ -24,6 +23,10 @@ from cibuildwheel.util.packaging import find_compatible_wheel
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence, Set
+
+    from cibuildwheel.options import BuildOptions, Options
+    from cibuildwheel.selector import BuildSelector
     from cibuildwheel.typing import PathOrStr
 
 ARCHITECTURE_OCI_PLATFORM_MAP = {

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import functools
 import inspect
@@ -8,32 +10,37 @@ import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Set
 from pathlib import Path
-from typing import Literal, assert_never
+from typing import assert_never
 
 from filelock import FileLock
 from packaging.version import Version
 
 from cibuildwheel import errors
-from cibuildwheel.architecture import Architecture
 from cibuildwheel.audit import run_audit
 from cibuildwheel.ci import detect_ci_provider
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import (
     BuildFrontendName,
     get_build_frontend_extra_flags,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, target_marker_env, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+    from typing import Literal
+
+    from cibuildwheel.architecture import Architecture
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 
 @functools.cache

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import functools
 import json
@@ -7,7 +9,6 @@ import subprocess
 import sys
 import tomllib
 import typing
-from collections.abc import Set
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Final, TypedDict
@@ -17,11 +18,8 @@ from filelock import FileLock
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
 from cibuildwheel.audit import run_audit
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import get_build_frontend_extra_flags, prepare_config_settings
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -39,6 +37,14 @@ from cibuildwheel.util.python_build_standalone import (
     create_python_build_standalone_environment,
 )
 from cibuildwheel.venv import constraint_flags, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import json
 import os
@@ -5,7 +7,6 @@ import platform as platform_module
 import shutil
 import subprocess
 import textwrap
-from collections.abc import MutableMapping, Sequence, Set
 from functools import cache
 from pathlib import Path
 from typing import assert_never
@@ -15,15 +16,12 @@ from filelock import FileLock
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
 from cibuildwheel.audit import run_audit
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import (
     BuildFrontendName,
     get_build_frontend_extra_flags,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -36,6 +34,14 @@ from cibuildwheel.util.file import (
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, target_marker_env, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping, Sequence, Set
+
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 
 def get_nuget_args(

--- a/cibuildwheel/projectfiles.py
+++ b/cibuildwheel/projectfiles.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import ast
 import configparser
 import contextlib
-from pathlib import Path
-from typing import Any
 
 import dependency_groups
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
 
 
 def get_parent(node: ast.AST | None, depth: int = 1) -> ast.AST | None:

--- a/cibuildwheel/schema.py
+++ b/cibuildwheel/schema.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import json
-from typing import Any
 
 from cibuildwheel.util import resources
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def get_schema(tool_name: str = "cibuildwheel") -> dict[str, Any]:

--- a/cibuildwheel/selector.py
+++ b/cibuildwheel/selector.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import dataclasses
 import itertools
 from enum import StrEnum
 from fnmatch import fnmatch
-from typing import Self
 
 import bracex
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Self
+
+    from packaging.specifiers import SpecifierSet
 
 
 def selector_matches(patterns: str, string: str) -> bool:

--- a/cibuildwheel/util/cmd.py
+++ b/cibuildwheel/util/cmd.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import os
 import shlex
 import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Iterator, Mapping
-from typing import Final, Literal
 
 from cibuildwheel.errors import FatalError
-from cibuildwheel.typing import PathOrStr
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+    from typing import Final, Literal
+
+    from cibuildwheel.typing import PathOrStr
 
 _IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import os
 import shutil
 import ssl
 import tarfile
 import time
 import urllib.request
-from collections.abc import Callable
 from pathlib import Path, PurePath
 from typing import Final
 from zipfile import ZipFile
@@ -13,6 +14,10 @@ import certifi
 from platformdirs import user_cache_path
 
 from cibuildwheel.errors import FatalError
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DEFAULT_CIBW_CACHE_PATH: Final[Path] = user_cache_path(appname="cibuildwheel", appauthor="pypa")
 CIBW_CACHE_PATH: Final[Path] = Path(

--- a/cibuildwheel/util/helpers.py
+++ b/cibuildwheel/util/helpers.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import dataclasses
 import itertools
-import os
 import re
 import shlex
 import textwrap
 from collections import defaultdict
-from collections.abc import Sequence
 
-from cibuildwheel.typing import PathOrStr
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import os
+    from collections.abc import Sequence
+
+    from cibuildwheel.typing import PathOrStr
 
 
 def format_safe(template: str, **kwargs: str | os.PathLike[str]) -> str:

--- a/cibuildwheel/util/packaging.py
+++ b/cibuildwheel/util/packaging.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import shlex
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import Literal, Self, TypeVar
+from typing import TypeVar
 
 from packaging.utils import parse_wheel_filename
 
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.helpers import parse_key_value_string, unwrap
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Literal, Self
 
 
 @dataclass(kw_only=True)

--- a/cibuildwheel/util/python_build_standalone.py
+++ b/cibuildwheel/util/python_build_standalone.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import fnmatch
 import functools
 import json
 import platform
 import typing
-from pathlib import Path
 
 from filelock import FileLock
 
 from cibuildwheel.util.file import download, extract_tar
 from cibuildwheel.util.resources import PYTHON_BUILD_STANDALONE_RELEASES
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class PythonBuildStandaloneAsset(typing.TypedDict):

--- a/cibuildwheel/util/resources.py
+++ b/cibuildwheel/util/resources.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import functools
 import tomllib
 from pathlib import Path
-from typing import Final
 
-from cibuildwheel.typing import PlatformName
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Final
+
+    from cibuildwheel.typing import PlatformName
 
 PATH: Final[Path] = Path(__file__).parent.parent / "resources"
 INSTALL_CERTIFI_SCRIPT: Final[Path] = PATH / "install_certifi.py"

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import os
 import shutil
 import sys
 import tomllib
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Final, cast
+from typing import cast
 
 from filelock import FileLock
 from packaging.markers import default_environment
@@ -16,6 +17,11 @@ from packaging.version import Version
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.file import CIBW_CACHE_PATH, download
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Final
 
 _IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ flake8-unused-arguments.ignore-variadic-names = true
 flake8-tidy-imports.ban-relative-imports = "all"
 flake8-annotations.allow-star-arg-any = true
 flake8-annotations.mypy-init-return = true
+future-annotations = true
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.Mapping".msg = "Use collections.abc.Mapping instead."

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess
-from collections.abc import Generator
 
 import pytest
 from filelock import FileLock
@@ -15,6 +16,10 @@ from cibuildwheel.venv import find_uv
 
 from . import utils
 from .utils import DEFAULT_CIBW_ENABLE, EMULATED_ARCHS, get_platform
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/test/test_0_basic.py
+++ b/test/test_0_basic.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import textwrap
-from pathlib import Path
 
 import packaging.utils
 import pytest
@@ -8,6 +9,10 @@ from cibuildwheel.logger import Logger
 from cibuildwheel.selector import EnableGroup
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_abi3audit.py
+++ b/test/test_abi3audit.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pyproject_toml = r"""
 [build-system]

--- a/test/test_abi_variants.py
+++ b/test/test_abi_variants.py
@@ -1,9 +1,14 @@
-import textwrap
-from pathlib import Path
+from __future__ import annotations
 
-import pytest
+import textwrap
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
 
 pyproject_toml = r"""
 [build-system]

--- a/test/test_before_all.py
+++ b/test/test_before_all.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_before_build_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_before_build.py
+++ b/test/test_before_build.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # pyodide does not support building without isolation, need to check the base_prefix
 SYS_PREFIX = f"sys.{'base_' if utils.get_platform() == 'pyodide' else ''}prefix"

--- a/test/test_before_test.py
+++ b/test/test_before_test.py
@@ -1,6 +1,10 @@
-from pathlib import Path
+from __future__ import annotations
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 before_test_project = test_projects.new_c_project()
 before_test_project.files["test/spam_test.py"] = r"""

--- a/test/test_build_frontend_args.py
+++ b/test/test_build_frontend_args.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize(

--- a/test/test_build_skip.py
+++ b/test/test_build_skip.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import textwrap
-from pathlib import Path
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_skip_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_container_engine.py
+++ b/test/test_container_engine.py
@@ -1,8 +1,12 @@
-from pathlib import Path
+from __future__ import annotations
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project()
 

--- a/test/test_container_images.py
+++ b/test/test_container_images.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import platform
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 dockcross_only_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_cpp_standards.py
+++ b/test/test_cpp_standards.py
@@ -1,9 +1,13 @@
-from pathlib import Path
+from __future__ import annotations
 
 import jinja2
 
 from . import utils
 from .test_projects import TestProject
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 cpp_test_project = TestProject()
 

--- a/test/test_custom_repair_wheel.py
+++ b/test/test_custom_repair_wheel.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import subprocess
 import textwrap
 from contextlib import nullcontext as does_not_raise
-from pathlib import Path
 
 import pytest
 
 from test import test_projects
 
 from . import utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project()
 basic_project.files["repair.py"] = """

--- a/test/test_dependency_versions.py
+++ b/test/test_dependency_versions.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import json
 import re
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from cibuildwheel.util import resources
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 VERSION_REGEX = r"([\w-]+)==([^;\s]+)"
 

--- a/test/test_emulation.py
+++ b/test/test_emulation.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import itertools
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_a_test = test_projects.new_c_project()
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_environment_asserts = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
 import textwrap
-from collections.abc import Mapping
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pytest
-
-from test.test_projects.base import TestProject
-
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import pytest
+
+    from test.test_projects.base import TestProject
 
 # utilities
 

--- a/test/test_ios.py
+++ b/test/test_ios.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import os
 import platform
 import shutil
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pytestmark = pytest.mark.ios
 

--- a/test/test_linux_python.py
+++ b/test/test_linux_python.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import platform
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_python_exist(tmp_path: Path, capfd: pytest.CaptureFixture[str]) -> None:

--- a/test/test_macos_archs.py
+++ b/test/test_macos_archs.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import platform
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project()
 basic_project.files["tests/test_suite.py"] = r"""

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import platform
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # TODO: specify these at runtime according to manylinux_image
 project_with_manylinux_symbols = test_projects.new_c_project(

--- a/test/test_meson_python.py
+++ b/test/test_meson_python.py
@@ -1,8 +1,12 @@
-from pathlib import Path
+from __future__ import annotations
 
 import packaging.utils
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 meson_project = test_projects.new_meson_project()
 

--- a/test/test_musllinux_X_Y_only.py
+++ b/test/test_musllinux_X_Y_only.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_manylinux_symbols = test_projects.new_c_project(
     spam_c_top_level_add=textwrap.dedent(

--- a/test/test_pep518.py
+++ b/test/test_pep518.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 import textwrap
 from pathlib import Path
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_projects/base.py
+++ b/test/test_projects/base.py
@@ -1,7 +1,12 @@
-from pathlib import Path
+from __future__ import annotations
+
 from typing import Any, Self
 
 import jinja2
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FilesDict = dict[str, str | jinja2.Template]
 TemplateContext = dict[str, Any]

--- a/test/test_pure_wheel.py
+++ b/test/test_pure_wheel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 
@@ -6,6 +8,10 @@ import pytest
 from test import test_projects
 
 from . import utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pure_python_project = test_projects.TestProject()
 pure_python_project.files["setup.py"] = """

--- a/test/test_pyodide.py
+++ b/test/test_pyodide.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from cibuildwheel.util.file import CIBW_CACHE_PATH
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pytestmark = pytest.mark.pyodide
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_ssl_tests = test_projects.new_c_project(
     setup_py_add=textwrap.dedent(

--- a/test/test_subdir_package.py
+++ b/test/test_subdir_package.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import jinja2
-import pytest
 
 from . import utils
 from .test_projects import TestProject
 from .test_projects.c import SPAM_C_TEMPLATE
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import pytest
 
 subdir_package_project = TestProject()
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import inspect
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 project_with_a_test = test_projects.new_c_project(
     setup_cfg_add=textwrap.dedent(

--- a/test/test_troubleshooting.py
+++ b/test/test_troubleshooting.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from . import utils
 from .test_projects import TestProject, new_c_project
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SO_FILE_WARNING = "NOTE: Shared object (.so) files found in this project."
 

--- a/test/test_wheel_tag.py
+++ b/test/test_wheel_tag.py
@@ -1,8 +1,12 @@
-from pathlib import Path
+from __future__ import annotations
 
 import pytest
 
 from . import test_projects, utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 basic_project = test_projects.new_c_project()
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,11 +4,12 @@ Utility functions used by the cibuildwheel tests.
 This file is added to the PYTHONPATH in the test runner at bin/run_test.py.
 """
 
+from __future__ import annotations
+
 import os
 import platform as pm
 import subprocess
 import sys
-from collections.abc import Generator, Mapping, Sequence
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Final
@@ -19,6 +20,10 @@ from cibuildwheel.architecture import Architecture
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.selector import EnableGroup
 from cibuildwheel.util.file import CIBW_CACHE_PATH
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping, Sequence
 
 EMULATED_ARCHS: Final[list[str]] = sorted(
     arch.value for arch in (Architecture.all_archs("linux") - Architecture.auto_archs("linux"))

--- a/unit_test/architecture_test.py
+++ b/unit_test/architecture_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform as platform_module
 import shutil
 import sys
@@ -6,7 +8,10 @@ import pytest
 
 import cibuildwheel.architecture
 from cibuildwheel.architecture import Architecture, arch_synonym
-from cibuildwheel.typing import PlatformName
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cibuildwheel.typing import PlatformName
 
 
 @pytest.fixture(

--- a/unit_test/audit_test.py
+++ b/unit_test/audit_test.py
@@ -1,4 +1,5 @@
-import contextlib
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -7,6 +8,10 @@ import pytest
 
 from cibuildwheel import errors
 from cibuildwheel.audit import needs_audit, run_audit
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import contextlib
 
 
 def mock_virtualenv() -> contextlib.AbstractContextManager[Mock]:

--- a/unit_test/download_test.py
+++ b/unit_test/download_test.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import ssl
-from pathlib import Path
 
 import certifi
 import pytest
 
 from cibuildwheel.util.file import download
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 DOWNLOAD_URL = "https://cdn.jsdelivr.net/gh/pypa/cibuildwheel@v1.6.3/requirements-dev.txt"
 

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import contextlib
 import sys
-from collections.abc import Generator
-from pathlib import Path
 
 import pytest
 import setuptools._distutils.util
@@ -11,6 +11,9 @@ from cibuildwheel.errors import FatalError
 from cibuildwheel.platforms.windows import PythonConfiguration, setup_setuptools_cross_compile
 
 TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
 
 # monkeypatching os.name is too flaky. E.g. It works on my machine, but fails in pipeline
 if not sys.platform.startswith("win") and not TYPE_CHECKING:

--- a/unit_test/linux_build_steps_test.py
+++ b/unit_test/linux_build_steps_test.py
@@ -1,12 +1,17 @@
-import textwrap
-from pathlib import Path
-from pprint import pprint
+from __future__ import annotations
 
-import pytest
+import textwrap
+from pprint import pprint
 
 import cibuildwheel.platforms.linux
 from cibuildwheel.oci_container import OCIContainerEngineConfig
 from cibuildwheel.options import CommandLineArguments, Options
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
 
 
 def test_linux_container_split(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/unit_test/main_commands_test.py
+++ b/unit_test/main_commands_test.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import errno
 import shutil
 import sys
-from pathlib import Path
 
 import pytest
 
 import cibuildwheel.__main__ as main_module
 from cibuildwheel.__main__ import main
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_clean_cache_when_cache_exists(

--- a/unit_test/main_tests/conftest.py
+++ b/unit_test/main_tests/conftest.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import contextlib
 import platform as platform_module
 import subprocess
 import sys
-from collections.abc import Generator, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,10 @@ from cibuildwheel import architecture
 from cibuildwheel.logger import Logger
 from cibuildwheel.platforms import android, ios, linux, macos, pyodide, windows
 from cibuildwheel.util import file
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
 
 
 class ArgsInterceptor:

--- a/unit_test/main_tests/main_options_test.py
+++ b/unit_test/main_tests/main_options_test.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import sys
 import tomllib
-from collections.abc import Mapping
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from cibuildwheel.util.packaging import DependencyConstraints
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from .conftest import ArgsInterceptor
 
 # CIBW_PLATFORM is tested in main_platform_test.py
@@ -37,7 +40,7 @@ def test_old_free_threaded(
 
 @pytest.mark.usefixtures("platform")
 def test_output_dir(
-    intercepted_build_args: "ArgsInterceptor", monkeypatch: pytest.MonkeyPatch
+    intercepted_build_args: ArgsInterceptor, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     OUTPUT_DIR = Path("some_output_dir")
 
@@ -49,7 +52,7 @@ def test_output_dir(
 
 
 @pytest.mark.usefixtures("platform")
-def test_output_dir_default(intercepted_build_args: "ArgsInterceptor") -> None:
+def test_output_dir_default(intercepted_build_args: ArgsInterceptor) -> None:
     main()
 
     assert intercepted_build_args.args[0].globals.output_dir == Path("wheelhouse").resolve()
@@ -59,7 +62,7 @@ def test_output_dir_default(intercepted_build_args: "ArgsInterceptor") -> None:
 @pytest.mark.parametrize("also_set_environment", [False, True])
 def test_output_dir_argument(
     also_set_environment: bool,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     OUTPUT_DIR = Path("some_output_dir")
@@ -75,7 +78,7 @@ def test_output_dir_argument(
 
 @pytest.mark.usefixtures("platform", "allow_empty")
 def test_build_selector(
-    intercepted_build_args: "ArgsInterceptor", monkeypatch: pytest.MonkeyPatch
+    intercepted_build_args: ArgsInterceptor, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CIBW_BUILD", "cp313-*")
     monkeypatch.setenv("CIBW_SKIP", "cp39-*")
@@ -191,7 +194,7 @@ def test_manylinux_images(
     image: str | None,
     full_image: str,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if image is not None:
@@ -230,7 +233,7 @@ def test_repair_command(
     repair_command: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if repair_command is not None:
@@ -259,7 +262,7 @@ def test_environment(
     environment: Mapping[str, str],
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     env_string = " ".join(f"{k}={v}" for k, v in environment.items())
@@ -284,7 +287,7 @@ def test_test_requires(
     test_requires: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if test_requires is not None:
@@ -307,7 +310,7 @@ def test_audit_requires(
     audit_requires: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if audit_requires is not None:
@@ -331,7 +334,7 @@ def test_test_extras(
     test_extras: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if test_extras is not None:
@@ -354,7 +357,7 @@ def test_test_command(
     test_command: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if test_command is not None:
@@ -377,7 +380,7 @@ def test_before_build(
     before_build: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if before_build is not None:
@@ -399,7 +402,7 @@ def test_build_verbosity(
     build_verbosity: int | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if build_verbosity is not None:
@@ -420,7 +423,7 @@ def test_build_verbosity(
 def test_config_settings(
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_settings = (
@@ -507,7 +510,7 @@ def test_before_all(
     before_all: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if before_all is not None:
@@ -533,7 +536,7 @@ def test_dependency_versions(
     dependency_versions: str | None,
     platform_specific: bool,
     platform: str,
-    intercepted_build_args: "ArgsInterceptor",
+    intercepted_build_args: ArgsInterceptor,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -593,7 +596,7 @@ def test_debug_traceback(
 
 @pytest.mark.parametrize("method", ["unset", "command_line", "env_var"])
 def test_enable(
-    method: str, intercepted_build_args: "ArgsInterceptor", monkeypatch: pytest.MonkeyPatch
+    method: str, intercepted_build_args: ArgsInterceptor, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("CIBW_ENABLE", raising=False)
 
@@ -613,7 +616,7 @@ def test_enable(
 
 
 def test_enable_all(
-    intercepted_build_args: "ArgsInterceptor", monkeypatch: pytest.MonkeyPatch
+    intercepted_build_args: ArgsInterceptor, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "argv", [*sys.argv, "--enable", "all"])
     monkeypatch.delenv("CIBW_ENABLE", raising=False)
@@ -625,7 +628,7 @@ def test_enable_all(
 
 
 def test_enable_arg_inherits(
-    intercepted_build_args: "ArgsInterceptor", monkeypatch: pytest.MonkeyPatch
+    intercepted_build_args: ArgsInterceptor, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CIBW_ENABLE", "pypy graalpy")
     monkeypatch.setattr(sys, "argv", [*sys.argv, "--enable", "cpython-prerelease"])
@@ -652,7 +655,7 @@ def test_enable_arg_error_message(
     assert "Valid group names are:" in err
 
 
-def test_defaults(platform: str, intercepted_build_args: "ArgsInterceptor") -> None:
+def test_defaults(platform: str, intercepted_build_args: ArgsInterceptor) -> None:
     main()
 
     build_options: BuildOptions = intercepted_build_args.args[0].build_options(identifier=None)

--- a/unit_test/main_tests/main_platform_test.py
+++ b/unit_test/main_tests/main_platform_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest
@@ -5,10 +7,14 @@ import pytest
 from cibuildwheel.__main__ import main
 from cibuildwheel.architecture import Architecture
 from cibuildwheel.selector import EnableGroup
-from cibuildwheel.typing import PlatformName
 
 from ..conftest import MOCK_PACKAGE_DIR
-from .conftest import ArgsInterceptor
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cibuildwheel.typing import PlatformName
+
+    from .conftest import ArgsInterceptor
 
 
 @pytest.mark.parametrize("option_value", [None, "auto", ""])

--- a/unit_test/main_tests/main_requires_python_test.py
+++ b/unit_test/main_tests/main_requires_python_test.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import sys
 import textwrap
-from pathlib import Path
 
 import pytest
 from packaging.specifiers import SpecifierSet
 
 from cibuildwheel.__main__ import main
 
-from .conftest import ArgsInterceptor
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .conftest import ArgsInterceptor
 
 
 @pytest.fixture(autouse=True)

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import json
 import os
@@ -7,7 +9,6 @@ import subprocess
 import sys
 import textwrap
 import time
-from collections.abc import Iterator
 from contextlib import nullcontext
 from pathlib import Path, PurePath, PurePosixPath
 
@@ -24,6 +25,10 @@ from cibuildwheel.oci_container import (
     OCIPlatform,
     _check_engine_version,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # Test utilities
 

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 import platform as platform_module
 import textwrap
 import unittest.mock
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
 
@@ -24,6 +25,10 @@ from cibuildwheel.options import (
 from cibuildwheel.platforms import ALL_PLATFORM_MODULES, get_build_identifiers
 from cibuildwheel.util import resources
 from cibuildwheel.util.packaging import DependencyConstraints
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 PYPROJECT_1 = """
 [tool.cibuildwheel]

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import shlex
-from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -13,7 +14,12 @@ from cibuildwheel.options import (
     ShlexTableFormat,
     _resolve_cascade,
 )
-from cibuildwheel.typing import PlatformName
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cibuildwheel.typing import PlatformName
 
 PYPROJECT_1 = """
 [tool.cibuildwheel]

--- a/unit_test/projectfiles_test.py
+++ b/unit_test/projectfiles_test.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import tomllib
-from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -9,6 +10,10 @@ from cibuildwheel.projectfiles import (
     resolve_dependency_groups,
     setup_py_python_requires,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_read_setup_py_simple(tmp_path: Path) -> None:


### PR DESCRIPTION
This will become the default in Python 3.14 in any case given the current lint rules.
It ensures typing only imports do not slow down execution (admittedly only useful in edge use cases, such as querying help).

If #2797 makes it, it will further speed-up this one:
```
hyperfine --warmup 10 \
     -n "main"                --prepare "git checkout main"               ".nox/tests-3-15/bin/python -m cibuildwheel --help" \
     -n "Henry's PR"          --prepare "git checkout pr/2797"            ".nox/tests-3-15/bin/python -m cibuildwheel --help" \
     -n "type-checking"       --prepare "git checkout type-checking"      ".nox/tests-3-15/bin/python -m cibuildwheel --help" \
     -n "type-checking-lazy"  --prepare "git checkout type-checking-lazy" ".nox/tests-3-15/bin/python -m cibuildwheel --help"
Benchmark 1: main
  Time (mean ± σ):     308.7 ms ±  16.7 ms    [User: 194.7 ms, System: 44.1 ms]
  Range (min … max):   294.3 ms … 349.3 ms    10 runs
 
Benchmark 2: Henry's PR
  Time (mean ± σ):     106.2 ms ±   9.4 ms    [User: 62.7 ms, System: 17.6 ms]
  Range (min … max):    88.7 ms … 118.2 ms    19 runs
 
Benchmark 3: type-checking (this PR)
  Time (mean ± σ):     306.9 ms ±  15.5 ms    [User: 194.2 ms, System: 43.2 ms]
  Range (min … max):   290.2 ms … 342.8 ms    10 runs
 
Benchmark 4: type-checking-lazy
  Time (mean ± σ):      77.5 ms ±   6.1 ms    [User: 45.6 ms, System: 13.7 ms]
  Range (min … max):    68.9 ms …  86.3 ms    22 runs
 
Summary
  type-checking-lazy ran
    1.37 ± 0.16 times faster than Henry's PR
    3.96 ± 0.37 times faster than type-checking (this PR)
    3.98 ± 0.38 times faster than main
```