### PR TITLE
fix: prevent deadlock when `linux32` fails

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -298,7 +298,10 @@ class OCIContainer:
                     ).strip()
                 else:
                     raise
-            simulate_32_bit = container_machine not in {"i686", "armv7l", "armv8l"}
+            if container_machine not in {"i686", "armv7l", "armv8l"}:
+                simulate_32_bit = True
+                # sanity check to ensure no deadlock waiting for container to start
+                call(*run_cmd, self.image, "linux32", "/bin/true", capture_stdout=True)
 
         shell_args = ["linux32", "/bin/bash"] if simulate_32_bit else ["/bin/bash"]
 

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -555,9 +555,12 @@ def test_local_image(
         platform,
     }:
         pytest.skip("Skipping test because docker on this platform does not support QEMU")
-    if container_engine.name == "podman" and platform == OCIPlatform.ARMV7:
-        # both GHA & local macOS arm64 podman desktop are failing
-        pytest.xfail("podman fails with armv7l images")
+    if container_engine.name == "podman":
+        if platform == OCIPlatform.ARMV7:
+            # both GHA & local macOS arm64 podman desktop are failing
+            pytest.xfail("podman fails with armv7l images")
+        elif platform == OCIPlatform.i386 and sys.platform.startswith("darwin"):
+            pytest.xfail("podman fails with i386 images on macOS")
 
     remote_image = "debian:trixie-slim"
     platform_name = platform.value.replace("/", "_")
@@ -636,9 +639,13 @@ def test_multiarch_image(container_engine: OCIContainerEngineConfig, platform: O
         platform,
     }:
         pytest.skip("Skipping test because docker on this platform does not support QEMU")
-    if container_engine.name == "podman" and platform == OCIPlatform.ARMV7:
-        # both GHA & local macOS arm64 podman desktop are failing
-        pytest.xfail("podman fails with armv7l images")
+    if container_engine.name == "podman":
+        if platform == OCIPlatform.ARMV7:
+            # both GHA & local macOS arm64 podman desktop are failing
+            pytest.xfail("podman fails with armv7l images")
+        elif platform == OCIPlatform.i386 and sys.platform.startswith("darwin"):
+            pytest.xfail("podman fails with i386 images on macOS")
+
     with OCIContainer(
         engine=container_engine, image="debian:trixie-slim", oci_platform=platform
     ) as container:


### PR DESCRIPTION
Found while crafting #2879

This was the case when running `nox -s tests -- --run-podman -v -s 'unit_test/oci_container_test.py::test_multiarch_image[podman-OCIPlatform.i386]'` on macOS arm64.