### PR TITLE
docs: clarify package-dir action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: cibuildwheel
 description: 'Installs and runs cibuildwheel on the current runner'
 inputs:
   package-dir:
-    description: 'Input directory, defaults to "."'
+    description: 'Path to the package to build, defaults to ".". Can be a directory or an sdist.'
     required: false
     default: .
   output-dir:


### PR DESCRIPTION
Closes #1682

## Summary
- Clarify the GitHub Action `package-dir` input description
- Align the input wording with cibuildwheel's CLI behavior, which accepts a directory or source distribution

## Checks
- `git diff --check`
- Parsed `action.yml` with PyYAML