### PR TITLE
WIP: unify platform structure

### DIFF
--- a/cibuildwheel/platforms/_run.py
+++ b/cibuildwheel/platforms/_run.py
@@ -132,6 +132,8 @@ def run_host_build(
                     backend.before_build(state)
                     built_wheel = backend.build_wheel(state)
                     repaired_wheel = backend.repair_wheel(state, built_wheel)
+                    if repaired_wheel.name in {w.name for w in built_wheels}:
+                        raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
                     run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
             else:
                 # Test-only stage: consume a wheel built by an earlier run.
@@ -142,9 +144,12 @@ def run_host_build(
 
             output_wheel: Path | None = None
             if Stage.BUILD in stages and compatible_wheel is None:
-                output_wheel = move_file(
-                    repaired_wheel, build_options.output_dir / repaired_wheel.name
-                )
+                expected_wheel = build_options.output_dir / repaired_wheel.name
+                output_wheel = move_file(repaired_wheel, expected_wheel)
+                if output_wheel != expected_wheel.resolve():
+                    log.warning(
+                        f"{repaired_wheel} was moved to {output_wheel} instead of {expected_wheel}"
+                    )
                 built_wheels.append(output_wheel)
 
             backend.teardown(state)

--- a/cibuildwheel/platforms/_run.py
+++ b/cibuildwheel/platforms/_run.py
@@ -1,0 +1,155 @@
+"""Shared build driver for the "host" platforms.
+
+The five non-container platforms (android, macos, windows, ios, pyodide) all run
+their build phases directly on the build machine and share an identical
+orchestration loop: run ``before_all`` once, then for each Python configuration
+set up an environment, optionally build + repair + audit a wheel, optionally test
+it, and move the result into the output directory.
+
+That loop lives here, in :func:`run_host_build`, so each platform only has to
+provide the platform-specific phase functions described by :class:`HostBackend`.
+A platform satisfies the protocol simply by exposing module-level functions with
+the right names (see ``android.py`` for the reference implementation).
+
+Linux is deliberately *not* a host backend: it batches configurations by
+container image and runs every phase through ``container.call`` inside an
+``OCIContainer``, so it keeps its own bespoke loop.
+"""
+
+from __future__ import annotations
+
+import enum
+import subprocess
+
+from cibuildwheel import errors
+from cibuildwheel.audit import run_audit
+from cibuildwheel.logger import log
+from cibuildwheel.util.file import move_file
+from cibuildwheel.util.packaging import find_compatible_wheel
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+    from typing import Protocol, TypeVar
+
+    from cibuildwheel.architecture import Architecture
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
+    from cibuildwheel.typing import GenericPythonConfiguration
+
+    ConfigT = TypeVar("ConfigT", bound=GenericPythonConfiguration)
+    StateT = TypeVar("StateT")
+
+    class HostBackend(Protocol[ConfigT, StateT]):
+        """The phase functions every host platform must expose.
+
+        ``StateT`` is an opaque, per-platform object (typically a frozen
+        dataclass) created by :meth:`setup` and threaded through the remaining
+        phases; the driver never inspects it.
+        """
+
+        def get_python_configurations(
+            self, build_selector: BuildSelector, architectures: set[Architecture]
+        ) -> Sequence[ConfigT]: ...
+
+        def before_all(self, options: Options, configs: Sequence[ConfigT]) -> None: ...
+
+        def setup(self, config: ConfigT, options: Options, tmp_path: Path) -> StateT: ...
+
+        def before_build(self, state: StateT) -> None: ...
+
+        def build_wheel(self, state: StateT) -> Path: ...
+
+        def repair_wheel(self, state: StateT, built_wheel: Path) -> Path: ...
+
+        def test_wheel(self, state: StateT, wheel: Path) -> None: ...
+
+        def teardown(self, state: StateT) -> None: ...
+
+
+class Stage(enum.Enum):
+    BUILD = "build"
+    TEST = "test"
+
+
+ALL_STAGES = frozenset({Stage.BUILD, Stage.TEST})
+
+
+def find_prebuilt_wheel(output_dir: Path, identifier: str) -> Path:
+    """Locate a wheel in ``output_dir`` previously built for ``identifier``.
+
+    Used by the test-only stage, which consumes wheels produced by an earlier
+    build-only stage rather than building them itself.
+    """
+    wheel = find_compatible_wheel(sorted(output_dir.glob("*.whl")), identifier)
+    if wheel is None:
+        msg = f"No pre-built wheel for {identifier!r} found in {output_dir}"
+        raise errors.FatalError(msg)
+    return wheel
+
+
+def run_host_build(
+    backend: HostBackend[ConfigT, StateT],
+    options: Options,
+    tmp_path: Path,
+    *,
+    stages: frozenset[Stage] = ALL_STAGES,
+) -> None:
+    """Run the shared host build loop for ``backend``.
+
+    ``stages`` selects which phases run: building (and repairing/auditing/moving
+    the wheel) and/or testing. The default runs both, reproducing the historical
+    behaviour exactly: the wheel is only moved into ``output_dir`` after a
+    successful test, so a failing test leaves no wheel behind.
+    """
+    configs = backend.get_python_configurations(
+        options.globals.build_selector, options.globals.architectures
+    )
+    if not configs:
+        return
+
+    try:
+        if Stage.BUILD in stages:
+            backend.before_all(options, configs)
+
+        built_wheels: list[Path] = []
+        for config in configs:
+            log.build_start(config.identifier)
+            build_options = options.build_options(config.identifier)
+            state = backend.setup(config, options, tmp_path)
+
+            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
+
+            if Stage.BUILD in stages:
+                if compatible_wheel is not None:
+                    print(
+                        f"\nFound previously built wheel {compatible_wheel.name} that is "
+                        f"compatible with {config.identifier}. Skipping build step..."
+                    )
+                    repaired_wheel = compatible_wheel
+                else:
+                    backend.before_build(state)
+                    built_wheel = backend.build_wheel(state)
+                    repaired_wheel = backend.repair_wheel(state, built_wheel)
+                    run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
+            else:
+                # Test-only stage: consume a wheel built by an earlier run.
+                repaired_wheel = find_prebuilt_wheel(build_options.output_dir, config.identifier)
+
+            if Stage.TEST in stages:
+                backend.test_wheel(state, repaired_wheel)
+
+            output_wheel: Path | None = None
+            if Stage.BUILD in stages and compatible_wheel is None:
+                output_wheel = move_file(
+                    repaired_wheel, build_options.output_dir / repaired_wheel.name
+                )
+                built_wheels.append(output_wheel)
+
+            backend.teardown(state)
+            log.build_end(output_wheel)
+
+    except subprocess.CalledProcessError as error:
+        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
+        raise errors.FatalError(msg) from error

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -5,7 +5,6 @@ import platform
 import re
 import shlex
 import shutil
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,29 +20,29 @@ from packaging.utils import canonicalize_name
 
 from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.architecture import Architecture, arch_synonym
-from cibuildwheel.audit import run_audit
 from cibuildwheel.frontend import (
     get_build_frontend_extra_flags,
     parse_config_settings,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
+from cibuildwheel.platforms._run import run_host_build
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
     CIBW_CACHE_PATH,
     copy_test_sources,
     download,
-    move_file,
     remove_on_error,
 )
 from cibuildwheel.util.helpers import prepare_command
-from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.util.python_build_standalone import create_python_build_standalone_environment
 from cibuildwheel.venv import constraint_flags, find_uv, virtualenv
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
     from cibuildwheel.typing import PathOrStr
@@ -101,7 +100,7 @@ def shell_prepared(command: str, *, build_options: BuildOptions, env: dict[str, 
     )
 
 
-def before_all(options: Options, python_configurations: list[PythonConfiguration]) -> None:
+def before_all(options: Options, python_configurations: Sequence[PythonConfiguration]) -> None:
     before_all_options = options.build_options(python_configurations[0].identifier)
     if before_all_options.before_all:
         log.step("Running before_all...")
@@ -130,57 +129,23 @@ def build(options: Options, tmp_path: Path) -> None:
         )
         raise errors.FatalError(msg)
 
-    configs = get_python_configurations(
-        options.globals.build_selector, options.globals.architectures
-    )
-    if not configs:
-        return
+    run_host_build(platforms.android, options, tmp_path)
 
-    try:
-        before_all(options, configs)
 
-        built_wheels: list[Path] = []
-        for config in configs:
-            log.build_start(config.identifier)
-            build_options = options.build_options(config.identifier)
-            build_path = tmp_path / config.identifier
-            build_path.mkdir()
-            python_dir = setup_target_python(config, build_path)
-            build_env, android_env = setup_env(config, build_options, build_path, python_dir)
+def setup(config: PythonConfiguration, options: Options, tmp_path: Path) -> BuildState:
+    build_options = options.build_options(config.identifier)
+    build_path = tmp_path / config.identifier
+    build_path.mkdir()
+    python_dir = setup_target_python(config, build_path)
+    build_env, android_env = setup_env(config, build_options, build_path, python_dir)
 
-            state = BuildState(
-                config, build_options, build_path, python_dir, build_env, android_env
-            )
-            setup_xbuild_files(state)
+    state = BuildState(config, build_options, build_path, python_dir, build_env, android_env)
+    setup_xbuild_files(state)
+    return state
 
-            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
-            if compatible_wheel:
-                print(
-                    f"\nFound previously built wheel {compatible_wheel.name} that is "
-                    f"compatible with {config.identifier}. Skipping build step..."
-                )
-                repaired_wheel = compatible_wheel
-            else:
-                before_build(state)
-                built_wheel = build_wheel(state)
-                repaired_wheel = repair_wheel(state, built_wheel)
-                run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
 
-            test_wheel(state, repaired_wheel)
-
-            output_wheel: Path | None = None
-            if compatible_wheel is None:
-                output_wheel = move_file(
-                    repaired_wheel, build_options.output_dir / repaired_wheel.name
-                )
-                built_wheels.append(output_wheel)
-
-            shutil.rmtree(build_path)
-            log.build_end(output_wheel)
-
-    except subprocess.CalledProcessError as error:
-        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
-        raise errors.FatalError(msg) from error
+def teardown(state: BuildState) -> None:
+    shutil.rmtree(state.build_path)
 
 
 def setup_target_python(config: PythonConfiguration, build_path: Path) -> Path:

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -14,14 +14,14 @@ from typing import assert_never
 from filelock import FileLock
 from packaging.version import Version
 
-from cibuildwheel import errors
-from cibuildwheel.audit import run_audit
+from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.frontend import (
     BuildFrontendName,
     get_build_frontend_extra_flags,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
+from cibuildwheel.platforms._run import run_host_build
 from cibuildwheel.platforms.macos import install_cpython as install_build_cpython
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell, split_command
@@ -29,11 +29,9 @@ from cibuildwheel.util.file import (
     CIBW_CACHE_PATH,
     copy_test_sources,
     download,
-    move_file,
     remove_on_error,
 )
 from cibuildwheel.util.helpers import prepare_command, unwrap_preserving_paragraphs
-from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.venv import constraint_flags, virtualenv
 
 TYPE_CHECKING = False
@@ -42,7 +40,7 @@ if TYPE_CHECKING:
 
     from cibuildwheel.architecture import Architecture
     from cibuildwheel.environment import ParsedEnvironment
-    from cibuildwheel.options import Options
+    from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
 
 
@@ -438,339 +436,327 @@ def setup_python(
     return target_install_path, env
 
 
+@dataclasses.dataclass(frozen=True)
+class BuildState:
+    config: PythonConfiguration
+    options: BuildOptions
+    identifier_tmp_dir: Path
+    target_install_path: Path
+    env: dict[str, str]
+
+
 def build(options: Options, tmp_path: Path) -> None:
     if sys.platform != "darwin":
         msg = "iOS binaries can only be built on macOS"
         raise errors.FatalError(msg)
 
-    python_configurations = get_python_configurations(
-        build_selector=options.globals.build_selector,
-        architectures=options.globals.architectures,
+    run_host_build(platforms.ios, options, tmp_path)
+
+
+def before_all(options: Options, python_configurations: Sequence[PythonConfiguration]) -> None:
+    before_all_options = options.build_options(python_configurations[0].identifier)
+    if before_all_options.before_all:
+        log.step("Running before_all...")
+        env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+        env.setdefault("IPHONEOS_DEPLOYMENT_TARGET", "13.0")
+        before_all_prepared = prepare_command(
+            before_all_options.before_all,
+            project=".",
+            package=before_all_options.package_dir,
+        )
+        shell(before_all_prepared, env=env)
+
+
+def setup(config: PythonConfiguration, options: Options, tmp_path: Path) -> BuildState:
+    build_options = options.build_options(config.identifier)
+    build_frontend = build_options.build_frontend
+    # uv doesn't support iOS
+    # Not using set because mypy can't narrow it
+    if build_frontend.name == "build[uv]" or build_frontend.name == "uv":  # noqa: PLR1714
+        msg = "uv doesn't support iOS"
+        raise errors.FatalError(msg)
+
+    identifier_tmp_dir = tmp_path / config.identifier
+    identifier_tmp_dir.mkdir()
+
+    constraints_path = build_options.dependency_constraints.get_for_python_version(
+        version=config.version, tmp_dir=identifier_tmp_dir
     )
 
-    if not python_configurations:
-        return
+    target_install_path, env = setup_python(
+        identifier_tmp_dir / "build",
+        python_configuration=config,
+        dependency_constraint=constraints_path,
+        environment=build_options.environment,
+        build_frontend=build_frontend.name,
+        xbuild_tools=build_options.xbuild_tools,
+    )
+    env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+
+    return BuildState(config, build_options, identifier_tmp_dir, target_install_path, env)
+
+
+def before_build(state: BuildState) -> None:
+    build_options = state.options
+    if build_options.before_build:
+        log.step("Running before_build...")
+        before_build_prepared = prepare_command(
+            build_options.before_build,
+            project=".",
+            package=build_options.package_dir,
+        )
+        shell(before_build_prepared, env=state.env)
+
+
+def build_wheel(state: BuildState) -> Path:
+    build_options = state.options
+    build_frontend = build_options.build_frontend
+    built_wheel_dir = state.identifier_tmp_dir / "built_wheel"
+
+    log.step("Building wheel...")
+    built_wheel_dir.mkdir()
+
+    extra_flags = get_build_frontend_extra_flags(
+        build_frontend,
+        build_options.build_verbosity,
+        prepare_config_settings(
+            build_options.config_settings,
+            project=".",
+            package=build_options.package_dir,
+        ),
+    )
+
+    match build_frontend.name:
+        case "pip":
+            # Path.resolve() is needed. Without it pip wheel may try to
+            # fetch package from pypi.org. See
+            # https://github.com/pypa/cibuildwheel/pull/369
+            call(
+                "python",
+                "-m",
+                "pip",
+                "wheel",
+                build_options.package_dir.resolve(),
+                f"--wheel-dir={built_wheel_dir}",
+                "--no-deps",
+                *extra_flags,
+                env=state.env,
+            )
+        case "build":
+            call(
+                "python",
+                "-m",
+                "build",
+                build_options.package_dir,
+                "--wheel",
+                f"--outdir={built_wheel_dir}",
+                *extra_flags,
+                env=state.env,
+            )
+        case "build[uv]" | "uv":
+            # rejected in setup(); handled here so the match stays exhaustive
+            msg = "uv doesn't support iOS"
+            raise errors.FatalError(msg)
+        case _:
+            assert_never(build_frontend)
+
+    built_wheel = next(built_wheel_dir.glob("*.whl"))
+
+    if built_wheel.name.endswith("none-any.whl"):
+        raise errors.NonPlatformWheelError()
+    return built_wheel
+
+
+def repair_wheel(state: BuildState, built_wheel: Path) -> Path:
+    build_options = state.options
+    repaired_wheel_dir = state.identifier_tmp_dir / "repaired_wheel"
+    repaired_wheel_dir.mkdir()
+
+    if build_options.repair_command:
+        log.step("Repairing wheel...")
+
+        repair_command_prepared = prepare_command(
+            build_options.repair_command,
+            wheel=built_wheel,
+            dest_dir=repaired_wheel_dir,
+            package=build_options.package_dir,
+            project=".",
+        )
+        shell(repair_command_prepared, env=state.env)
+    else:
+        shutil.move(str(built_wheel), repaired_wheel_dir)
 
     try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+        repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
+    except StopIteration:
+        raise errors.RepairStepProducedNoWheelError() from None
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            env.setdefault("IPHONEOS_DEPLOYMENT_TARGET", "13.0")
-            before_all_prepared = prepare_command(
-                before_all_options.before_all,
-                project=".",
-                package=before_all_options.package_dir,
-            )
-            shell(before_all_prepared, env=env)
+    log.step_end()
+    return repaired_wheel
 
-        built_wheels: list[Path] = []
 
-        for config in python_configurations:
-            build_options = options.build_options(config.identifier)
-            build_frontend = build_options.build_frontend
-            # uv doesn't support iOS
-            # Not using set because mypy can't narrow it
-            if build_frontend.name == "build[uv]" or build_frontend.name == "uv":  # noqa: PLR1714
-                msg = "uv doesn't support iOS"
-                raise errors.FatalError(msg)
+def test_wheel(state: BuildState, wheel: Path) -> None:
+    build_options = state.options
+    config = state.config
+    if not (build_options.test_command and build_options.test_selector(config.identifier)):
+        return
 
-            log.build_start(config.identifier)
+    if not config.is_simulator:
+        log.step("Skipping tests on non-simulator SDK")
+        return
+    if config.arch != os.uname().machine:
+        log.step("Skipping tests on non-native simulator architecture")
+        return
 
-            identifier_tmp_dir = tmp_path / config.identifier
-            identifier_tmp_dir.mkdir()
-            built_wheel_dir = identifier_tmp_dir / "built_wheel"
-            repaired_wheel_dir = identifier_tmp_dir / "repaired_wheel"
+    test_env = build_options.test_environment.as_dictionary(prev_environment=state.env)
 
-            constraints_path = build_options.dependency_constraints.get_for_python_version(
-                version=config.version, tmp_dir=identifier_tmp_dir
-            )
+    if build_options.before_test:
+        before_test_prepared = prepare_command(
+            build_options.before_test,
+            project=".",
+            package=build_options.package_dir,
+        )
+        shell(before_test_prepared, env=test_env)
 
-            target_install_path, env = setup_python(
-                identifier_tmp_dir / "build",
-                python_configuration=config,
-                dependency_constraint=constraints_path,
-                environment=build_options.environment,
-                build_frontend=build_frontend.name,
-                xbuild_tools=build_options.xbuild_tools,
-            )
-            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+    log.step("Setting up test harness...")
+    # Clone the testbed project into the build directory
+    testbed_path = state.identifier_tmp_dir / "testbed"
+    call(
+        "python",
+        state.target_install_path / "testbed",
+        "clone",
+        testbed_path,
+        env=test_env,
+    )
 
-            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
-            if compatible_wheel:
-                log.step_end()
-                print(
-                    f"\nFound previously built wheel {compatible_wheel.name} "
-                    f"that is compatible with {config.identifier}. "
-                    "Skipping build step..."
-                )
-                test_wheel = compatible_wheel
-            else:
-                if build_options.before_build:
-                    log.step("Running before_build...")
-                    before_build_prepared = prepare_command(
-                        build_options.before_build,
-                        project=".",
-                        package=build_options.package_dir,
-                    )
-                    shell(before_build_prepared, env=env)
+    testbed_app_path = testbed_path / "iOSTestbed" / "app"
 
-                log.step("Building wheel...")
-                built_wheel_dir.mkdir()
+    # Copy the test sources to the testbed app
+    if build_options.test_sources:
+        copy_test_sources(
+            build_options.test_sources,
+            Path.cwd(),
+            testbed_app_path,
+        )
+    else:
+        (testbed_app_path / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
 
-                extra_flags = get_build_frontend_extra_flags(
-                    build_frontend,
-                    build_options.build_verbosity,
-                    prepare_config_settings(
-                        build_options.config_settings,
-                        project=".",
-                        package=build_options.package_dir,
-                    ),
-                )
+    log.step("Installing test requirements...")
+    # Install the compiled wheel (with any test extras), plus
+    # the test requirements. Use the --platform tag to force
+    # the installation of iOS wheels; this requires the use of
+    # --only-binary=:all:
+    ios_version = test_env["IPHONEOS_DEPLOYMENT_TARGET"]
+    platform_tag = f"ios_{ios_version.replace('.', '_')}_{config.arch}_{config.sdk}"
 
-                match build_frontend.name:
-                    case "pip":
-                        # Path.resolve() is needed. Without it pip wheel may try to
-                        # fetch package from pypi.org. See
-                        # https://github.com/pypa/cibuildwheel/pull/369
-                        call(
-                            "python",
-                            "-m",
-                            "pip",
-                            "wheel",
-                            build_options.package_dir.resolve(),
-                            f"--wheel-dir={built_wheel_dir}",
-                            "--no-deps",
-                            *extra_flags,
-                            env=env,
-                        )
-                    case "build":
-                        call(
-                            "python",
-                            "-m",
-                            "build",
-                            build_options.package_dir,
-                            "--wheel",
-                            f"--outdir={built_wheel_dir}",
-                            *extra_flags,
-                            env=env,
-                        )
-                    case _:
-                        assert_never(build_frontend)
+    call(
+        "python",
+        "-m",
+        "pip",
+        "install",
+        "--only-binary=:all:",
+        "--platform",
+        platform_tag,
+        "--target",
+        testbed_path / "iOSTestbed" / "app_packages",
+        f"{wheel}{build_options.test_extras}",
+        *build_options.test_requires,
+        env=test_env,
+    )
 
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+    log.step("Running test suite...")
 
-                if built_wheel.name.endswith("none-any.whl"):
-                    raise errors.NonPlatformWheelError()
+    # iOS doesn't support placeholders in the test command,
+    # because the source dir isn't visible on the simulator.
+    if "{project}" in build_options.test_command or "{package}" in build_options.test_command:
+        msg = unwrap_preserving_paragraphs(
+            f"""
+            iOS tests configured with a test command that uses the "{{project}}" or
+            "{{package}}" placeholder. iOS tests cannot use placeholders, because the
+            source directory is not visible on the simulator.
 
-                repaired_wheel_dir.mkdir()
-                if build_options.repair_command:
-                    log.step("Repairing wheel...")
+            In addition, iOS tests must run as a Python module, so the test command
+            must begin with 'python -m'.
 
-                    repair_command_prepared = prepare_command(
-                        build_options.repair_command,
-                        wheel=built_wheel,
-                        dest_dir=repaired_wheel_dir,
-                        package=build_options.package_dir,
-                        project=".",
-                    )
-                    shell(repair_command_prepared, env=env)
-                else:
-                    shutil.move(str(built_wheel), repaired_wheel_dir)
+            Test command: {build_options.test_command!r}
+            """
+        )
+        raise errors.FatalError(msg)
 
-                try:
-                    repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
-                except StopIteration:
-                    raise errors.RepairStepProducedNoWheelError() from None
+    test_command_list = shlex.split(build_options.test_command)
+    try:
+        for test_command_parts in split_command(test_command_list):
+            match test_command_parts:
+                case ["python", "-m", *rest]:
+                    final_command = rest
+                case ["pytest", *rest]:
+                    # pytest works exactly the same as a module, so we
+                    # can just run it as a module.
+                    msg = unwrap_preserving_paragraphs(f"""
+                        iOS tests configured with a test command which doesn't start
+                        with 'python -m'. iOS tests must execute python modules - other
+                        entrypoints are not supported.
 
-                if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
+                        cibuildwheel will try to execute it as if it started with
+                        'python -m'. If this works, all you need to do is add that to
+                        your test command.
 
-                log.step_end()
-
-                run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
-
-                test_wheel = repaired_wheel
-
-            if build_options.test_command and build_options.test_selector(config.identifier):
-                if not config.is_simulator:
-                    log.step("Skipping tests on non-simulator SDK")
-                elif config.arch != os.uname().machine:
-                    log.step("Skipping tests on non-native simulator architecture")
-                else:
-                    test_env = build_options.test_environment.as_dictionary(prev_environment=env)
-
-                    if build_options.before_test:
-                        before_test_prepared = prepare_command(
-                            build_options.before_test,
-                            project=".",
-                            package=build_options.package_dir,
-                        )
-                        shell(before_test_prepared, env=test_env)
-
-                    log.step("Setting up test harness...")
-                    # Clone the testbed project into the build directory
-                    testbed_path = identifier_tmp_dir / "testbed"
-                    call(
-                        "python",
-                        target_install_path / "testbed",
-                        "clone",
-                        testbed_path,
-                        env=test_env,
-                    )
-
-                    testbed_app_path = testbed_path / "iOSTestbed" / "app"
-
-                    # Copy the test sources to the testbed app
-                    if build_options.test_sources:
-                        copy_test_sources(
-                            build_options.test_sources,
-                            Path.cwd(),
-                            testbed_app_path,
-                        )
-                    else:
-                        (testbed_app_path / "test_fail.py").write_text(
-                            resources.TEST_FAIL_CWD_FILE.read_text()
-                        )
-
-                    log.step("Installing test requirements...")
-                    # Install the compiled wheel (with any test extras), plus
-                    # the test requirements. Use the --platform tag to force
-                    # the installation of iOS wheels; this requires the use of
-                    # --only-binary=:all:
-                    ios_version = test_env["IPHONEOS_DEPLOYMENT_TARGET"]
-                    platform_tag = f"ios_{ios_version.replace('.', '_')}_{config.arch}_{config.sdk}"
-
-                    call(
-                        "python",
-                        "-m",
-                        "pip",
-                        "install",
-                        "--only-binary=:all:",
-                        "--platform",
-                        platform_tag,
-                        "--target",
-                        testbed_path / "iOSTestbed" / "app_packages",
-                        f"{test_wheel}{build_options.test_extras}",
-                        *build_options.test_requires,
-                        env=test_env,
-                    )
-
-                    log.step("Running test suite...")
-
-                    # iOS doesn't support placeholders in the test command,
-                    # because the source dir isn't visible on the simulator.
-                    if (
-                        "{project}" in build_options.test_command
-                        or "{package}" in build_options.test_command
-                    ):
-                        msg = unwrap_preserving_paragraphs(
-                            f"""
-                            iOS tests configured with a test command that uses the "{{project}}" or
-                            "{{package}}" placeholder. iOS tests cannot use placeholders, because the
-                            source directory is not visible on the simulator.
-
-                            In addition, iOS tests must run as a Python module, so the test command
-                            must begin with 'python -m'.
+                        Test command: {build_options.test_command!r}
+                    """)
+                    log.warning(msg)
+                    final_command = ["pytest", *rest]
+                case _:
+                    msg = unwrap_preserving_paragraphs(
+                        f"""
+                            iOS tests configured with a test command which doesn't start
+                            with 'python -m'. iOS tests must execute python modules - other
+                            entrypoints are not supported.
 
                             Test command: {build_options.test_command!r}
-                            """
-                        )
-                        raise errors.FatalError(msg)
-
-                    test_command_list = shlex.split(build_options.test_command)
-                    try:
-                        for test_command_parts in split_command(test_command_list):
-                            match test_command_parts:
-                                case ["python", "-m", *rest]:
-                                    final_command = rest
-                                case ["pytest", *rest]:
-                                    # pytest works exactly the same as a module, so we
-                                    # can just run it as a module.
-                                    msg = unwrap_preserving_paragraphs(f"""
-                                        iOS tests configured with a test command which doesn't start
-                                        with 'python -m'. iOS tests must execute python modules - other
-                                        entrypoints are not supported.
-
-                                        cibuildwheel will try to execute it as if it started with
-                                        'python -m'. If this works, all you need to do is add that to
-                                        your test command.
-
-                                        Test command: {build_options.test_command!r}
-                                    """)
-                                    log.warning(msg)
-                                    final_command = ["pytest", *rest]
-                                case _:
-                                    msg = unwrap_preserving_paragraphs(
-                                        f"""
-                                            iOS tests configured with a test command which doesn't start
-                                            with 'python -m'. iOS tests must execute python modules - other
-                                            entrypoints are not supported.
-
-                                            Test command: {build_options.test_command!r}
-                                        """
-                                    )
-                                    raise errors.FatalError(msg)
-
-                            test_runtime_args = build_options.test_runtime.args
-
-                            # 2025-10: The GitHub Actions macos-15 runner has a known issue where
-                            # the default simulator won't start due to a disk performance issue;
-                            # see https://github.com/actions/runner-images/issues/12777 for details.
-                            # In the meantime, if it looks like we're running on a GitHub Actions
-                            # macos-15 runner, use a simulator that is known to work, unless the
-                            # user explicitly specifies a simulator.
-                            os_version, _, arch = platform.mac_ver()
-                            if (
-                                "GITHUB_ACTIONS" in os.environ
-                                and os_version.startswith("15.")
-                                and arch == "arm64"
-                                and not any(
-                                    arg.startswith("--simulator") for arg in test_runtime_args
-                                )
-                            ):
-                                test_runtime_args = [
-                                    "--simulator",
-                                    "iPhone 16e,OS=18.5",
-                                    *test_runtime_args,
-                                ]
-
-                            call(
-                                "python",
-                                testbed_path,
-                                "run",
-                                *(["--verbose"] if build_options.build_verbosity > 0 else []),
-                                *test_runtime_args,
-                                "--",
-                                *final_command,
-                                env=test_env,
-                            )
-                    except subprocess.CalledProcessError:
-                        # catches the first test command failure in the loop,
-                        # implementing short-circuiting
-                        log.step_end(success=False)
-                        log.error(f"Test suite failed on {config.identifier}")
-                        sys.exit(1)
-
-                    log.step_end()
-
-            # We're all done here; move it to output (overwrite existing)
-            output_wheel: Path | None = None
-            if compatible_wheel is None:
-                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
-                moved_wheel = move_file(repaired_wheel, output_wheel)
-                if moved_wheel != output_wheel.resolve():
-                    log.warning(
-                        f"{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
+                        """
                     )
-                built_wheels.append(output_wheel)
+                    raise errors.FatalError(msg)
 
-            # Clean up
-            shutil.rmtree(identifier_tmp_dir)
+            test_runtime_args = build_options.test_runtime.args
 
-            log.build_end(output_wheel)
-    except subprocess.CalledProcessError as error:
-        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
-        raise errors.FatalError(msg) from error
+            # 2025-10: The GitHub Actions macos-15 runner has a known issue where
+            # the default simulator won't start due to a disk performance issue;
+            # see https://github.com/actions/runner-images/issues/12777 for details.
+            # In the meantime, if it looks like we're running on a GitHub Actions
+            # macos-15 runner, use a simulator that is known to work, unless the
+            # user explicitly specifies a simulator.
+            os_version, _, arch = platform.mac_ver()
+            if (
+                "GITHUB_ACTIONS" in os.environ
+                and os_version.startswith("15.")
+                and arch == "arm64"
+                and not any(arg.startswith("--simulator") for arg in test_runtime_args)
+            ):
+                test_runtime_args = [
+                    "--simulator",
+                    "iPhone 16e,OS=18.5",
+                    *test_runtime_args,
+                ]
+
+            call(
+                "python",
+                testbed_path,
+                "run",
+                *(["--verbose"] if build_options.build_verbosity > 0 else []),
+                *test_runtime_args,
+                "--",
+                *final_command,
+                env=test_env,
+            )
+    except subprocess.CalledProcessError:
+        # catches the first test command failure in the loop,
+        # implementing short-circuiting
+        log.step_end(success=False)
+        log.error(f"Test suite failed on {config.identifier}")
+        sys.exit(1)
+
+    log.step_end()
+
+
+def teardown(state: BuildState) -> None:
+    shutil.rmtree(state.identifier_tmp_dir)

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -7,7 +7,6 @@ import os
 import platform
 import re
 import shutil
-import subprocess
 import sys
 import typing
 from pathlib import Path
@@ -16,8 +15,7 @@ from typing import assert_never
 from filelock import FileLock
 from packaging.version import Version
 
-from cibuildwheel import errors
-from cibuildwheel.audit import run_audit
+from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.ci import detect_ci_provider
 from cibuildwheel.frontend import (
     BuildFrontendName,
@@ -25,27 +23,27 @@ from cibuildwheel.frontend import (
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
+from cibuildwheel.platforms._run import run_host_build
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
     CIBW_CACHE_PATH,
     copy_test_sources,
     download,
-    move_file,
     remove_on_error,
 )
 from cibuildwheel.util.helpers import prepare_command, unwrap
-from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
+from cibuildwheel.util.packaging import get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, target_marker_env, virtualenv
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Set
+    from collections.abc import Sequence, Set
     from typing import Literal
 
     from cibuildwheel.architecture import Architecture
     from cibuildwheel.environment import ParsedEnvironment
-    from cibuildwheel.options import Options
+    from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
 
 
@@ -433,344 +431,337 @@ def setup_python(
     return base_python, env
 
 
+@dataclasses.dataclass(frozen=True)
+class BuildState:
+    config: PythonConfiguration
+    options: BuildOptions
+    identifier_tmp_dir: Path
+    base_python: Path
+    env: dict[str, str]
+    pip_version: str | None
+
+
 def build(options: Options, tmp_path: Path) -> None:
-    python_configurations = get_python_configurations(
-        options.globals.build_selector, options.globals.architectures
+    run_host_build(platforms.macos, options, tmp_path)
+
+
+def before_all(options: Options, python_configurations: Sequence[PythonConfiguration]) -> None:
+    before_all_options = options.build_options(python_configurations[0].identifier)
+    if before_all_options.before_all:
+        log.step("Running before_all...")
+        env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+        env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
+        before_all_prepared = prepare_command(
+            before_all_options.before_all, project=".", package=before_all_options.package_dir
+        )
+        shell(before_all_prepared, env=env)
+
+
+def setup(config: PythonConfiguration, options: Options, tmp_path: Path) -> BuildState:
+    build_options = options.build_options(config.identifier)
+    build_frontend = build_options.build_frontend
+    use_uv = build_frontend.name in {"build[uv]", "uv"}
+    if use_uv and find_uv() is None:
+        msg = "uv not found"
+        raise AssertionError(msg)
+
+    identifier_tmp_dir = tmp_path / config.identifier
+    identifier_tmp_dir.mkdir()
+
+    constraints_path = build_options.dependency_constraints.get_for_python_version(
+        version=config.version, tmp_dir=identifier_tmp_dir
     )
 
-    if not python_configurations:
-        return
+    base_python, env = setup_python(
+        identifier_tmp_dir / "build",
+        config,
+        constraints_path,
+        build_options.environment,
+        build_frontend.name,
+    )
+    env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+    pip_version = None if use_uv else get_pip_version(env)
+
+    return BuildState(config, build_options, identifier_tmp_dir, base_python, env, pip_version)
+
+
+def before_build(state: BuildState) -> None:
+    build_options = state.options
+    if build_options.before_build:
+        log.step("Running before_build...")
+        before_build_prepared = prepare_command(
+            build_options.before_build, project=".", package=build_options.package_dir
+        )
+        shell(before_build_prepared, env=state.env)
+
+
+def build_wheel(state: BuildState) -> Path:
+    build_options = state.options
+    build_frontend = build_options.build_frontend
+    use_uv = build_frontend.name in {"build[uv]", "uv"}
+    uv_path = find_uv()
+    built_wheel_dir = state.identifier_tmp_dir / "built_wheel"
+
+    log.step("Building wheel...")
+    built_wheel_dir.mkdir()
+
+    extra_flags = get_build_frontend_extra_flags(
+        build_frontend,
+        build_options.build_verbosity,
+        prepare_config_settings(
+            build_options.config_settings,
+            project=".",
+            package=build_options.package_dir,
+        ),
+    )
+
+    build_env = state.env.copy()
+
+    match build_frontend.name:
+        case "pip":
+            # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
+            # see https://github.com/pypa/cibuildwheel/pull/369
+            call(
+                "python",
+                "-m",
+                "pip",
+                "wheel",
+                build_options.package_dir.resolve(),
+                f"--wheel-dir={built_wheel_dir}",
+                "--no-deps",
+                *extra_flags,
+                env=build_env,
+            )
+        case "build" | "build[uv]":
+            if use_uv and "--no-isolation" not in extra_flags and "-n" not in extra_flags:
+                extra_flags.append("--installer=uv")
+            call(
+                "python",
+                "-m",
+                "build",
+                build_options.package_dir,
+                "--wheel",
+                f"--outdir={built_wheel_dir}",
+                *extra_flags,
+                env=build_env,
+            )
+        case "uv":
+            assert uv_path is not None
+            call(
+                uv_path,
+                "build",
+                f"--python={state.base_python}",
+                build_options.package_dir,
+                "--wheel",
+                f"--out-dir={built_wheel_dir}",
+                *extra_flags,
+                env=build_env,
+            )
+        case _:
+            assert_never(build_frontend)
+
+    built_wheel = next(built_wheel_dir.glob("*.whl"))
+    if built_wheel.name.endswith("none-any.whl"):
+        raise errors.NonPlatformWheelError()
+    return built_wheel
+
+
+def repair_wheel(state: BuildState, built_wheel: Path) -> Path:
+    build_options = state.options
+    config_is_arm64 = state.config.identifier.endswith("arm64")
+    config_is_universal2 = state.config.identifier.endswith("universal2")
+    repaired_wheel_dir = state.identifier_tmp_dir / "repaired_wheel"
+    repaired_wheel_dir.mkdir()
+
+    if build_options.repair_command:
+        log.step("Repairing wheel...")
+
+        if config_is_universal2:
+            delocate_archs = "x86_64,arm64"
+        elif config_is_arm64:
+            delocate_archs = "arm64"
+        else:
+            delocate_archs = "x86_64"
+
+        repair_command_prepared = prepare_command(
+            build_options.repair_command,
+            wheel=built_wheel,
+            dest_dir=repaired_wheel_dir,
+            delocate_archs=delocate_archs,
+            package=build_options.package_dir,
+            project=".",
+        )
+        shell(repair_command_prepared, env=state.env)
+    else:
+        shutil.move(str(built_wheel), repaired_wheel_dir)
 
     try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+        repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
+    except StopIteration:
+        raise errors.RepairStepProducedNoWheelError() from None
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            env.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
-            before_all_prepared = prepare_command(
-                before_all_options.before_all, project=".", package=before_all_options.package_dir
-            )
-            shell(before_all_prepared, env=env)
+    log.step_end()
+    return repaired_wheel
 
-        built_wheels: list[Path] = []
 
-        for config in python_configurations:
-            build_options = options.build_options(config.identifier)
-            build_frontend = build_options.build_frontend
-            use_uv = build_frontend.name in {"build[uv]", "uv"}
-            uv_path = find_uv()
-            if use_uv and uv_path is None:
-                msg = "uv not found"
-                raise AssertionError(msg)
-            pip = ["pip"] if not use_uv else [str(uv_path), "pip"]
-            log.build_start(config.identifier)
+def test_wheel(state: BuildState, wheel: Path) -> None:
+    build_options = state.options
+    config = state.config
+    if not (build_options.test_command and build_options.test_selector(config.identifier)):
+        return
 
-            identifier_tmp_dir = tmp_path / config.identifier
-            identifier_tmp_dir.mkdir()
-            built_wheel_dir = identifier_tmp_dir / "built_wheel"
-            repaired_wheel_dir = identifier_tmp_dir / "repaired_wheel"
+    config_is_arm64 = config.identifier.endswith("arm64")
+    config_is_universal2 = config.identifier.endswith("universal2")
+    use_uv = build_options.build_frontend.name in {"build[uv]", "uv"}
+    uv_path = find_uv()
+    pip = ["pip"] if not use_uv else [str(uv_path), "pip"]
 
-            config_is_arm64 = config.identifier.endswith("arm64")
-            config_is_universal2 = config.identifier.endswith("universal2")
+    machine_arch = platform.machine()
+    testing_archs: list[Literal["x86_64", "arm64"]]
 
-            constraints_path = build_options.dependency_constraints.get_for_python_version(
-                version=config.version, tmp_dir=identifier_tmp_dir
-            )
+    if config_is_arm64:
+        testing_archs = ["arm64"]
+    elif config_is_universal2:
+        testing_archs = ["x86_64", "arm64"]
+    else:
+        testing_archs = ["x86_64"]
 
-            base_python, env = setup_python(
-                identifier_tmp_dir / "build",
-                config,
-                constraints_path,
-                build_options.environment,
-                build_frontend.name,
-            )
-            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
-            pip_version = None if use_uv else get_pip_version(env)
+    for testing_arch in testing_archs:
+        if config_is_universal2:
+            arch_specific_identifier = f"{config.identifier}:{testing_arch}"
+            if not build_options.test_selector(arch_specific_identifier):
+                continue
 
-            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
-            if compatible_wheel:
-                log.step_end()
-                print(
-                    f"\nFound previously built wheel {compatible_wheel.name}, that's compatible with {config.identifier}. Skipping build step..."
+        if machine_arch == "x86_64" and testing_arch == "arm64":
+            if config_is_arm64:
+                log.warning(
+                    unwrap(
+                        """
+                        While arm64 wheels can be built on x86_64, they cannot be
+                        tested. Consider building arm64 wheels natively, if your CI
+                        provider offers this. To silence this warning, set
+                        `CIBW_TEST_SKIP: "*-macosx_arm64"`.
+                        """
+                    )
                 )
-                repaired_wheel = compatible_wheel
+            elif config_is_universal2:
+                log.warning(
+                    unwrap(
+                        """
+                        While universal2 wheels can be built on x86_64, the arm64 part
+                        of the wheel cannot be tested on x86_64. Consider building
+                        universal2 wheels on an arm64 runner, if your CI provider offers
+                        this. Notably, an arm64 runner can also test the x86_64 part of
+                        the wheel, through Rosetta emulation. To silence this warning,
+                        set `CIBW_TEST_SKIP: "*-macosx_universal2:arm64"`.
+                        """
+                    )
+                )
             else:
-                if build_options.before_build:
-                    log.step("Running before_build...")
-                    before_build_prepared = prepare_command(
-                        build_options.before_build, project=".", package=build_options.package_dir
-                    )
-                    shell(before_build_prepared, env=env)
+                msg = "unreachable"
+                raise RuntimeError(msg)
 
-                log.step("Building wheel...")
-                built_wheel_dir.mkdir()
+            # skip this test
+            continue
 
-                extra_flags = get_build_frontend_extra_flags(
-                    build_frontend,
-                    build_options.build_verbosity,
-                    prepare_config_settings(
-                        build_options.config_settings,
-                        project=".",
-                        package=build_options.package_dir,
-                    ),
+        log.step(
+            "Testing wheel..."
+            if testing_arch == machine_arch
+            else f"Testing wheel on {testing_arch}..."
+        )
+
+        arch_prefix = []
+        uv_arch_args = []
+        if testing_arch != machine_arch:
+            if machine_arch == "arm64" and testing_arch == "x86_64":
+                # rosetta2 will provide the emulation with just the arch prefix.
+                arch_prefix = ["arch", "-x86_64"]
+                uv_arch_args = ["--python-platform", "x86_64-apple-darwin"]
+            else:
+                msg = f"don't know how to emulate {testing_arch} on {machine_arch}"
+                raise RuntimeError(msg)
+
+        # define a custom 'call' function that adds the arch prefix each time
+        call_with_arch = functools.partial(call, *arch_prefix)
+        shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")
+
+        # set up a virtual environment to install and test from, to make sure
+        # there are no dependencies that were pulled in at build time.
+        venv_dir = state.identifier_tmp_dir / f"venv-test-{testing_arch}"
+        virtualenv_env = virtualenv(
+            config.version,
+            state.base_python,
+            venv_dir,
+            None,
+            use_uv=use_uv,
+            env=state.env,
+            pip_version=state.pip_version,
+        )
+        if use_uv:
+            pip_install = functools.partial(call, *pip, "install", *uv_arch_args)
+        else:
+            pip_install = functools.partial(call_with_arch, *pip, "install")
+
+        virtualenv_env["MACOSX_DEPLOYMENT_TARGET"] = get_test_macosx_deployment_target()
+
+        virtualenv_env = build_options.test_environment.as_dictionary(
+            prev_environment=virtualenv_env
+        )
+
+        # check that we are using the Python from the virtual environment
+        call_with_arch("which", "python", env=virtualenv_env)
+
+        if build_options.before_test:
+            before_test_prepared = prepare_command(
+                build_options.before_test,
+                project=".",
+                package=build_options.package_dir,
+            )
+            shell_with_arch(before_test_prepared, env=virtualenv_env)
+
+        # install the wheel
+        pip_install(
+            f"{wheel}{build_options.test_extras}",
+            env=virtualenv_env,
+        )
+
+        # test the wheel
+        if build_options.test_requires:
+            pip_install(
+                *build_options.test_requires,
+                env=virtualenv_env,
+            )
+
+        # run the tests from a temp dir, with an absolute path in the command
+        # (this ensures that Python runs the tests against the installed wheel
+        # and not the repo code)
+        test_command_prepared = prepare_command(
+            build_options.test_command,
+            project=Path.cwd(),
+            package=build_options.package_dir.resolve(),
+            wheel=wheel,
+        )
+
+        test_cwd = state.identifier_tmp_dir / "test_cwd"
+
+        if build_options.test_sources:
+            # only create test_cwd if it doesn't already exist - it
+            # may have been created during a previous `testing_arch`
+            if not test_cwd.exists():
+                test_cwd.mkdir()
+                copy_test_sources(
+                    build_options.test_sources,
+                    Path.cwd(),
+                    test_cwd,
                 )
+        else:
+            # Use the test_fail.py file to raise a nice error if the user
+            # tries to run tests in the cwd
+            test_cwd.mkdir(exist_ok=True)
+            (test_cwd / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
 
-                build_env = env.copy()
+        shell_with_arch(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
 
-                match build_frontend.name:
-                    case "pip":
-                        # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
-                        # see https://github.com/pypa/cibuildwheel/pull/369
-                        call(
-                            "python",
-                            "-m",
-                            "pip",
-                            "wheel",
-                            build_options.package_dir.resolve(),
-                            f"--wheel-dir={built_wheel_dir}",
-                            "--no-deps",
-                            *extra_flags,
-                            env=build_env,
-                        )
-                    case "build" | "build[uv]":
-                        if (
-                            use_uv
-                            and "--no-isolation" not in extra_flags
-                            and "-n" not in extra_flags
-                        ):
-                            extra_flags.append("--installer=uv")
-                        call(
-                            "python",
-                            "-m",
-                            "build",
-                            build_options.package_dir,
-                            "--wheel",
-                            f"--outdir={built_wheel_dir}",
-                            *extra_flags,
-                            env=build_env,
-                        )
-                    case "uv":
-                        assert uv_path is not None
-                        call(
-                            uv_path,
-                            "build",
-                            f"--python={base_python}",
-                            build_options.package_dir,
-                            "--wheel",
-                            f"--out-dir={built_wheel_dir}",
-                            *extra_flags,
-                            env=build_env,
-                        )
-                    case _:
-                        assert_never(build_frontend)
 
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
-
-                repaired_wheel_dir.mkdir()
-
-                if built_wheel.name.endswith("none-any.whl"):
-                    raise errors.NonPlatformWheelError()
-
-                if build_options.repair_command:
-                    log.step("Repairing wheel...")
-
-                    if config_is_universal2:
-                        delocate_archs = "x86_64,arm64"
-                    elif config_is_arm64:
-                        delocate_archs = "arm64"
-                    else:
-                        delocate_archs = "x86_64"
-
-                    repair_command_prepared = prepare_command(
-                        build_options.repair_command,
-                        wheel=built_wheel,
-                        dest_dir=repaired_wheel_dir,
-                        delocate_archs=delocate_archs,
-                        package=build_options.package_dir,
-                        project=".",
-                    )
-                    shell(repair_command_prepared, env=env)
-                else:
-                    shutil.move(str(built_wheel), repaired_wheel_dir)
-
-                try:
-                    repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
-                except StopIteration:
-                    raise errors.RepairStepProducedNoWheelError() from None
-
-                if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
-
-                log.step_end()
-
-                run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
-
-            if build_options.test_command and build_options.test_selector(config.identifier):
-                machine_arch = platform.machine()
-                testing_archs: list[Literal["x86_64", "arm64"]]
-
-                if config_is_arm64:
-                    testing_archs = ["arm64"]
-                elif config_is_universal2:
-                    testing_archs = ["x86_64", "arm64"]
-                else:
-                    testing_archs = ["x86_64"]
-
-                for testing_arch in testing_archs:
-                    if config_is_universal2:
-                        arch_specific_identifier = f"{config.identifier}:{testing_arch}"
-                        if not build_options.test_selector(arch_specific_identifier):
-                            continue
-
-                    if machine_arch == "x86_64" and testing_arch == "arm64":
-                        if config_is_arm64:
-                            log.warning(
-                                unwrap(
-                                    """
-                                    While arm64 wheels can be built on x86_64, they cannot be
-                                    tested. Consider building arm64 wheels natively, if your CI
-                                    provider offers this. To silence this warning, set
-                                    `CIBW_TEST_SKIP: "*-macosx_arm64"`.
-                                    """
-                                )
-                            )
-                        elif config_is_universal2:
-                            log.warning(
-                                unwrap(
-                                    """
-                                    While universal2 wheels can be built on x86_64, the arm64 part
-                                    of the wheel cannot be tested on x86_64. Consider building
-                                    universal2 wheels on an arm64 runner, if your CI provider offers
-                                    this. Notably, an arm64 runner can also test the x86_64 part of
-                                    the wheel, through Rosetta emulation. To silence this warning,
-                                    set `CIBW_TEST_SKIP: "*-macosx_universal2:arm64"`.
-                                    """
-                                )
-                            )
-                        else:
-                            msg = "unreachable"
-                            raise RuntimeError(msg)
-
-                        # skip this test
-                        continue
-
-                    log.step(
-                        "Testing wheel..."
-                        if testing_arch == machine_arch
-                        else f"Testing wheel on {testing_arch}..."
-                    )
-
-                    arch_prefix = []
-                    uv_arch_args = []
-                    if testing_arch != machine_arch:
-                        if machine_arch == "arm64" and testing_arch == "x86_64":
-                            # rosetta2 will provide the emulation with just the arch prefix.
-                            arch_prefix = ["arch", "-x86_64"]
-                            uv_arch_args = ["--python-platform", "x86_64-apple-darwin"]
-                        else:
-                            msg = f"don't know how to emulate {testing_arch} on {machine_arch}"
-                            raise RuntimeError(msg)
-
-                    # define a custom 'call' function that adds the arch prefix each time
-                    call_with_arch = functools.partial(call, *arch_prefix)
-                    shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")
-
-                    # set up a virtual environment to install and test from, to make sure
-                    # there are no dependencies that were pulled in at build time.
-                    venv_dir = identifier_tmp_dir / f"venv-test-{testing_arch}"
-                    virtualenv_env = virtualenv(
-                        config.version,
-                        base_python,
-                        venv_dir,
-                        None,
-                        use_uv=use_uv,
-                        env=env,
-                        pip_version=pip_version,
-                    )
-                    if use_uv:
-                        pip_install = functools.partial(call, *pip, "install", *uv_arch_args)
-                    else:
-                        pip_install = functools.partial(call_with_arch, *pip, "install")
-
-                    virtualenv_env["MACOSX_DEPLOYMENT_TARGET"] = get_test_macosx_deployment_target()
-
-                    virtualenv_env = build_options.test_environment.as_dictionary(
-                        prev_environment=virtualenv_env
-                    )
-
-                    # check that we are using the Python from the virtual environment
-                    call_with_arch("which", "python", env=virtualenv_env)
-
-                    if build_options.before_test:
-                        before_test_prepared = prepare_command(
-                            build_options.before_test,
-                            project=".",
-                            package=build_options.package_dir,
-                        )
-                        shell_with_arch(before_test_prepared, env=virtualenv_env)
-
-                    # install the wheel
-                    pip_install(
-                        f"{repaired_wheel}{build_options.test_extras}",
-                        env=virtualenv_env,
-                    )
-
-                    # test the wheel
-                    if build_options.test_requires:
-                        pip_install(
-                            *build_options.test_requires,
-                            env=virtualenv_env,
-                        )
-
-                    # run the tests from a temp dir, with an absolute path in the command
-                    # (this ensures that Python runs the tests against the installed wheel
-                    # and not the repo code)
-                    test_command_prepared = prepare_command(
-                        build_options.test_command,
-                        project=Path.cwd(),
-                        package=build_options.package_dir.resolve(),
-                        wheel=repaired_wheel,
-                    )
-
-                    test_cwd = identifier_tmp_dir / "test_cwd"
-
-                    if build_options.test_sources:
-                        # only create test_cwd if it doesn't already exist - it
-                        # may have been created during a previous `testing_arch`
-                        if not test_cwd.exists():
-                            test_cwd.mkdir()
-                            copy_test_sources(
-                                build_options.test_sources,
-                                Path.cwd(),
-                                test_cwd,
-                            )
-                    else:
-                        # Use the test_fail.py file to raise a nice error if the user
-                        # tries to run tests in the cwd
-                        test_cwd.mkdir(exist_ok=True)
-                        (test_cwd / "test_fail.py").write_text(
-                            resources.TEST_FAIL_CWD_FILE.read_text()
-                        )
-
-                    shell_with_arch(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
-
-            # we're all done here; move it to output (overwrite existing)
-            output_wheel = None
-            if compatible_wheel is None:
-                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
-                moved_wheel = move_file(repaired_wheel, output_wheel)
-                if moved_wheel != output_wheel.resolve():
-                    log.warning(
-                        f"{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
-                    )
-                built_wheels.append(output_wheel)
-
-            # clean up
-            shutil.rmtree(identifier_tmp_dir)
-
-            log.build_end(output_wheel)
-    except subprocess.CalledProcessError as error:
-        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
-        raise errors.FatalError(msg) from error
+def teardown(state: BuildState) -> None:
+    shutil.rmtree(state.identifier_tmp_dir)

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -5,7 +5,6 @@ import functools
 import json
 import os
 import shutil
-import subprocess
 import sys
 import tomllib
 import typing
@@ -15,11 +14,11 @@ from typing import Final, TypedDict
 
 from filelock import FileLock
 
-from cibuildwheel import errors
+from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.architecture import Architecture
-from cibuildwheel.audit import run_audit
 from cibuildwheel.frontend import get_build_frontend_extra_flags, prepare_config_settings
 from cibuildwheel.logger import log
+from cibuildwheel.platforms._run import run_host_build
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -28,11 +27,10 @@ from cibuildwheel.util.file import (
     download,
     extract_tar,
     extract_zip,
-    move_file,
     remove_on_error,
 )
 from cibuildwheel.util.helpers import prepare_command, unwrap, unwrap_preserving_paragraphs
-from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
+from cibuildwheel.util.packaging import get_pip_version
 from cibuildwheel.util.python_build_standalone import (
     PythonBuildStandaloneError,
     create_python_build_standalone_environment,
@@ -41,10 +39,10 @@ from cibuildwheel.venv import constraint_flags, virtualenv
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Set
+    from collections.abc import Sequence, Set
 
     from cibuildwheel.environment import ParsedEnvironment
-    from cibuildwheel.options import Options
+    from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
 
 IS_WIN: Final[bool] = sys.platform.startswith("win")
@@ -345,235 +343,229 @@ def get_python_configurations(
     return [c for c in all_python_configurations() if build_selector(c.identifier)]
 
 
+@dataclasses.dataclass(frozen=True)
+class BuildState:
+    config: PythonConfiguration
+    options: BuildOptions
+    identifier_tmp_dir: Path
+    env: dict[str, str]
+    pip_version: str
+
+
 def build(options: Options, tmp_path: Path) -> None:
-    python_configurations = get_python_configurations(
-        options.globals.build_selector, options.globals.architectures
+    run_host_build(platforms.pyodide, options, tmp_path)
+
+
+def before_all(options: Options, python_configurations: Sequence[PythonConfiguration]) -> None:
+    before_all_options = options.build_options(python_configurations[0].identifier)
+    if before_all_options.before_all:
+        log.step("Running before_all...")
+        env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+        before_all_prepared = prepare_command(
+            before_all_options.before_all, project=".", package=before_all_options.package_dir
+        )
+        shell(before_all_prepared, env=env)
+
+
+def setup(config: PythonConfiguration, options: Options, tmp_path: Path) -> BuildState:
+    build_options = options.build_options(config.identifier)
+    build_frontend = build_options.build_frontend
+
+    if build_frontend.name == "pip":
+        msg = "The pyodide platform doesn't support pip frontend"
+        raise errors.FatalError(msg)
+
+    identifier_tmp_dir = tmp_path / config.identifier
+    identifier_tmp_dir.mkdir()
+
+    constraints_path = build_options.dependency_constraints.get_for_python_version(
+        version=config.version, variant="pyodide", tmp_dir=identifier_tmp_dir
     )
 
-    if not python_configurations:
+    env = setup_python(
+        tmp=identifier_tmp_dir / "build",
+        python_configuration=config,
+        constraints_path=constraints_path,
+        environment=build_options.environment,
+        user_pyodide_version=build_options.pyodide_version,
+    )
+    env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+    pip_version = get_pip_version(env)
+    # The Pyodide command line runner mounts all directories in the host
+    # filesystem into the Pyodide file system, except for the custom
+    # file systems /dev, /lib, /proc, and /tmp. Mounting the mount
+    # points for alternate file systems causes some mysterious failure
+    # of the process (it just quits without any clear error).
+    #
+    # Because of this, by default Pyodide can't see anything under /tmp.
+    # This environment variable tells it also to mount our temp
+    # directory.
+    oldmounts = ""
+    extra_mounts = [str(identifier_tmp_dir)]
+    if Path.cwd().is_relative_to("/tmp"):
+        extra_mounts.append(str(Path.cwd()))
+
+    if "_PYODIDE_EXTRA_MOUNTS" in env:
+        oldmounts = env["_PYODIDE_EXTRA_MOUNTS"] + ":"
+    env["_PYODIDE_EXTRA_MOUNTS"] = oldmounts + ":".join(extra_mounts)
+
+    return BuildState(config, build_options, identifier_tmp_dir, env, pip_version)
+
+
+def before_build(state: BuildState) -> None:
+    build_options = state.options
+    if build_options.before_build:
+        log.step("Running before_build...")
+        before_build_prepared = prepare_command(
+            build_options.before_build, project=".", package=build_options.package_dir
+        )
+        shell(before_build_prepared, env=state.env)
+
+
+def build_wheel(state: BuildState) -> Path:
+    build_options = state.options
+    built_wheel_dir = state.identifier_tmp_dir / "built_wheel"
+    built_wheel_dir.mkdir()
+
+    log.step("Building wheel...")
+
+    extra_flags = get_build_frontend_extra_flags(
+        build_options.build_frontend,
+        build_options.build_verbosity,
+        prepare_config_settings(
+            build_options.config_settings,
+            project=".",
+            package=build_options.package_dir,
+        ),
+    )
+
+    call(
+        "pyodide",
+        "build",
+        build_options.package_dir,
+        f"--outdir={built_wheel_dir}",
+        *extra_flags,
+        env=state.env,
+    )
+    built_wheel = next(built_wheel_dir.glob("*.whl"))
+
+    if built_wheel.name.endswith("none-any.whl"):
+        raise errors.NonPlatformWheelError()
+    return built_wheel
+
+
+def repair_wheel(state: BuildState, built_wheel: Path) -> Path:
+    build_options = state.options
+    repaired_wheel_dir = state.identifier_tmp_dir / "repaired_wheel"
+    repaired_wheel_dir.mkdir()
+
+    if build_options.repair_command:
+        log.step("Repairing wheel...")
+
+        repair_command_prepared = prepare_command(
+            build_options.repair_command,
+            wheel=built_wheel,
+            dest_dir=repaired_wheel_dir,
+            package=build_options.package_dir,
+            project=".",
+        )
+        shell(repair_command_prepared, env=state.env)
+        log.step_end()
+    else:
+        shutil.move(str(built_wheel), repaired_wheel_dir)
+
+    return next(repaired_wheel_dir.glob("*.whl"))
+
+
+def test_wheel(state: BuildState, wheel: Path) -> None:
+    build_options = state.options
+    config = state.config
+    if not (build_options.test_command and build_options.test_selector(config.identifier)):
         return
 
-    try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+    log.step("Testing wheel...")
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            before_all_prepared = prepare_command(
-                before_all_options.before_all, project=".", package=before_all_options.package_dir
-            )
-            shell(before_all_prepared, env=env)
+    venv_dir = state.identifier_tmp_dir / "venv-test"
+    # set up a virtual environment to install and test from, to make sure
+    # there are no dependencies that were pulled in at build time.
 
-        built_wheels: list[Path] = []
+    virtualenv_env = state.env.copy()
+    virtualenv_env["PATH"] = os.pathsep.join(
+        [
+            str(ensure_node(config.node_version)),
+            virtualenv_env["PATH"],
+        ]
+    )
 
-        for config in python_configurations:
-            build_options = options.build_options(config.identifier)
-            build_frontend = build_options.build_frontend
+    # pyodide venv uses virtualenv under the hood
+    # use the pip embedded with virtualenv & disable network updates
+    virtualenv_create_env = virtualenv_env.copy()
+    virtualenv_create_env["VIRTUALENV_PIP"] = state.pip_version
+    virtualenv_create_env["VIRTUALENV_NO_PERIODIC_UPDATE"] = "1"
 
-            if build_frontend.name == "pip":
-                msg = "The pyodide platform doesn't support pip frontend"
-                raise errors.FatalError(msg)
+    call("pyodide", "venv", venv_dir, env=virtualenv_create_env)
 
-            log.build_start(config.identifier)
+    virtualenv_env["PATH"] = os.pathsep.join(
+        [
+            str(venv_dir / "bin"),
+            virtualenv_env["PATH"],
+        ]
+    )
+    virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
 
-            identifier_tmp_dir = tmp_path / config.identifier
+    virtualenv_env = build_options.test_environment.as_dictionary(prev_environment=virtualenv_env)
 
-            built_wheel_dir = identifier_tmp_dir / "built_wheel"
-            repaired_wheel_dir = identifier_tmp_dir / "repaired_wheel"
-            identifier_tmp_dir.mkdir()
-            built_wheel_dir.mkdir()
-            repaired_wheel_dir.mkdir()
+    # check that we are using the Python from the virtual environment
+    call("which", "python", env=virtualenv_env)
 
-            constraints_path = build_options.dependency_constraints.get_for_python_version(
-                version=config.version, variant="pyodide", tmp_dir=identifier_tmp_dir
-            )
+    if build_options.before_test:
+        before_test_prepared = prepare_command(
+            build_options.before_test,
+            project=".",
+            package=build_options.package_dir,
+            wheel=wheel,
+        )
+        shell(before_test_prepared, env=virtualenv_env)
 
-            env = setup_python(
-                tmp=identifier_tmp_dir / "build",
-                python_configuration=config,
-                constraints_path=constraints_path,
-                environment=build_options.environment,
-                user_pyodide_version=build_options.pyodide_version,
-            )
-            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
-            pip_version = get_pip_version(env)
-            # The Pyodide command line runner mounts all directories in the host
-            # filesystem into the Pyodide file system, except for the custom
-            # file systems /dev, /lib, /proc, and /tmp. Mounting the mount
-            # points for alternate file systems causes some mysterious failure
-            # of the process (it just quits without any clear error).
-            #
-            # Because of this, by default Pyodide can't see anything under /tmp.
-            # This environment variable tells it also to mount our temp
-            # directory.
-            oldmounts = ""
-            extra_mounts = [str(identifier_tmp_dir)]
-            if Path.cwd().is_relative_to("/tmp"):
-                extra_mounts.append(str(Path.cwd()))
+    # install the wheel
+    call(
+        "pip",
+        "install",
+        f"{wheel}{build_options.test_extras}",
+        env=virtualenv_env,
+    )
 
-            if "_PYODIDE_EXTRA_MOUNTS" in env:
-                oldmounts = env["_PYODIDE_EXTRA_MOUNTS"] + ":"
-            env["_PYODIDE_EXTRA_MOUNTS"] = oldmounts + ":".join(extra_mounts)
+    # test the wheel
+    if build_options.test_requires:
+        call("pip", "install", *build_options.test_requires, env=virtualenv_env)
 
-            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
-            if compatible_wheel:
-                log.step_end()
-                print(
-                    f"\nFound previously built wheel {compatible_wheel.name}, that's compatible with {config.identifier}. Skipping build step..."
-                )
-                built_wheel = compatible_wheel
-            else:
-                if build_options.before_build:
-                    log.step("Running before_build...")
-                    before_build_prepared = prepare_command(
-                        build_options.before_build, project=".", package=build_options.package_dir
-                    )
-                    shell(before_build_prepared, env=env)
+    # run the tests from a temp dir, with an absolute path in the command
+    # (this ensures that Python runs the tests against the installed wheel
+    # and not the repo code)
+    test_command_prepared = prepare_command(
+        build_options.test_command,
+        project=Path.cwd(),
+        package=build_options.package_dir.resolve(),
+    )
 
-                log.step("Building wheel...")
+    test_cwd = state.identifier_tmp_dir / "test_cwd"
+    test_cwd.mkdir(exist_ok=True)
 
-                extra_flags = get_build_frontend_extra_flags(
-                    build_frontend,
-                    build_options.build_verbosity,
-                    prepare_config_settings(
-                        build_options.config_settings,
-                        project=".",
-                        package=build_options.package_dir,
-                    ),
-                )
+    if build_options.test_sources:
+        copy_test_sources(
+            build_options.test_sources,
+            Path.cwd(),
+            test_cwd,
+        )
+    else:
+        # Use the test_fail.py file to raise a nice error if the user
+        # tries to run tests in the cwd
+        (test_cwd / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
 
-                call(
-                    "pyodide",
-                    "build",
-                    build_options.package_dir,
-                    f"--outdir={built_wheel_dir}",
-                    *extra_flags,
-                    env=env,
-                )
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+    shell(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
 
-                if built_wheel.name.endswith("none-any.whl"):
-                    raise errors.NonPlatformWheelError()
 
-                if build_options.repair_command:
-                    log.step("Repairing wheel...")
-
-                    repair_command_prepared = prepare_command(
-                        build_options.repair_command,
-                        wheel=built_wheel,
-                        dest_dir=repaired_wheel_dir,
-                        package=build_options.package_dir,
-                        project=".",
-                    )
-                    shell(repair_command_prepared, env=env)
-                    log.step_end()
-                else:
-                    shutil.move(str(built_wheel), repaired_wheel_dir)
-
-                repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
-
-                if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
-
-                run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
-
-            if build_options.test_command and build_options.test_selector(config.identifier):
-                log.step("Testing wheel...")
-
-                venv_dir = identifier_tmp_dir / "venv-test"
-                # set up a virtual environment to install and test from, to make sure
-                # there are no dependencies that were pulled in at build time.
-
-                virtualenv_env = env.copy()
-                virtualenv_env["PATH"] = os.pathsep.join(
-                    [
-                        str(ensure_node(config.node_version)),
-                        virtualenv_env["PATH"],
-                    ]
-                )
-
-                # pyodide venv uses virtualenv under the hood
-                # use the pip embedded with virtualenv & disable network updates
-                virtualenv_create_env = virtualenv_env.copy()
-                virtualenv_create_env["VIRTUALENV_PIP"] = pip_version
-                virtualenv_create_env["VIRTUALENV_NO_PERIODIC_UPDATE"] = "1"
-
-                call("pyodide", "venv", venv_dir, env=virtualenv_create_env)
-
-                virtualenv_env["PATH"] = os.pathsep.join(
-                    [
-                        str(venv_dir / "bin"),
-                        virtualenv_env["PATH"],
-                    ]
-                )
-                virtualenv_env["VIRTUAL_ENV"] = str(venv_dir)
-
-                virtualenv_env = build_options.test_environment.as_dictionary(
-                    prev_environment=virtualenv_env
-                )
-
-                # check that we are using the Python from the virtual environment
-                call("which", "python", env=virtualenv_env)
-
-                if build_options.before_test:
-                    before_test_prepared = prepare_command(
-                        build_options.before_test,
-                        project=".",
-                        package=build_options.package_dir,
-                        wheel=repaired_wheel,
-                    )
-                    shell(before_test_prepared, env=virtualenv_env)
-
-                # install the wheel
-                call(
-                    "pip",
-                    "install",
-                    f"{repaired_wheel}{build_options.test_extras}",
-                    env=virtualenv_env,
-                )
-
-                # test the wheel
-                if build_options.test_requires:
-                    call("pip", "install", *build_options.test_requires, env=virtualenv_env)
-
-                # run the tests from a temp dir, with an absolute path in the command
-                # (this ensures that Python runs the tests against the installed wheel
-                # and not the repo code)
-                test_command_prepared = prepare_command(
-                    build_options.test_command,
-                    project=Path.cwd(),
-                    package=build_options.package_dir.resolve(),
-                )
-
-                test_cwd = identifier_tmp_dir / "test_cwd"
-                test_cwd.mkdir(exist_ok=True)
-
-                if build_options.test_sources:
-                    copy_test_sources(
-                        build_options.test_sources,
-                        Path.cwd(),
-                        test_cwd,
-                    )
-                else:
-                    # Use the test_fail.py file to raise a nice error if the user
-                    # tries to run tests in the cwd
-                    (test_cwd / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
-
-                shell(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
-
-            # we're all done here; move it to output (overwrite existing)
-            output_wheel: Path | None = None
-            if compatible_wheel is None:
-                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
-                moved_wheel = move_file(repaired_wheel, output_wheel)
-                if moved_wheel != output_wheel.resolve():
-                    log.warning(
-                        f"{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
-                    )
-                built_wheels.append(output_wheel)
-            log.build_end(output_wheel)
-
-    except subprocess.CalledProcessError as error:
-        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
-        raise errors.FatalError(msg) from error
+def teardown(state: BuildState) -> None:
+    # Unlike the other platforms, pyodide has never cleaned up its per-identifier
+    # tmp dir here; the whole run tmp_path is removed by the caller at the end.
+    pass

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -5,7 +5,6 @@ import json
 import os
 import platform as platform_module
 import shutil
-import subprocess
 import textwrap
 from functools import cache
 from pathlib import Path
@@ -13,15 +12,15 @@ from typing import assert_never
 
 from filelock import FileLock
 
-from cibuildwheel import errors
+from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.architecture import Architecture
-from cibuildwheel.audit import run_audit
 from cibuildwheel.frontend import (
     BuildFrontendName,
     get_build_frontend_extra_flags,
     prepare_config_settings,
 )
 from cibuildwheel.logger import log
+from cibuildwheel.platforms._run import run_host_build
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -29,11 +28,10 @@ from cibuildwheel.util.file import (
     copy_test_sources,
     download,
     extract_zip,
-    move_file,
     remove_on_error,
 )
 from cibuildwheel.util.helpers import prepare_command, unwrap
-from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
+from cibuildwheel.util.packaging import get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, target_marker_env, virtualenv
 
 TYPE_CHECKING = False
@@ -41,7 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import MutableMapping, Sequence, Set
 
     from cibuildwheel.environment import ParsedEnvironment
-    from cibuildwheel.options import Options
+    from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
 
 
@@ -429,286 +427,277 @@ def setup_python(
     return base_python, env
 
 
+@dataclasses.dataclass(frozen=True)
+class BuildState:
+    config: PythonConfiguration
+    options: BuildOptions
+    identifier_tmp_dir: Path
+    base_python: Path
+    env: dict[str, str]
+    pip_version: str | None
+
+
 def build(options: Options, tmp_path: Path) -> None:
-    python_configurations = get_python_configurations(
-        options.globals.build_selector, options.globals.architectures
+    run_host_build(platforms.windows, options, tmp_path)
+
+
+def before_all(options: Options, python_configurations: Sequence[PythonConfiguration]) -> None:
+    before_all_options = options.build_options(python_configurations[0].identifier)
+    if before_all_options.before_all:
+        log.step("Running before_all...")
+        env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
+        before_all_prepared = prepare_command(
+            before_all_options.before_all, project=".", package=before_all_options.package_dir
+        )
+        shell(before_all_prepared, env=env)
+
+
+def setup(config: PythonConfiguration, options: Options, tmp_path: Path) -> BuildState:
+    build_options = options.build_options(config.identifier)
+    build_frontend = build_options.build_frontend
+    use_uv = build_frontend.name in {"build[uv]", "uv"}
+
+    identifier_tmp_dir = tmp_path / config.identifier
+    identifier_tmp_dir.mkdir()
+
+    constraints_path = build_options.dependency_constraints.get_for_python_version(
+        version=config.version,
+        tmp_dir=identifier_tmp_dir,
     )
 
-    if not python_configurations:
-        return
+    # install Python
+    base_python, env = setup_python(
+        identifier_tmp_dir / "build",
+        config,
+        constraints_path,
+        build_options.environment,
+        build_frontend.name,
+    )
+    env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
+    pip_version = None if use_uv else get_pip_version(env)
 
+    return BuildState(config, build_options, identifier_tmp_dir, base_python, env, pip_version)
+
+
+def before_build(state: BuildState) -> None:
+    build_options = state.options
+    if build_options.before_build:
+        log.step("Running before_build...")
+        before_build_prepared = prepare_command(
+            build_options.before_build,
+            project=".",
+            package=build_options.package_dir,
+        )
+        shell(before_build_prepared, env=state.env)
+
+
+def build_wheel(state: BuildState) -> Path:
+    build_options = state.options
+    config = state.config
+    build_frontend = build_options.build_frontend
+    use_uv = build_frontend.name in {"build[uv]", "uv"}
     uv_path = find_uv()
+    built_wheel_dir = state.identifier_tmp_dir / "built_wheel"
+    env = state.env
+
+    log.step("Building wheel...")
+    built_wheel_dir.mkdir()
+
+    extra_flags = get_build_frontend_extra_flags(
+        build_frontend,
+        build_options.build_verbosity,
+        prepare_config_settings(
+            build_options.config_settings,
+            project=".",
+            package=build_options.package_dir,
+        ),
+    )
+
+    if (
+        config.identifier.startswith("gp311")
+        and build_frontend.name == "build"
+        and "--no-isolation" not in extra_flags
+        and "-n" not in extra_flags
+    ):
+        # GraalPy 24 fails to discover its standard library when a venv is created
+        # from a virtualenv seeded executable. See
+        # https://github.com/oracle/graalpython/issues/491 and remove this once
+        # GraalPy 24 is dropped.
+        log.notice(
+            "Disabling build isolation to workaround GraalPy bug. If the build fails, consider using pip or build[uv] as build frontend."
+        )
+        shell("graalpy -m pip install setuptools wheel", env=env)
+        extra_flags = [*extra_flags, "-n"]
+
+    match build_frontend.name:
+        case "pip":
+            # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
+            # see https://github.com/pypa/cibuildwheel/pull/369
+            call(
+                "python",
+                "-m",
+                "pip",
+                "wheel",
+                build_options.package_dir.resolve(),
+                f"--wheel-dir={built_wheel_dir}",
+                "--no-deps",
+                *extra_flags,
+                env=env,
+            )
+        case "build" | "build[uv]":
+            if use_uv and "--no-isolation" not in extra_flags and "-n" not in extra_flags:
+                extra_flags.append("--installer=uv")
+
+            call(
+                "python",
+                "-m",
+                "build",
+                build_options.package_dir,
+                "--wheel",
+                f"--outdir={built_wheel_dir}",
+                *extra_flags,
+                env=env,
+            )
+        case "uv":
+            assert uv_path is not None
+            call(
+                uv_path,
+                "build",
+                f"--python={state.base_python}",
+                build_options.package_dir,
+                "--wheel",
+                f"--out-dir={built_wheel_dir}",
+                *extra_flags,
+                env=env,
+            )
+        case _:
+            assert_never(build_frontend)
+
+    built_wheel = next(built_wheel_dir.glob("*.whl"))
+    if built_wheel.name.endswith("none-any.whl"):
+        raise errors.NonPlatformWheelError()
+    return built_wheel
+
+
+def repair_wheel(state: BuildState, built_wheel: Path) -> Path:
+    build_options = state.options
+    repaired_wheel_dir = state.identifier_tmp_dir / "repaired_wheel"
+    repaired_wheel_dir.mkdir()
+
+    if build_options.repair_command:
+        log.step("Repairing wheel...")
+        repair_command_prepared = prepare_command(
+            build_options.repair_command,
+            wheel=built_wheel,
+            dest_dir=repaired_wheel_dir,
+            package=build_options.package_dir,
+            project=".",
+        )
+        shell(repair_command_prepared, env=state.env)
+    else:
+        shutil.move(str(built_wheel), repaired_wheel_dir)
 
     try:
-        before_all_options_identifier = python_configurations[0].identifier
-        before_all_options = options.build_options(before_all_options_identifier)
+        repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
+    except StopIteration:
+        raise errors.RepairStepProducedNoWheelError() from None
+    return repaired_wheel
 
-        if before_all_options.before_all:
-            log.step("Running before_all...")
-            env = before_all_options.environment.as_dictionary(prev_environment=os.environ)
-            before_all_prepared = prepare_command(
-                before_all_options.before_all, project=".", package=options.globals.package_dir
+
+def test_wheel(state: BuildState, wheel: Path) -> None:
+    build_options = state.options
+    config = state.config
+    use_uv = build_options.build_frontend.name in {"build[uv]", "uv"}
+
+    test_selected = build_options.test_selector(config.identifier)
+    if test_selected and config.arch == "ARM64" != platform_module.machine():
+        log.warning(
+            unwrap(
+                """
+                    While arm64 wheels can be built on other platforms, they cannot
+                    be tested. An arm64 runner is required. To silence this warning,
+                    set `CIBW_TEST_SKIP: "*-win_arm64"`.
+                    """
             )
-            shell(before_all_prepared, env=env)
+        )
+        # skip this test
+    elif test_selected and build_options.test_command:
+        log.step("Testing wheel...")
+        # set up a virtual environment to install and test from, to make sure
+        # there are no dependencies that were pulled in at build time.
+        venv_dir = state.identifier_tmp_dir / "venv-test"
+        virtualenv_env = virtualenv(
+            config.version,
+            state.base_python,
+            venv_dir,
+            None,
+            use_uv=use_uv,
+            env=state.env,
+            pip_version=state.pip_version,
+        )
 
-        built_wheels: list[Path] = []
+        virtualenv_env = build_options.test_environment.as_dictionary(
+            prev_environment=virtualenv_env
+        )
 
-        for config in python_configurations:
-            build_options = options.build_options(config.identifier)
-            build_frontend = build_options.build_frontend
-            use_uv = build_frontend.name in {"build[uv]", "uv"}
-            log.build_start(config.identifier)
+        # check that we are using the Python from the virtual environment
+        call("where", "python", env=virtualenv_env)
 
-            identifier_tmp_dir = tmp_path / config.identifier
-            identifier_tmp_dir.mkdir()
-            built_wheel_dir = identifier_tmp_dir / "built_wheel"
-            repaired_wheel_dir = identifier_tmp_dir / "repaired_wheel"
-
-            constraints_path = build_options.dependency_constraints.get_for_python_version(
-                version=config.version,
-                tmp_dir=identifier_tmp_dir,
+        if build_options.before_test:
+            before_test_prepared = prepare_command(
+                build_options.before_test,
+                project=".",
+                package=build_options.package_dir,
             )
+            shell(before_test_prepared, env=virtualenv_env)
 
-            # install Python
-            base_python, env = setup_python(
-                identifier_tmp_dir / "build",
-                config,
-                constraints_path,
-                build_options.environment,
-                build_frontend.name,
+        pip: Sequence[Path | str]
+        if use_uv:
+            uv_path = find_uv()
+            assert uv_path is not None
+            pip = [uv_path, "pip"]
+        else:
+            pip = ["pip"]
+
+        # install the wheel
+        call(
+            *pip,
+            "install",
+            str(wheel) + build_options.test_extras,
+            env=virtualenv_env,
+        )
+
+        # test the wheel
+        if build_options.test_requires:
+            call(*pip, "install", *build_options.test_requires, env=virtualenv_env)
+
+        # run the tests from a temp dir, with an absolute path in the command
+        # (this ensures that Python runs the tests against the installed wheel
+        # and not the repo code)
+        test_cwd = state.identifier_tmp_dir / "test_cwd"
+        test_cwd.mkdir()
+
+        if build_options.test_sources:
+            copy_test_sources(
+                build_options.test_sources,
+                Path.cwd(),
+                test_cwd,
             )
-            env["CIBUILDWHEEL_BUILD_IDENTIFIER"] = config.identifier
-            pip_version = None if use_uv else get_pip_version(env)
+        else:
+            # Use the test_fail.py file to raise a nice error if the user
+            # tries to run tests in the cwd
+            (test_cwd / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
 
-            compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
-            if compatible_wheel:
-                log.step_end()
-                print(
-                    f"\nFound previously built wheel {compatible_wheel.name}, that's compatible with {config.identifier}. Skipping build step..."
-                )
-                repaired_wheel = compatible_wheel
-            else:
-                # run the before_build command
-                if build_options.before_build:
-                    log.step("Running before_build...")
-                    before_build_prepared = prepare_command(
-                        build_options.before_build,
-                        project=".",
-                        package=options.globals.package_dir,
-                    )
-                    shell(before_build_prepared, env=env)
+        test_command_prepared = prepare_command(
+            build_options.test_command,
+            project=Path.cwd(),
+            package=build_options.package_dir.resolve(),
+            wheel=wheel,
+        )
+        shell(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
 
-                log.step("Building wheel...")
-                built_wheel_dir.mkdir()
 
-                extra_flags = get_build_frontend_extra_flags(
-                    build_frontend,
-                    build_options.build_verbosity,
-                    prepare_config_settings(
-                        build_options.config_settings,
-                        project=".",
-                        package=options.globals.package_dir,
-                    ),
-                )
-
-                if (
-                    config.identifier.startswith("gp311")
-                    and build_frontend.name == "build"
-                    and "--no-isolation" not in extra_flags
-                    and "-n" not in extra_flags
-                ):
-                    # GraalPy 24 fails to discover its standard library when a venv is created
-                    # from a virtualenv seeded executable. See
-                    # https://github.com/oracle/graalpython/issues/491 and remove this once
-                    # GraalPy 24 is dropped.
-                    log.notice(
-                        "Disabling build isolation to workaround GraalPy bug. If the build fails, consider using pip or build[uv] as build frontend."
-                    )
-                    shell("graalpy -m pip install setuptools wheel", env=env)
-                    extra_flags = [*extra_flags, "-n"]
-
-                match build_frontend.name:
-                    case "pip":
-                        # Path.resolve() is needed. Without it pip wheel may try to fetch package from pypi.org
-                        # see https://github.com/pypa/cibuildwheel/pull/369
-                        call(
-                            "python",
-                            "-m",
-                            "pip",
-                            "wheel",
-                            options.globals.package_dir.resolve(),
-                            f"--wheel-dir={built_wheel_dir}",
-                            "--no-deps",
-                            *extra_flags,
-                            env=env,
-                        )
-                    case "build" | "build[uv]":
-                        if (
-                            use_uv
-                            and "--no-isolation" not in extra_flags
-                            and "-n" not in extra_flags
-                        ):
-                            extra_flags.append("--installer=uv")
-
-                        call(
-                            "python",
-                            "-m",
-                            "build",
-                            build_options.package_dir,
-                            "--wheel",
-                            f"--outdir={built_wheel_dir}",
-                            *extra_flags,
-                            env=env,
-                        )
-                    case "uv":
-                        assert uv_path is not None
-                        call(
-                            uv_path,
-                            "build",
-                            f"--python={base_python}",
-                            build_options.package_dir,
-                            "--wheel",
-                            f"--out-dir={built_wheel_dir}",
-                            *extra_flags,
-                            env=env,
-                        )
-                    case _:
-                        assert_never(build_frontend)
-
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
-
-                # repair the wheel
-                repaired_wheel_dir.mkdir()
-
-                if built_wheel.name.endswith("none-any.whl"):
-                    raise errors.NonPlatformWheelError()
-
-                if build_options.repair_command:
-                    log.step("Repairing wheel...")
-                    repair_command_prepared = prepare_command(
-                        build_options.repair_command,
-                        wheel=built_wheel,
-                        dest_dir=repaired_wheel_dir,
-                        package=build_options.package_dir,
-                        project=".",
-                    )
-                    shell(repair_command_prepared, env=env)
-                else:
-                    shutil.move(str(built_wheel), repaired_wheel_dir)
-
-                try:
-                    repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
-                except StopIteration:
-                    raise errors.RepairStepProducedNoWheelError() from None
-
-                if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
-                    raise errors.AlreadyBuiltWheelError(repaired_wheel.name)
-
-                run_audit(tmp_dir=tmp_path, build_options=build_options, wheel=repaired_wheel)
-
-            test_selected = options.globals.test_selector(config.identifier)
-            if test_selected and config.arch == "ARM64" != platform_module.machine():
-                log.warning(
-                    unwrap(
-                        """
-                            While arm64 wheels can be built on other platforms, they cannot
-                            be tested. An arm64 runner is required. To silence this warning,
-                            set `CIBW_TEST_SKIP: "*-win_arm64"`.
-                            """
-                    )
-                )
-                # skip this test
-            elif test_selected and build_options.test_command:
-                log.step("Testing wheel...")
-                # set up a virtual environment to install and test from, to make sure
-                # there are no dependencies that were pulled in at build time.
-                venv_dir = identifier_tmp_dir / "venv-test"
-                virtualenv_env = virtualenv(
-                    config.version,
-                    base_python,
-                    venv_dir,
-                    None,
-                    use_uv=use_uv,
-                    env=env,
-                    pip_version=pip_version,
-                )
-
-                virtualenv_env = build_options.test_environment.as_dictionary(
-                    prev_environment=virtualenv_env
-                )
-
-                # check that we are using the Python from the virtual environment
-                call("where", "python", env=virtualenv_env)
-
-                if build_options.before_test:
-                    before_test_prepared = prepare_command(
-                        build_options.before_test,
-                        project=".",
-                        package=build_options.package_dir,
-                    )
-                    shell(before_test_prepared, env=virtualenv_env)
-
-                pip: Sequence[Path | str]
-                if use_uv:
-                    assert uv_path is not None
-                    pip = [uv_path, "pip"]
-                else:
-                    pip = ["pip"]
-
-                # install the wheel
-                call(
-                    *pip,
-                    "install",
-                    str(repaired_wheel) + build_options.test_extras,
-                    env=virtualenv_env,
-                )
-
-                # test the wheel
-                if build_options.test_requires:
-                    call(*pip, "install", *build_options.test_requires, env=virtualenv_env)
-
-                # run the tests from a temp dir, with an absolute path in the command
-                # (this ensures that Python runs the tests against the installed wheel
-                # and not the repo code)
-                test_cwd = identifier_tmp_dir / "test_cwd"
-                test_cwd.mkdir()
-
-                if build_options.test_sources:
-                    copy_test_sources(
-                        build_options.test_sources,
-                        Path.cwd(),
-                        test_cwd,
-                    )
-                else:
-                    # Use the test_fail.py file to raise a nice error if the user
-                    # tries to run tests in the cwd
-                    (test_cwd / "test_fail.py").write_text(resources.TEST_FAIL_CWD_FILE.read_text())
-
-                test_command_prepared = prepare_command(
-                    build_options.test_command,
-                    project=Path.cwd(),
-                    package=options.globals.package_dir.resolve(),
-                    wheel=repaired_wheel,
-                )
-                shell(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
-
-            # we're all done here; move it to output (remove if already exists)
-            output_wheel = None
-            if compatible_wheel is None:
-                output_wheel = build_options.output_dir.joinpath(repaired_wheel.name)
-                moved_wheel = move_file(repaired_wheel, output_wheel)
-                if moved_wheel != output_wheel.resolve():
-                    log.warning(
-                        f"{repaired_wheel} was moved to {moved_wheel} instead of {output_wheel}"
-                    )
-                built_wheels.append(output_wheel)
-
-            # clean up
-            # (we ignore errors because occasionally Windows fails to unlink a file and we
-            # don't want to abort a build because of that)
-            shutil.rmtree(identifier_tmp_dir, ignore_errors=True)
-
-            log.build_end(output_wheel)
-    except subprocess.CalledProcessError as error:
-        msg = f"Command {error.cmd} failed with code {error.returncode}. {error.stdout or ''}"
-        raise errors.FatalError(msg) from error
+def teardown(state: BuildState) -> None:
+    # (we ignore errors because occasionally Windows fails to unlink a file and we
+    # don't want to abort a build because of that)
+    shutil.rmtree(state.identifier_tmp_dir, ignore_errors=True)


### PR DESCRIPTION
This is a refactor of all the platforms (except linux) to have a common structure. Unlike #996, this does not rely on inheritance, and instead just enforces a standard structure via a Protocol. No shared code, each file still reads standalone. There's a shared runner that combined and orchestrates the run; this was basically the same every time before, now it's in a shared location, saving code and making 1 (okay, 2 if you count linux) canonical place to see how the runs are orchestrated. This also enables a future feature; a new `--stage` option that will allow a user to just run one stage (build or test) instead of all stages.

This is a bit shorter in LoC if you remove the new tests.

Several minor issues were discovered and fixed while working on this: ":robot: android gained the duplicate-wheel-name guard; all platforms gained the post-move warning; pyodide's compatible-wheel-plus-test path no longer references an unset variable". Not sure about the last one, will investigate.

I haven't reviewed the code yet myself, this is pretty much straight from Opus after a bit of planning. (Adding on the `--stage` feature before coming back to review this.) I might experiment a bit more, like looking to see if we could also include Linux (the containers make it rather different than all the others). This is also very much post-4.0.

By the way, I expect this to review poorly in diff mode due to changed (reduced) indentation. Might be better to look at the before and after separatety without diff coloring.

> [!NOTE]
> From an initial look, this needs quite a bit of work. Initial thoughts:
> 
> * It knew that we were going to do `--staged` next, so staged stuff leaked in
> * I think we can simplify the central code a bit. It feels over designed.
> * I think we can use Python features (context manager) to further help simplify
> * The staged thing is going to have issues picking up the wheels. I think (based on looking at these) that we can simply collect all wheels that match the current identifier for later stages, at least when run individually. But not sure we can split up the repair stage. (Claude also thought that would be hard)
> * I still want to play with ideas to include linux.py
>
> However, it's really awesome that I can go from an idea to a PoC in minutes (`--stage`, that is - I've had this structure for a platforms in mind for a while.) 

Assisted-by: ClaudeCode:claude-opus-4.8