### PR TITLE
Clarify environment precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,10 +64,12 @@ You can configure cibuildwheel with a config file, such as `pyproject.toml`.
 Options have the same names as the environment variable overrides, but are
 placed in `[tool.cibuildwheel]` and are lower case, with dashes, following
 common [TOML](https://toml.io) practice. Anything placed in subsections
-named after a platform will only affect those platforms. Lists can be used
-instead of strings for items that are naturally a list. Multiline strings also
-work just like in the environment variables. Environment variables will take
-precedence if defined.
+named after a platform will only affect those platforms. Platform-specific
+values replace the corresponding global value for that platform; table options
+are not merged key by key. Lists can be used instead of strings for items that
+are naturally a list. Multiline strings also work just like in the environment
+variables. Environment variable overrides, such as `CIBW_TEST_COMMAND` and
+`CIBW_TEST_COMMAND_LINUX`, will take precedence if defined.
 
 The example above using environment variables could have been written like this:
 
@@ -178,7 +180,7 @@ on Python 3.11, and will have `environment = {FOO="BAZ", "PYTHON"="MONTY", "HAM"
 In the TOML configuration, you can choose how tables and lists are inherited.
 By default, all values are overridden completely (`"none"`) but sometimes you'd
 rather `"append"` or `"prepend"` to an existing list or table. You can do this
-with the `inherit` table in overrides.  For example, if you want to add an environment
+with the `inherit` table in overrides. For example, if you want to add an environment
 variable for CPython 3.11, without `inherit` you'd have to repeat all the
 original environment variables in the override. With `inherit`, it's just:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -594,6 +594,12 @@ You must use this variable to pass variables to Linux builds, since they execute
 You can use `$PATH` syntax to insert other variables, or the `$(pwd)` syntax to insert the output of other shell commands.
 Variables are evaluated in the order they appear. Any variable referenced before it is set will evaluate to an empty string.
 
+The environment seen by the build and test steps starts with the build
+environment. On Linux, this is the container environment, plus any variables
+passed through with [`environment-pass`](#environment-pass). On other platforms,
+the host environment is already available. Assignments in `environment` are
+evaluated after that base environment and replace any duplicate variable names.
+
 To specify more than one environment variable, separate the assignments by spaces.
 
 Platform-specific environment variables are also available:<br/>


### PR DESCRIPTION
## Summary
- Clarify that CIBW_* environment variable overrides take precedence over TOML configuration options.
- Document that platform-specific TOML values replace global values instead of merging tables key by key.
- Explain how the build/test environment is composed before environment assignments are applied.

Closes #2836

## Validation
- git diff --check