### PR TITLE
docs: replace outdated note about build frontend and remove mention of ClearLinux

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -807,7 +807,7 @@ instead.
 ### `before-build` {: #before-build env-var toml}
 > Execute a shell command preparing each wheel's build
 
-A shell command to run before building the wheel. This option allows you to run a command in **each** Python environment before the `pip wheel` command. This is useful if you need to set up some dependency so it's available during the build.
+A shell command to run before building the wheel. This option allows you to run a command in **each** Python environment before the wheel is built. This is useful if you need to set up some dependency so it's available during the build.
 
 If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a `pyproject.toml` file's `build-system.requires` array instead. This is reproducible, and users who do not get your wheels (such as Alpine or ClearLinux users) will still benefit.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -809,7 +809,7 @@ instead.
 
 A shell command to run before building the wheel. This option allows you to run a command in **each** Python environment before the wheel is built. This is useful if you need to set up some dependency so it's available during the build.
 
-If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a `pyproject.toml` file's `build-system.requires` array instead. This is reproducible, and users who do not get your wheels (such as Alpine users) will still benefit.
+If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a `pyproject.toml` file's `build-system.requires` array instead. This is reproducible, and users who do not get your wheels (such as BSD operating system variants) will still benefit.
 
 The active Python binary can be accessed using `python`, and pip with `pip`; cibuildwheel makes sure the right version of Python and pip will be executed. The placeholder `{package}` can be used here; it will be replaced by the path to the package being built by cibuildwheel.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -809,7 +809,7 @@ instead.
 
 A shell command to run before building the wheel. This option allows you to run a command in **each** Python environment before the wheel is built. This is useful if you need to set up some dependency so it's available during the build.
 
-If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a `pyproject.toml` file's `build-system.requires` array instead. This is reproducible, and users who do not get your wheels (such as Alpine or ClearLinux users) will still benefit.
+If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a `pyproject.toml` file's `build-system.requires` array instead. This is reproducible, and users who do not get your wheels (such as Alpine users) will still benefit.
 
 The active Python binary can be accessed using `python`, and pip with `pip`; cibuildwheel makes sure the right version of Python and pip will be executed. The placeholder `{package}` can be used here; it will be replaced by the path to the package being built by cibuildwheel.
 


### PR DESCRIPTION
- Remove a reference to `pip wheel`, as our build frontend has been pypa/build since v2.x I believe, or at least for a long time anyway. I made the sentence agnostic to the build frontend.
- Drop a mention of ClearLinux, as it is now discontinued and fully abandoned since July 2025: https://endoflife.date/clear-linux

Noticed when reading through https://github.com/scikit-learn/scikit-learn-release/issues/1