### PR TITLE
fix(macos): wrap before_build with arch -x86_64 under Rosetta

### DIFF
--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -455,6 +455,24 @@ def setup_python(
     return base_python, env
 
 
+def rosetta_arch_prefix(*, machine_arch: str, target_arch: Literal["x86_64", "arm64"]) -> list[str]:
+    """
+    Return the command prefix needed to run a command targeting ``target_arch``
+    on a host running ``machine_arch``.
+
+    On an arm64 host, running an x86_64 command requires the ``arch -x86_64``
+    prefix so that Rosetta 2 emulation kicks in and architecture-probing tooling
+    (``platform.machine()``, ``uname -m``, arch-specific compilers, ...) reports
+    x86_64 consistently. The native cases (and the unsupported
+    x86_64-host-targeting-arm64 case, which is handled separately) need no
+    prefix.
+    """
+    if machine_arch == "arm64" and target_arch == "x86_64":
+        # rosetta2 will provide the emulation with just the arch prefix.
+        return ["arch", "-x86_64"]
+    return []
+
+
 def build(options: Options, tmp_path: Path) -> None:
     python_configurations = get_python_configurations(
         options.globals.build_selector, options.globals.architectures
@@ -524,7 +542,20 @@ def build(options: Options, tmp_path: Path) -> None:
                     before_build_prepared = prepare_command(
                         build_options.before_build, project=".", package=build_options.package_dir
                     )
-                    shell(before_build_prepared, env=env)
+                    # For an x86_64 build on an arm64 host, run the hook under
+                    # Rosetta so that arch-probing tooling matches the wheel's
+                    # target arch, mirroring the test loop. universal2 builds
+                    # compile both arches in a single invocation (via ARCHFLAGS)
+                    # and have no single correct arch prefix, so they are left
+                    # unwrapped (native arm64).
+                    if not config_is_universal2 and not config_is_arm64:
+                        arch_prefix = rosetta_arch_prefix(
+                            machine_arch=platform.machine(), target_arch="x86_64"
+                        )
+                        shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")
+                        shell_with_arch(before_build_prepared, env=env)
+                    else:
+                        shell(before_build_prepared, env=env)
 
                 log.step("Building wheel...")
                 built_wheel_dir.mkdir()
@@ -687,12 +718,12 @@ def build(options: Options, tmp_path: Path) -> None:
                         else f"Testing wheel on {testing_arch}..."
                     )
 
-                    arch_prefix = []
+                    arch_prefix = rosetta_arch_prefix(
+                        machine_arch=machine_arch, target_arch=testing_arch
+                    )
                     uv_arch_args = []
                     if testing_arch != machine_arch:
                         if machine_arch == "arm64" and testing_arch == "x86_64":
-                            # rosetta2 will provide the emulation with just the arch prefix.
-                            arch_prefix = ["arch", "-x86_64"]
                             uv_arch_args = ["--python-platform", "x86_64-apple-darwin"]
                         else:
                             msg = f"don't know how to emulate {testing_arch} on {machine_arch}"

--- a/unit_test/macos_rosetta_test.py
+++ b/unit_test/macos_rosetta_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from cibuildwheel.platforms.macos import rosetta_arch_prefix
+
+
+@pytest.mark.parametrize(
+    ("machine_arch", "target_arch", "expected"),
+    [
+        # arm64 host building x86_64 -> needs Rosetta prefix
+        ("arm64", "x86_64", ["arch", "-x86_64"]),
+        # native cases -> no prefix
+        ("arm64", "arm64", []),
+        ("x86_64", "x86_64", []),
+        # x86_64 host targeting arm64 is unsupported and handled separately;
+        # the helper itself just returns no prefix.
+        ("x86_64", "arm64", []),
+    ],
+)
+def test_rosetta_arch_prefix(machine_arch: str, target_arch: str, expected: list[str]) -> None:
+    assert rosetta_arch_prefix(machine_arch=machine_arch, target_arch=target_arch) == expected  # type: ignore[arg-type]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

On a macOS **arm64** host building **x86_64** wheels via Rosetta (common now that GHA deprecated `macos-13`), the command hooks were wrapped with `arch -x86_64` inconsistently:

- `before_test` and the test command run under `arch -x86_64` (test loop: `shell_with_arch = functools.partial(call, *arch_prefix, "/bin/sh", "-c")` with `arch_prefix = ["arch", "-x86_64"]`).
- `before_build` ran via a plain `shell(before_build_prepared, env=env)` — **no** prefix.

The wheel itself still cross-compiles via `ARCHFLAGS`, but hooks that probe the architecture or invoke arch-specific tooling (`platform.machine()`, `uname -m`, compilers, etc.) behaved differently in `before_build` vs `before_test`. The NumPy maintainers hit this (#2592).

## Fix

- Extract the prefix logic into a small shared helper `rosetta_arch_prefix(machine_arch, target_arch)` so the build and test paths stay in sync.
- Wrap `before_build` with `arch -x86_64` when the host is arm64 and the build target is x86_64-only, mirroring the test loop.
- Refactor the test loop to use the same helper (no behavior change there — it returns `[]` for native and the previously-handled cases).

The native paths (arm64-on-arm64, x86_64-on-x86_64) are unchanged: the helper returns an empty prefix, so `before_build` still goes through plain `shell()`.

### Design decisions

- **universal2**: A universal2 config compiles *both* arches in a single invocation via `ARCHFLAGS="-arch arm64 -arch x86_64"`. There is no single `arch` prefix that is correct for that hook, so I left universal2 **unwrapped** (runs natively as arm64). Forcing `arch -x86_64` would be wrong for the arm64 slice. This matches how the build itself is invoked (one process, both arches).
- **before_all**: Left **unwrapped** for now. It runs once before all builds, keyed off `python_configurations[0]`, which does not necessarily represent the arch of every build in a mixed selection. Wrapping it based on the first config could be misleading. Tradeoff noted below as an open question.

## Open questions for maintainers

1. Confirm the desired semantics: wrap `before_build` for **x86_64-only** configs on arm64 hosts, but **not** universal2. Is leaving universal2 native correct, or would you prefer wrapping it as the native arch explicitly (a no-op today) for clarity?
2. Should `before_all` also be wrapped? If so, based on what — the first config's arch, or only when *all* selected configs target x86_64? Or leave it native (current behavior)?
3. The fix is verified by a unit test on the pure helper. Full end-to-end behavior needs a real arm64-host / x86_64-target (Rosetta) environment, which isn't available in unit tests — see limitation below.

## Tests

Added `unit_test/macos_rosetta_test.py` covering `rosetta_arch_prefix` for the arm64->x86_64 (Rosetta), native, and unsupported-direction cases. The wrapping wiring inside `build()` itself isn't unit-testable without a real cross-arch build (it requires real Python.org installs and Rosetta); this is noted as a limitation.

`uv run pytest unit_test` -> 795 passed. Ruff + mypy (strict) clean on the changed file.

Closes #2592
