### PR TITLE
fix(macos): make matching python3-config available in build/test venvs

### DIFF
--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -210,18 +210,8 @@ def virtualenv(
 def _symlink_python_config_scripts(base_python: Path, venv_bin: Path) -> None:
     """
     Symlink the base interpreter's ``python*-config`` scripts into the venv's
-    bin directory.
-
-    Virtualenvs do not ship a ``python3-config`` (or versioned
-    ``python{X.Y}-config``) script, so extensions that call it (e.g. to get
-    include dirs or link flags) would otherwise pick up an unrelated
-    ``python3-config`` from elsewhere on PATH -- typically the system or
-    Homebrew Python. This is most relevant for the python.org framework builds
-    on macOS, which do ship these scripts next to the base interpreter.
-
-    Interpreters that don't ship a config script (e.g. PyPy, GraalPy, or some
-    uv-managed builds) are handled gracefully: nothing is linked and the build
-    is not failed.
+    bin directory if provided and not already linked (virtualenvs don't always
+    provide them).
     """
     # The config scripts live next to the base interpreter, e.g.
     # `python3-config` and `python3.12-config`.

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -152,6 +152,10 @@ def virtualenv(
     venv. Otherwise, pip is installed.
     """
 
+    # the unresolved path, so e.g. the python.org framework bin directory is
+    # used rather than the internal location of the real binary
+    base_python_bin_dir = None if _IS_WIN else python.parent
+
     # virtualenv may fail if this is a symlink.
     python = python.resolve()
 
@@ -189,9 +193,7 @@ def virtualenv(
             python,
             venv_path,
         )
-    if not _IS_WIN:
-        _symlink_python_config_scripts(python, venv_path / "bin")
-    venv_env = activate_virtualenv(venv_path, env=env)
+    venv_env = activate_virtualenv(venv_path, env=env, base_python_bin_dir=base_python_bin_dir)
     if not use_uv and pip_version == "embed":
         call(
             "python",
@@ -207,30 +209,22 @@ def virtualenv(
     return venv_env
 
 
-def _symlink_python_config_scripts(base_python: Path, venv_bin: Path) -> None:
-    """
-    Symlink the base interpreter's ``python*-config`` scripts into the venv's
-    bin directory if provided and not already linked (virtualenvs don't always
-    provide them).
-    """
-    # The config scripts live next to the base interpreter, e.g.
-    # `python3-config` and `python3.12-config`.
-    for config_script in sorted(base_python.parent.glob("python*-config")):
-        target = venv_bin / config_script.name
-        if target.exists() or target.is_symlink():
-            continue
-        with contextlib.suppress(OSError):
-            target.symlink_to(config_script)
-
-
 def activate_virtualenv(
     venv_path: Path,
     env: dict[str, str] | None = None,
+    base_python_bin_dir: Path | None = None,
 ) -> dict[str, str]:
     """
     Return a copy of the environment with the virtualenv at `venv_path` activated.
+
+    If given, `base_python_bin_dir` is placed on PATH right after the venv, so
+    that scripts installed alongside the base interpreter that aren't copied
+    into the venv (such as python3-config, see #2021) resolve to the matching
+    interpreter.
     """
     paths = [str(venv_path), str(venv_path / "Scripts")] if _IS_WIN else [str(venv_path / "bin")]
+    if base_python_bin_dir is not None:
+        paths.append(str(base_python_bin_dir))
     venv_env = os.environ.copy() if env is None else env.copy()
     venv_env["PATH"] = os.pathsep.join([*paths, venv_env["PATH"]])
     venv_env["VIRTUAL_ENV"] = str(venv_path)

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -189,6 +189,8 @@ def virtualenv(
             python,
             venv_path,
         )
+    if not _IS_WIN:
+        _symlink_python_config_scripts(python, venv_path / "bin")
     venv_env = activate_virtualenv(venv_path, env=env)
     if not use_uv and pip_version == "embed":
         call(
@@ -203,6 +205,32 @@ def virtualenv(
             cwd=venv_path,
         )
     return venv_env
+
+
+def _symlink_python_config_scripts(base_python: Path, venv_bin: Path) -> None:
+    """
+    Symlink the base interpreter's ``python*-config`` scripts into the venv's
+    bin directory.
+
+    Virtualenvs do not ship a ``python3-config`` (or versioned
+    ``python{X.Y}-config``) script, so extensions that call it (e.g. to get
+    include dirs or link flags) would otherwise pick up an unrelated
+    ``python3-config`` from elsewhere on PATH -- typically the system or
+    Homebrew Python. This is most relevant for the python.org framework builds
+    on macOS, which do ship these scripts next to the base interpreter.
+
+    Interpreters that don't ship a config script (e.g. PyPy, GraalPy, or some
+    uv-managed builds) are handled gracefully: nothing is linked and the build
+    is not failed.
+    """
+    # The config scripts live next to the base interpreter, e.g.
+    # `python3-config` and `python3.12-config`.
+    for config_script in sorted(base_python.parent.glob("python*-config")):
+        target = venv_bin / config_script.name
+        if target.exists() or target.is_symlink():
+            continue
+        with contextlib.suppress(OSError):
+            target.symlink_to(config_script)
 
 
 def activate_virtualenv(

--- a/unit_test/venv_test.py
+++ b/unit_test/venv_test.py
@@ -1,71 +1,60 @@
-from __future__ import annotations
-
+import os
 import sys
+from pathlib import Path
 
 import pytest
 
-from cibuildwheel.venv import _symlink_python_config_scripts
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from pathlib import Path
-
-pytestmark = pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="config scripts are a POSIX concept"
-)
+import cibuildwheel.venv
+from cibuildwheel.venv import activate_virtualenv, find_uv, virtualenv
 
 
-def test_symlink_python_config_scripts(tmp_path: Path) -> None:
+def test_activate_virtualenv(tmp_path: Path) -> None:
+    venv_path = tmp_path / "venv"
+    env = activate_virtualenv(venv_path, env={"PATH": "/usr/bin"})
+    paths = env["PATH"].split(os.pathsep)
+    if sys.platform == "win32":
+        assert paths[:2] == [str(venv_path), str(venv_path / "Scripts")]
+    else:
+        assert paths[0] == str(venv_path / "bin")
+    assert paths[-1] == "/usr/bin"
+    assert env["VIRTUAL_ENV"] == str(venv_path)
+
+
+def test_activate_virtualenv_base_python_bin_dir(tmp_path: Path) -> None:
+    venv_path = tmp_path / "venv"
     base_bin = tmp_path / "base" / "bin"
-    base_bin.mkdir(parents=True)
-    base_python = base_bin / "python3"
-    base_python.touch()
-    # python.org framework builds ship both an unversioned and a versioned script
-    (base_bin / "python3-config").touch()
-    (base_bin / "python3.12-config").touch()
-
-    venv_bin = tmp_path / "venv" / "bin"
-    venv_bin.mkdir(parents=True)
-
-    _symlink_python_config_scripts(base_python, venv_bin)
-
-    for name in ("python3-config", "python3.12-config"):
-        linked = venv_bin / name
-        assert linked.is_symlink()
-        assert linked.resolve() == (base_bin / name).resolve()
+    env = activate_virtualenv(venv_path, env={"PATH": "/usr/bin"}, base_python_bin_dir=base_bin)
+    paths = env["PATH"].split(os.pathsep)
+    # the base interpreter's bin dir comes right after the venv, so scripts
+    # like python3-config resolve to the matching interpreter (see #2021)
+    if sys.platform == "win32":
+        assert paths[:3] == [str(venv_path), str(venv_path / "Scripts"), str(base_bin)]
+    else:
+        assert paths[:2] == [str(venv_path / "bin"), str(base_bin)]
+    assert paths[-1] == "/usr/bin"
 
 
-def test_symlink_python_config_scripts_no_config(tmp_path: Path) -> None:
-    """Interpreters without a config script (PyPy, GraalPy, ...) must not fail."""
-    base_bin = tmp_path / "base" / "bin"
-    base_bin.mkdir(parents=True)
-    base_python = base_bin / "pypy3"
-    base_python.touch()
-    # PyPy ships pypy3-config, which must not be picked up as python*-config
-    (base_bin / "pypy3-config").touch()
-
-    venv_bin = tmp_path / "venv" / "bin"
-    venv_bin.mkdir(parents=True)
-
-    _symlink_python_config_scripts(base_python, venv_bin)
-
-    assert list(venv_bin.iterdir()) == []
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only behavior")
+@pytest.mark.skipif(find_uv() is None, reason="requires uv")
+def test_virtualenv_puts_base_python_bin_dir_on_path(tmp_path: Path) -> None:
+    version = "{}.{}".format(*sys.version_info[:2])
+    venv_path = tmp_path / "venv"
+    env = virtualenv(
+        version, Path(sys.executable), venv_path, None, use_uv=True, env={"PATH": "/usr/bin"}
+    )
+    paths = env["PATH"].split(os.pathsep)
+    assert paths == [str(venv_path / "bin"), str(Path(sys.executable).parent), "/usr/bin"]
 
 
-def test_symlink_python_config_scripts_existing_not_overwritten(tmp_path: Path) -> None:
-    base_bin = tmp_path / "base" / "bin"
-    base_bin.mkdir(parents=True)
-    base_python = base_bin / "python3"
-    base_python.touch()
-    (base_bin / "python3-config").touch()
-
-    venv_bin = tmp_path / "venv" / "bin"
-    venv_bin.mkdir(parents=True)
-    # a pre-existing real file should be left untouched
-    existing = venv_bin / "python3-config"
-    existing.write_text("#!/bin/sh\n")
-
-    _symlink_python_config_scripts(base_python, venv_bin)
-
-    assert not existing.is_symlink()
-    assert existing.read_text() == "#!/bin/sh\n"
+@pytest.mark.skipif(find_uv() is None, reason="requires uv")
+def test_virtualenv_no_base_python_bin_dir_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cibuildwheel.venv, "_IS_WIN", True)
+    version = "{}.{}".format(*sys.version_info[:2])
+    venv_path = tmp_path / "venv"
+    env = virtualenv(
+        version, Path(sys.executable), venv_path, None, use_uv=True, env={"PATH": "/usr/bin"}
+    )
+    paths = env["PATH"].split(os.pathsep)
+    assert str(Path(sys.executable).parent) not in paths

--- a/unit_test/venv_test.py
+++ b/unit_test/venv_test.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from cibuildwheel.venv import _symlink_python_config_scripts
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="config scripts are a POSIX concept"
+)
+
+
+def test_symlink_python_config_scripts(tmp_path):
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "python3"
+    base_python.touch()
+    # python.org framework builds ship both an unversioned and a versioned script
+    (base_bin / "python3-config").touch()
+    (base_bin / "python3.12-config").touch()
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    _symlink_python_config_scripts(base_python, venv_bin)
+
+    for name in ("python3-config", "python3.12-config"):
+        linked = venv_bin / name
+        assert linked.is_symlink()
+        assert linked.resolve() == (base_bin / name).resolve()
+
+
+def test_symlink_python_config_scripts_no_config(tmp_path):
+    """Interpreters without a config script (PyPy, GraalPy, ...) must not fail."""
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "pypy3"
+    base_python.touch()
+    # PyPy ships pypy3-config, which must not be picked up as python*-config
+    (base_bin / "pypy3-config").touch()
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    _symlink_python_config_scripts(base_python, venv_bin)
+
+    assert list(venv_bin.iterdir()) == []
+
+
+def test_symlink_python_config_scripts_existing_not_overwritten(tmp_path):
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "python3"
+    base_python.touch()
+    (base_bin / "python3-config").touch()
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    # a pre-existing real file should be left untouched
+    existing = venv_bin / "python3-config"
+    existing.write_text("#!/bin/sh\n")
+
+    _symlink_python_config_scripts(base_python, venv_bin)
+
+    assert not existing.is_symlink()
+    assert existing.read_text() == "#!/bin/sh\n"

--- a/unit_test/venv_test.py
+++ b/unit_test/venv_test.py
@@ -6,12 +6,16 @@ import pytest
 
 from cibuildwheel.venv import _symlink_python_config_scripts
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
 pytestmark = pytest.mark.skipif(
     sys.platform.startswith("win"), reason="config scripts are a POSIX concept"
 )
 
 
-def test_symlink_python_config_scripts(tmp_path):
+def test_symlink_python_config_scripts(tmp_path: Path) -> None:
     base_bin = tmp_path / "base" / "bin"
     base_bin.mkdir(parents=True)
     base_python = base_bin / "python3"
@@ -31,7 +35,7 @@ def test_symlink_python_config_scripts(tmp_path):
         assert linked.resolve() == (base_bin / name).resolve()
 
 
-def test_symlink_python_config_scripts_no_config(tmp_path):
+def test_symlink_python_config_scripts_no_config(tmp_path: Path) -> None:
     """Interpreters without a config script (PyPy, GraalPy, ...) must not fail."""
     base_bin = tmp_path / "base" / "bin"
     base_bin.mkdir(parents=True)
@@ -48,7 +52,7 @@ def test_symlink_python_config_scripts_no_config(tmp_path):
     assert list(venv_bin.iterdir()) == []
 
 
-def test_symlink_python_config_scripts_existing_not_overwritten(tmp_path):
+def test_symlink_python_config_scripts_existing_not_overwritten(tmp_path: Path) -> None:
     base_bin = tmp_path / "base" / "bin"
     base_bin.mkdir(parents=True)
     base_python = base_bin / "python3"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

On macOS, cibuildwheel builds and tests inside a virtualenv and only adds the venv's `bin` directory to `PATH`. Virtualenvs don't contain `python3-config`, so builds that invoke it (for include dirs / link flags) pick up an unrelated one from elsewhere on `PATH` — typically the system or Homebrew Python — producing broken wheels or ABI mismatches.

## Fix

As suggested in review, the base interpreter's `bin` directory is added to `PATH` right after the venv's (POSIX only), for both build and test venvs. The matching `python3-config`/`python3.X-config` is then found first, and the same holds for anything else shipped next to the base interpreter (e.g. `pypy3-config`, `graalpy3-config`). The venv itself is not modified, and its `bin` still comes first, so `python`/`pip` continue to resolve to the venv.

Callers that need stricter isolation are unaffected: iOS rewrites `PATH` wholesale after venv creation, and Linux builds don't use this code path.

Closes #2021
