### PR TITLE
Drop use of `Unbuffered` wrapper class

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -344,11 +344,11 @@ def build_in_directory(args: CommandLineArguments) -> None:
     # Add CIBUILDWHEEL environment variable
     os.environ["CIBUILDWHEEL"] = "1"
 
-    # Python is buffering by default when running on the CI platforms, giving
-    # problems interleaving subprocess call output with unflushed calls to
-    # 'print'
+    # Python block-buffers stdout when it isn't a tty, which de-interleaves
+    # `print` output and direct fd-1 writes from subprocesses sharing this
+    # stdout. line_buffering allows each newline to flush all the way to fd-1.
     if isinstance(sys.stdout, io.TextIOWrapper):
-        sys.stdout.reconfigure(write_through=True)
+        sys.stdout.reconfigure(line_buffering=True)
 
     # create the cache dir before it gets printed & builds performed
     CIBW_CACHE_PATH.mkdir(parents=True, exist_ok=True)

--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import dataclasses
 import functools
+import io
 import os
 import shutil
 import sys
@@ -30,7 +31,7 @@ from cibuildwheel.util.resources import read_all_configs
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Sequence
-    from typing import Any, Literal, TextIO
+    from typing import Literal
 
 
 @dataclasses.dataclass
@@ -42,23 +43,6 @@ class GlobalOptions:
 class FileReport:
     name: str
     size: str
-
-
-# Taken from https://stackoverflow.com/a/107717
-class Unbuffered:
-    def __init__(self, stream: TextIO) -> None:
-        self.stream = stream
-
-    def write(self, data: str) -> None:
-        self.stream.write(data)
-        self.stream.flush()
-
-    def writelines(self, data: Iterable[str]) -> None:
-        self.stream.writelines(data)
-        self.stream.flush()
-
-    def __getattr__(self, attr: str) -> Any:  # noqa: ANN401
-        return getattr(self.stream, attr)
 
 
 def main() -> None:
@@ -363,7 +347,8 @@ def build_in_directory(args: CommandLineArguments) -> None:
     # Python is buffering by default when running on the CI platforms, giving
     # problems interleaving subprocess call output with unflushed calls to
     # 'print'
-    sys.stdout = Unbuffered(sys.stdout)
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(write_through=True)
 
     # create the cache dir before it gets printed & builds performed
     CIBW_CACHE_PATH.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
We can replace it with `sys.stdout.reconfigure(line_buffering=True)`. This takes and completes review point 6 of #2854.

`write_through=True` is not enough, as it only forces the text layer through to the `BufferedWriter`, which still block-buffers a pipe.

The `io.TextIOWrapper` instance check isn't really needed per se, but Mypy raises otherwise, so I added it. Even typeshed mentions the following advice, based on what I see locally in Pylance at `.vscode/extensions/ms-python.vscode-pylance-2026.2.1/dist/typeshed-fallback/stdlib/sys/__init__.pyi`:

```python
# TextIO is used instead of more specific types for the standard streams,
# since they are often monkeypatched at runtime. At startup, the objects
# are initialized to instances of TextIOWrapper, but can also be None under
# some circumstances.
#
# To use methods from TextIOWrapper, use an isinstance check to ensure that
# the streams have not been overridden:
#
# if isinstance(sys.stdout, io.TextIOWrapper):
#    sys.stdout.reconfigure(...)
stdin: TextIO | MaybeNone
stdout: TextIO | MaybeNone
stderr: TextIO | MaybeNone
```