### PR TITLE
fix: pass platform args to linux32 deadlock sanity check

### DIFF
--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -301,7 +301,14 @@ class OCIContainer:
             if container_machine not in {"i686", "armv7l", "armv8l"}:
                 simulate_32_bit = True
                 # sanity check to ensure no deadlock waiting for container to start
-                call(*run_cmd, self.image, "linux32", "/bin/true", capture_stdout=True)
+                call(
+                    *run_cmd,
+                    *platform_args,
+                    self.image,
+                    "linux32",
+                    "/bin/true",
+                    capture_stdout=True,
+                )
 
         shell_args = ["linux32", "/bin/bash"] if simulate_32_bit else ["/bin/bash"]
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `linux32` sanity check added in #2880 (which proactively surfaces a `linux32` failure so it raises here instead of deadlocking later) omits `*platform_args`, unlike every other run/create command in `__enter__` — the two `uname -m` probes and the `create` call all include it.

This matters specifically on the **i386 fallback path**: if the initial i386 probe fails, `platform_args` is reassigned to `AMD64`. Without forwarding it, the sanity check runs with no `--platform`/`--pull`, so on a multi-platform / containerd image backend the engine can select a different image variant than the one actually being built — making the check validate the wrong variant (or pull a different one), which defeats its purpose.

This forwards `*platform_args` to match the surrounding calls.

## Testing
- `uv run pytest unit_test/oci_container_test.py` passes (the `simulate_32_bit` branch is exercised by the docker/podman emulation integration tests `test_local_image` / `test_multiarch_image` on i386/ARMV7, which require `--run-docker`/`--run-podman`).
- `prek -a` clean.