### PR TITLE
fix: make CIBW_ARCHS parsing case-insensitive and platform-aware

### DIFF
--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -107,12 +107,28 @@ class Architecture(StrEnum):
                 case "auto32":
                     result |= cls.bitness_archs(platform=platform, bitness="32")
                 case _:
-                    try:
-                        result.add(cls(arch_str))
-                    except ValueError as e:
+                    if arch := cls._parse_arch_name(arch_str, platform=platform):
+                        result.add(arch)
+                    else:
                         msg = f"Invalid architecture '{arch_str}'"
-                        raise errors.ConfigurationError(msg) from e
+                        raise errors.ConfigurationError(msg)
         return result
+
+    @classmethod
+    def _parse_arch_name(cls, arch_str: str, platform: PlatformName) -> Self | None:
+        """Resolve an architecture name case-insensitively.
+
+        The same value (e.g. "arm64"/"ARM64") can map to different members
+        depending on the platform, so prefer a member valid for ``platform``
+        before falling back to any case-insensitive match.
+        """
+        for arch in cls.all_archs(platform):
+            if arch.value.lower() == arch_str.lower():
+                return arch
+        for arch in cls:
+            if arch.value.lower() == arch_str.lower():
+                return arch
+        return None
 
     @classmethod
     def native_arch(cls, platform: PlatformName) -> Self | None:

--- a/unit_test/architecture_test.py
+++ b/unit_test/architecture_test.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 import cibuildwheel.architecture
+import cibuildwheel.errors
 from cibuildwheel.architecture import Architecture, arch_synonym
 
 TYPE_CHECKING = False
@@ -142,3 +143,33 @@ def test_arch_synonym(
     arch: str, from_platform: PlatformName, to_platform: PlatformName, expected: str | None
 ) -> None:
     assert arch_synonym(arch, from_platform, to_platform) == expected
+
+
+@pytest.mark.parametrize(
+    ("config", "platform", "expected"),
+    [
+        # Case-insensitive, platform-resolved names (issue #2373).
+        ("arm64", "windows", {Architecture.ARM64}),
+        ("ARM64", "windows", {Architecture.ARM64}),
+        ("amd64", "windows", {Architecture.AMD64}),
+        ("AMD64", "windows", {Architecture.AMD64}),
+        ("X86", "windows", {Architecture.x86}),
+        ("x86", "windows", {Architecture.x86}),
+        # macOS resolves the lowercase arm64 even when given uppercase.
+        ("ARM64", "macos", {Architecture.arm64}),
+        ("arm64", "macos", {Architecture.arm64}),
+        ("X86_64", "macos", {Architecture.x86_64}),
+        # Multiple, mixed-case archs in one config string.
+        ("arm64 amd64", "windows", {Architecture.ARM64, Architecture.AMD64}),
+    ],
+)
+def test_arch_parse_config_case_insensitive(
+    config: str, platform: PlatformName, expected: set[Architecture]
+) -> None:
+    assert Architecture.parse_config(config, platform) == expected
+
+
+@pytest.mark.parametrize("platform", ["windows", "macos", "linux"])
+def test_arch_parse_config_invalid(platform: PlatformName) -> None:
+    with pytest.raises(cibuildwheel.errors.ConfigurationError):
+        Architecture.parse_config("nonexistent", platform)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`CIBW_ARCHS` architecture parsing was case-sensitive and platform-ambiguous. In `cibuildwheel/architecture.py`, `Architecture.parse_config` used a case-sensitive `StrEnum` lookup (`cls(arch_str)`). The enum carries both a lowercase `arm64` member (value `"arm64"`, used by macOS/Android) and an uppercase `ARM64` member (value `"ARM64"`, used by Windows), plus `AMD64`/`x86_64`, etc.

This caused surprising behavior:

- `Architecture.parse_config("arm64", platform="windows")` returned `{Architecture.arm64}` (the **macOS** member!) with no error, then failed later in `allowed_architectures_check` with a confusing `Invalid archs option` message.
- `Architecture.parse_config("ARM64", platform="windows")` worked.
- `"amd64"` (lowercase) failed to parse entirely, while `"AMD64"` worked.

So Windows-on-ARM users had to use exact-case `ARM64`/`AMD64`.

## Fix

The name lookup is now case-insensitive and resolves to the member valid for the target `platform`. A new helper `Architecture._parse_arch_name` first matches case-insensitively against `Architecture.all_archs(platform)`, then falls back to a case-insensitive match across all members so the existing clear `ConfigurationError` still fires for genuinely invalid names. The special tokens (`auto`, `native`, `all`, `auto64`, `auto32`) are untouched.

After the fix:

- `parse_config("arm64", "windows") == {Architecture.ARM64}`
- `parse_config("ARM64", "macos") == {Architecture.arm64}`
- lowercase `amd64` / `x86` work on Windows
- an actually-invalid name still raises `ConfigurationError`

## Tests

Added parametrized unit tests in `unit_test/architecture_test.py` covering the cases above.

Closes #2373
