### PR TITLE
Fix Windows Gitlab test running

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ linux:
     # (comment the below line in a PR to debug a Gitlab-specific issue)
     PYTEST_ADDOPTS: -k "unit_test or test_0_basic" --suppress-no-test-exit-code
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^gitlab/'
       variables:
         CIBW_ENABLE: "all"
   script:
@@ -31,7 +31,7 @@ windows:
   before_script:
     - choco install python -y --allow-downgrade --version 3.12.4
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^gitlab/'
       variables:
         CIBW_ENABLE: "all"
   script:
@@ -46,7 +46,7 @@ macos:
   variables:
     PYTEST_ADDOPTS: -k "unit_test or test_0_basic" --suppress-no-test-exit-code
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^gitlab/'
       variables:
         CIBW_ENABLE: "all"
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,9 +35,9 @@ windows:
       variables:
         CIBW_ENABLE: "all"
   script:
-    - py -m pip install -U pip
-    - py -m pip install -e. pytest-custom-exit-code --group test
-    - py bin\run_tests.py
+    - python -m pip install -U pip
+    - python -m pip install -e. pytest-custom-exit-code --group test
+    - python bin\run_tests.py
   tags:
     - saas-windows-medium-amd64
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,11 @@ windows:
   rules:
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^gitlab/'
       variables:
-        CIBW_ENABLE: "all"
+        # Everything except graalpy. GraalPy is JVM-based and very slow to
+        # start; on the small (2-core) GitLab SaaS Windows runners,
+        # virtualenv's interpreter query for graalpy.exe times out, failing
+        # the build. (Other platforms run the full "all" group.)
+        CIBW_ENABLE: "cpython-prerelease pypy pypy-eol pyodide-eol pyodide-prerelease"
   script:
     - python -m pip install -U pip
     - python -m pip install -e. pytest-custom-exit-code --group test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 linux:
-  image: python:3.12
+  image: python:3.13
   services:
     - name: docker:dind
       entrypoint: ["env", "-u", "DOCKER_HOST"]
@@ -25,11 +25,8 @@ linux:
     - python ./bin/run_tests.py
 
 windows:
-  image: mcr.microsoft.com/windows/servercore:1809
   variables:
     PYTEST_ADDOPTS: -k "unit_test or test_0_basic" --suppress-no-test-exit-code
-  before_script:
-    - choco install python -y --allow-downgrade --version 3.12.4
   rules:
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^gitlab/'
       variables:
@@ -42,7 +39,7 @@ windows:
     - saas-windows-medium-amd64
 
 macos:
-  image: macos-14-xcode-15
+  image: macos-15-xcode-16
   variables:
     PYTEST_ADDOPTS: -k "unit_test or test_0_basic" --suppress-no-test-exit-code
   rules:


### PR DESCRIPTION
These have been failing on main for a little while.

Don't look like a big issue. `py` is trying to execute the shebang in run_tests.py, which is a posix thing. Trying to use `python` directly...
