### PR TITLE
chore: drop orjson

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,6 @@ repos:
       - dependency-groups>=1.2
       - humanize
       - nox>=2025.2.9
-      - orjson
       - packaging
       - pygithub
       - pytest


### PR DESCRIPTION
Not used by mypy 2+ (sqlite used instead of json)

Also orjson doesn't have free-threading wheels.
