### PR TITLE
chore: minor cleanups and perf tweaks from code review

### DIFF
--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -363,11 +363,11 @@ class Logger:
         out.write("\n")
         return out.getvalue()
 
-    @property
+    @functools.cached_property
     def colors(self) -> Colors:
         return Colors(enabled=self.colors_enabled)
 
-    @property
+    @functools.cached_property
     def symbols(self) -> Symbols:
         return Symbols(unicode=self.unicode_enabled)
 

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -328,7 +328,7 @@ def setup_python(
         assert (venv_path / "Scripts" / "pip.exe").exists()
         where_pip = call("where", "pip", env=env, capture_stdout=True).splitlines()[0].strip()
         print(where_pip)
-        if where_pip.strip() != str(venv_path / "Scripts" / "pip.exe"):
+        if where_pip != str(venv_path / "Scripts" / "pip.exe"):
             msg = "pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it."
             raise errors.FatalError(msg)
         call("pip", "--version", env=env)

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -85,7 +85,8 @@ def download(url: str, dest: Path, *, sha256: str | None = None) -> None:
             time.sleep(3)
 
     if sha256:
-        computed = hashlib.sha256(dest.read_bytes()).hexdigest()
+        with dest.open("rb") as f:
+            computed = hashlib.file_digest(f, "sha256").hexdigest()
         if computed != sha256:
             dest.unlink(missing_ok=True)
             msg = f"SHA256 mismatch for {url}: expected {sha256!r}, got {computed!r}"
@@ -116,6 +117,8 @@ def extract_tar(tar_src: Path, dest: Path) -> None:
     See: https://docs.python.org/3/library/tarfile.html#tarfile.tar_filter for filter details
     """
     with tarfile.open(tar_src) as tar_:
+        # getattr shim needed while Python 3.11.0-3.11.3 are supported;
+        # once the minimum is 3.11.4+/3.12, replace with: tar_.extractall(dest, filter="tar")
         tar_.extraction_filter = getattr(tarfile, "tar_filter", (lambda member, _: member))
         tar_.extractall(dest)
 

--- a/cibuildwheel/util/python_build_standalone.py
+++ b/cibuildwheel/util/python_build_standalone.py
@@ -219,6 +219,7 @@ def create_python_build_standalone_environment(
     )
 
     python_base_dir = temp_dir / "pbs"
+    assert not python_base_dir.exists()
     extract_tar(archive_path, python_base_dir)
 
     return _find_python_executable(python_base_dir)

--- a/cibuildwheel/util/python_build_standalone.py
+++ b/cibuildwheel/util/python_build_standalone.py
@@ -143,7 +143,8 @@ def _download_or_get_from_cache(
         asset_cache_path = cache_dir / asset_filename
         if asset_cache_path.is_file():
             if sha256:
-                computed = hashlib.sha256(asset_cache_path.read_bytes()).hexdigest()
+                with asset_cache_path.open("rb") as f:
+                    computed = hashlib.file_digest(f, "sha256").hexdigest()
                 if computed != sha256:
                     print(
                         f"Cached python_build_standalone SHA256 mismatch for {asset_cache_path}; redownloading."
@@ -218,9 +219,6 @@ def create_python_build_standalone_environment(
     )
 
     python_base_dir = temp_dir / "pbs"
-    if python_base_dir.exists():
-        msg = f"python-build-standalone directory already exists: {python_base_dir}"
-        raise PythonBuildStandaloneError(msg)
     extract_tar(archive_path, python_base_dir)
 
     return _find_python_executable(python_base_dir)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR addresses items 5-9 from the code review checklist in #2908 with five small cleanup/perf fixes:

- **Streaming SHA-256 verification** (`util/file.py`, `util/python_build_standalone.py`): Replace `hashlib.sha256(path.read_bytes()).hexdigest()` with `hashlib.file_digest(f, "sha256").hexdigest()` to avoid loading entire archives (potentially hundreds of MB) into memory at once. `hashlib.file_digest` was added in Python 3.11.0, which is the minimum supported version.

- **`functools.cached_property` for `Logger.colors` / `Logger.symbols`** (`logger.py`): The `Colors` and `Symbols` objects were reconstructed on every property access, but `colors_enabled` and `unicode_enabled` never change after `__init__`. Converting to `cached_property` avoids the repeated allocations.

- **Remove redundant `.strip()`** (`platforms/windows.py`): `where_pip` was already `.strip()`-ed at assignment (line 329); the duplicate call on line 331 was dead code.

- **Remove unreachable `python_base_dir.exists()` guard** (`util/python_build_standalone.py`): Both callers of `create_python_build_standalone_environment` pass a fresh temp subdirectory, so the guard can never trip. Verified by inspecting `pyodide.py` (passes `tmp / "base"`) and `android.py` (passes a newly `mkdir`-ed `build_path`).

- **Comment explaining the `getattr` shim** (`util/file.py`): Notes why the shim is needed (Python 3.11.0-3.11.3 support) and what the cleanup looks like once the minimum is raised to 3.11.4+/3.12.

Part of #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
