### PR TITLE
chore: add unit tests for `OCIContainer._get_platform_args`

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -257,6 +257,7 @@ class OCIContainer:
                 # this allows to run local only images
                 pull = "never"
         except subprocess.CalledProcessError:
+            # silently fallback to "--pull=always"
             pass
         return f"--platform={oci_platform.value}", f"--pull={pull}"
 

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -568,13 +568,20 @@ def test_local_image(
         [container_engine.name, "pull", f"--platform={platform.value}", remote_image],
         check=True,
     )
+    container = OCIContainer(engine=container_engine, image=local_image, oci_platform=platform)
+    # before image is built & available, we want to pull it
+    subprocess.run([container_engine.name, "rmi", local_image], check=True)
+    assert container._get_platform_args() == (f"--platform={platform.value}", "--pull=always")
     subprocess.run(
         [container_engine.name, "build", f"--platform={platform.value}", "-t", local_image, "."],
         check=True,
         cwd=tmp_path,
     )
-    with OCIContainer(engine=container_engine, image=local_image, oci_platform=platform):
-        pass
+    # after image is built & available, we never want to pull it
+    expected_platform_args = f"--platform={platform.value}", "--pull=never"
+    assert container._get_platform_args() == expected_platform_args
+    with container:
+        assert container._get_platform_args() == expected_platform_args
 
 
 @pytest.mark.parametrize("platform", list(OCIPlatform))
@@ -612,6 +619,14 @@ def test_multiarch_image(container_engine: OCIContainerEngineConfig, platform: O
             OCIPlatform.S390X: "s390x",
         }
         assert output_map_dpkg[platform] == output.strip()
+        # There's no way to check reliably the presence of a specific platform image in the local
+        # store when the image storage backend supports multi-platform images (such as containerd).
+        # When platform != DEFAULT_OCI_PLATFORM and the image storage backend supports
+        # multi-platform images, _get_platform_args will return "--pull=always", at least when the
+        # DEFAULT_OCI_PLATFORM image is present.
+        if platform == DEFAULT_OCI_PLATFORM:
+            expected_platform_args = f"--platform={platform.value}", "--pull=never"
+            assert container._get_platform_args() == expected_platform_args
 
 
 @pytest.mark.parametrize(

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -570,7 +570,7 @@ def test_local_image(
     )
     container = OCIContainer(engine=container_engine, image=local_image, oci_platform=platform)
     # before image is built & available, we want to pull it
-    subprocess.run([container_engine.name, "rmi", local_image], check=True)
+    subprocess.run([container_engine.name, "rmi", local_image], check=False)
     assert container._get_platform_args() == (f"--platform={platform.value}", "--pull=always")
     subprocess.run(
         [container_engine.name, "build", f"--platform={platform.value}", "-t", local_image, "."],


### PR DESCRIPTION
In the context of checking one potential issue reported in #2854, I checked if the we could get rid of the `_get_platform_args` workaround at some point but the issue is still opened.

I can only report that the behaviour is now correct without the workaround on macOS with the latest Docker Desktop version, using containerd.

The behaviour of cibuildwheel can likely be different when working using multi-platform images depending on docker configuration. The impact is mostly when doing a qemu driven build and using a moving image  tag such as latest: a tag update will trigger a download rather than re-use an already present image. It's probably a niche use-case+configuration combination or it would have already been reported if deemed important.