### PR TITLE
docs: replace http://github.com links with https://github.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Credits
 
 `cibuildwheel` stands on the shoulders of giants.
 
-- ⭐️ @matthew-brett for [multibuild](https://github.com/multi-build/multibuild) and [matthew-brett/delocate](http://github.com/matthew-brett/delocate)
+- ⭐️ @matthew-brett for [multibuild](https://github.com/multi-build/multibuild) and [matthew-brett/delocate](https://github.com/matthew-brett/delocate)
 - @PyPA for the manylinux Docker images [pypa/manylinux](https://github.com/pypa/manylinux)
 - @ogrisel for [wheelhouse-uploader](https://github.com/ogrisel/wheelhouse-uploader) and `run_with_env.cmd`
 
@@ -391,6 +391,6 @@ Massive props also to-
 See also
 ========
 
-Another very similar tool to consider is [matthew-brett/multibuild](http://github.com/matthew-brett/multibuild). `multibuild` is a shell script toolbox for building a wheel on various platforms. It is used as a basis to build some of the big data science tools, like SciPy.
+Another very similar tool to consider is [matthew-brett/multibuild](https://github.com/matthew-brett/multibuild). `multibuild` is a shell script toolbox for building a wheel on various platforms. It is used as a basis to build some of the big data science tools, like SciPy.
 
 If you are building Rust wheels, you can get by without some of the tricks required to make GLIBC work via manylinux; this is especially relevant for cross-compiling, which is easy with Rust. See [maturin-action](https://github.com/PyO3/maturin-action) for a tool that is optimized for building Rust wheels and cross-compiling.


### PR DESCRIPTION
## What

Two links in `README.md` use `http://github.com` instead of `https://github.com`:

- **Line 379**: `matthew-brett/delocate` acknowledgement link
- **Line 394**: `matthew-brett/multibuild` in the "See also" section

## Why

GitHub has been HTTPS-only since 2017. Both links correctly serve HTTPS today and redirect from HTTP, but the source should use the canonical URL. Using `https://` from the start avoids an unnecessary 301 redirect and is consistent with all the other GitHub links in the file.

## How verified

Checked both URLs respond with `200 OK` on `https://` and return `301 → https://` on `http://`:

```
curl -I http://github.com/matthew-brett/delocate   → 301 → https://github.com/matthew-brett/delocate
curl -I https://github.com/matthew-brett/delocate  → 200 OK
curl -I http://github.com/matthew-brett/multibuild  → 301 → https://github.com/matthew-brett/multibuild
curl -I https://github.com/matthew-brett/multibuild → 200 OK
```