### PR TITLE
feat: add CIBUILDWHEEL_BUILD_IDENTIFIER environment variable

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -140,7 +140,7 @@ def build(options: Options, tmp_path: Path) -> None:
             build_path.mkdir()
             python_dir = setup_target_python(config, build_path)
             build_env, android_env = setup_env(config, build_options, build_path, python_dir)
-            build_env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+
             state = BuildState(
                 config, build_options, build_path, python_dir, build_env, android_env
             )
@@ -226,6 +226,7 @@ def setup_env(
 
     # Apply custom environment variables, and check environment is still valid
     build_env = build_options.environment.as_dictionary(build_env)
+    build_env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
     build_env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     for command in ["python"] if use_uv else ["python", "pip"]:
         command_path = call("which", command, env=build_env, capture_stdout=True).strip()

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -140,6 +140,7 @@ def build(options: Options, tmp_path: Path) -> None:
             build_path.mkdir()
             python_dir = setup_target_python(config, build_path)
             build_env, android_env = setup_env(config, build_options, build_path, python_dir)
+            build_env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
             state = BuildState(
                 config, build_options, build_path, python_dir, build_env, android_env
             )

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -476,6 +476,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_frontend=build_frontend.name,
                 xbuild_tools=build_options.xbuild_tools,
             )
+            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
             if compatible_wheel:

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -234,6 +234,7 @@ def build_in_container(
         env["PATH"] = f"{python_bin}:{env['PATH']}"
 
         env = build_options.environment.as_dictionary(env, executor=container.environment_executor)
+        env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
 
         # check config python is still on PATH
         which_python = container.call(["which", "python"], env=env, capture_output=True).strip()

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -459,6 +459,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_options.environment,
                 build_frontend.name,
             )
+            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
             pip_version = None if use_uv else get_pip_version(env)
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -385,6 +385,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 environment=build_options.environment,
                 user_pyodide_version=build_options.pyodide_version,
             )
+            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
             pip_version = get_pip_version(env)
             # The Pyodide command line runner mounts all directories in the host
             # filesystem into the Pyodide file system, except for the custom

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -460,6 +460,7 @@ def build(options: Options, tmp_path: Path) -> None:
                 build_options.environment,
                 build_frontend.name,
             )
+            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
             pip_version = None if use_uv else get_pip_version(env)
 
             compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)

--- a/docs/options.md
+++ b/docs/options.md
@@ -670,6 +670,9 @@ Platform-specific environment variables are also available:<br/>
     cibuildwheel always defines the environment variable `CIBUILDWHEEL=1`. This can be useful for [building wheels with optional extensions](faq.md#optional-extensions).
 
 !!! note
+    For each per-build step (`before_build`, the build itself, `repair_command`, `before_test`, `test_command`), cibuildwheel also sets `CIBUILDWHEEL_BUILD_IDENTIFIER` to the current build identifier (e.g. `cp311-manylinux_x86_64`). This can be used in scripts to distinguish different builds.
+
+!!! note
     To do its work, cibuildwheel sets the variables `VIRTUALENV_PIP`, `DIST_EXTRA_CONFIG`, `SETUPTOOLS_EXT_SUFFIX`, `PIP_DISABLE_PIP_VERSION_CHECK`, `PIP_ROOT_USER_ACTION`, and it extends the variables `PATH` and `PIP_CONSTRAINT`. Your assignments to these options might be replaced or extended.
 
 ### `environment-pass` {: #environment-pass env-var="CIBW_ENVIRONMENT_PASS_LINUX" toml}


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Closes #944, closes #2750.

Sets a new environment variable `CIBUILDWHEEL_BUILD_IDENTIFIER` to the current build identifier (e.g. `cp311-manylinux_x86_64`) in the environment for all per-build steps: `before_build`, the build itself, `repair_command`, `before_test`, and `test_command`.

## Motivation

Users need to inspect the current build identifier inside scripts and commands, for example to write per-build output files without one build overwriting another:

```toml
[tool.cibuildwheel]
test-command = "pytest --junit-xml=results-$CIBUILDWHEEL_BUILD_IDENTIFIER.xml"
```

## Design decisions

- Set **after** the user's `CIBW_ENVIRONMENT` overrides are applied, so it reliably reflects the actual identifier.
- Available **only** for per-build steps — not in `before_all`, where no single identifier applies (that step runs once for a batch of builds).
- Covers all six platforms: **linux**, **macOS**, **Windows**, **pyodide**, **Android**, and **iOS**.


Assisted-by: CopilotCLI:claude-sonnet-4.6