### PR TITLE
Use a custom Python shell for our action's cibuildwheel setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,6 @@ runs:
     - id: cibw
       run: |
         # Install cibuildwheel and build the command line
-        "$PYTHON" -u << "EOF"
         import os
         import shlex
         import shutil
@@ -116,10 +115,8 @@ runs:
             f.write(f"cmd-pwsh={cmd_pwsh}\n")
 
         print("::endgroup::")
-        EOF
-      shell: bash
+      shell: ${{ steps.python.outputs.python-path }} -u {0}
       env:
-        PYTHON: ${{ steps.python.outputs.python-path }}
         INPUT_PACKAGE_DIR: ${{ inputs.package-dir }}
         INPUT_OUTPUT_DIR: ${{ inputs.output-dir }}
         INPUT_CONFIG_FILE: ${{ inputs.config-file }}


### PR DESCRIPTION
Just a nicer way of expressing things instead of a Bash Heredoc. This uses a [Python](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-running-an-inline-python-script) [custom shell](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#custom-shell). I validated this with the GitHub Actions schema locally, and it looks like it's a supported pattern:

- https://github.com/search?q=%22shell:+$%7B%7B+steps%22+language:YAML&type=code
- https://github.com/search?q=%22shell:+python+-u%22+language:YAML&type=code&l=YAML

Let's see if our own tests that use the action pass or not!