### PR TITLE
fix: raise clear errors when no wheel is produced

### DIFF
--- a/cibuildwheel/errors.py
+++ b/cibuildwheel/errors.py
@@ -109,3 +109,19 @@ class AuditCommandFailedError(FatalError):
     def __init__(self, message: str) -> None:
         super().__init__(message)
         self.return_code = 9
+
+
+class BuildProducedNoWheelError(FatalError):
+    def __init__(self) -> None:
+        message = textwrap.dedent(
+            """
+            Build failed because the build frontend completed successfully but
+            did not produce a wheel.
+
+            This usually indicates a problem with your project configuration or
+            build backend. Check your project configuration, or run cibuildwheel
+            with CIBW_BUILD_VERBOSITY=1 to view build logs.
+            """
+        )
+        super().__init__(message)
+        self.return_code = 10

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -410,10 +410,14 @@ def setup_android_env(
     #   * a key=value string, without quotes
     for i, token in enumerate(shlex.split(env_output)):
         if i % 2 == 0:
-            assert token == "export", token
+            if token != "export":
+                msg = f"Unexpected output from android.py env: expected 'export', got {token!r}"
+                raise errors.FatalError(msg)
         else:
             key, sep, value = token.partition("=")
-            assert sep == "=", token
+            if sep != "=":
+                msg = f"Unexpected output from android.py env: expected 'key=value', got {token!r}"
+                raise errors.FatalError(msg)
             android_env[key] = value
 
     # localized_vars cleared the CFLAGS and CXXFLAGS in the sysconfigdata, but most

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -95,6 +95,14 @@ def all_python_configurations() -> list[PythonConfiguration]:
         matching = [
             config for config in macos_python_configs if config["identifier"] == macos_identifier
         ]
+        if not matching:
+            msg = (
+                f"Internal error: no macOS configuration found matching "
+                f"{macos_identifier!r}, needed to build the iOS configuration "
+                f"{config_dict['identifier']!r}. The bundled build-platforms.toml "
+                f"resources are inconsistent."
+            )
+            raise errors.FatalError(msg)
         return matching[0]
 
     # Load the platform configuration
@@ -560,7 +568,10 @@ def build(options: Options, tmp_path: Path) -> None:
                     case _:
                         assert_never(build_frontend)
 
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+                try:
+                    built_wheel = next(built_wheel_dir.glob("*.whl"))
+                except StopIteration:
+                    raise errors.BuildProducedNoWheelError() from None
 
                 if built_wheel.name.endswith("none-any.whl"):
                     raise errors.NonPlatformWheelError()

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -346,7 +346,10 @@ def build_in_container(
                 case _:
                     assert_never(build_frontend)
 
-            built_wheel = container.glob(built_wheel_dir, "*.whl")[0]
+            try:
+                built_wheel = container.glob(built_wheel_dir, "*.whl")[0]
+            except IndexError:
+                raise errors.BuildProducedNoWheelError() from None
 
             repaired_wheel_dir = temp_dir / "repaired_wheel"
             container.call(["rm", "-rf", repaired_wheel_dir])

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -566,7 +566,10 @@ def build(options: Options, tmp_path: Path) -> None:
                     case _:
                         assert_never(build_frontend)
 
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+                try:
+                    built_wheel = next(built_wheel_dir.glob("*.whl"))
+                except StopIteration:
+                    raise errors.BuildProducedNoWheelError() from None
 
                 repaired_wheel_dir.mkdir()
 

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -451,7 +451,10 @@ def build(options: Options, tmp_path: Path) -> None:
                     *extra_flags,
                     env=env,
                 )
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+                try:
+                    built_wheel = next(built_wheel_dir.glob("*.whl"))
+                except StopIteration:
+                    raise errors.BuildProducedNoWheelError() from None
 
                 if built_wheel.name.endswith("none-any.whl"):
                     raise errors.NonPlatformWheelError()
@@ -471,7 +474,10 @@ def build(options: Options, tmp_path: Path) -> None:
                 else:
                     shutil.move(str(built_wheel), repaired_wheel_dir)
 
-                repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
+                try:
+                    repaired_wheel = next(repaired_wheel_dir.glob("*.whl"))
+                except StopIteration:
+                    raise errors.RepairStepProducedNoWheelError() from None
 
                 if repaired_wheel.name in {wheel.name for wheel in built_wheels}:
                     raise errors.AlreadyBuiltWheelError(repaired_wheel.name)

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -522,7 +522,10 @@ def build(options: Options, tmp_path: Path) -> None:
                     case _:
                         assert_never(build_frontend)
 
-                built_wheel = next(built_wheel_dir.glob("*.whl"))
+                try:
+                    built_wheel = next(built_wheel_dir.glob("*.whl"))
+                except StopIteration:
+                    raise errors.BuildProducedNoWheelError() from None
 
                 # repair the wheel
                 repaired_wheel_dir.mkdir()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This addresses items 1-4 of #2908, replacing several bare tracebacks with clear `FatalError`s when a build does not produce a wheel or platform resources are inconsistent.

Changes:

- Add `errors.BuildProducedNoWheelError` (exit code 10) for the case where a build frontend exits successfully but produces no wheel.
- Guard the built-wheel globs on Linux, macOS, Windows, iOS, and Pyodide so they raise `BuildProducedNoWheelError` instead of a bare `IndexError` / `StopIteration`. (Android already handled this via its `glob1` helper.)
- Wrap Pyodide's repaired-wheel glob in `try/except StopIteration` to raise `RepairStepProducedNoWheelError`, matching the existing macOS/Windows pattern.
- Replace the `assert` statements that validate `android.py env` output with `errors.FatalError`, including the unexpected token in the message.
- Raise `errors.FatalError` naming the missing macOS identifier when `ios.py` cannot find a matching macOS configuration, instead of an `IndexError`.

Part of #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
