### PR TITLE
Use absolute path for `{project}` placeholder in `config-settings`

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -310,7 +310,9 @@ def setup_env(
         "wheel",
         parse_config_settings(
             prepare_config_settings(
-                build_options.config_settings, project=".", package=build_options.package_dir
+                build_options.config_settings,
+                project=Path.cwd(),
+                package=build_options.package_dir,
             )
         ),
     )
@@ -600,7 +602,7 @@ def build_wheel(state: BuildState) -> Path:
                     state.options.build_verbosity,
                     prepare_config_settings(
                         state.options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=state.options.package_dir,
                     ),
                 ),
@@ -621,7 +623,7 @@ def build_wheel(state: BuildState) -> Path:
                     state.options.build_verbosity,
                     prepare_config_settings(
                         state.options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=state.options.package_dir,
                     ),
                 ),

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -559,7 +559,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     build_options.build_verbosity,
                     prepare_config_settings(
                         build_options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=build_options.package_dir,
                     ),
                 )

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -537,7 +537,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     build_options.build_verbosity,
                     prepare_config_settings(
                         build_options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=build_options.package_dir,
                     ),
                 )

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -489,7 +489,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     build_options.build_verbosity,
                     prepare_config_settings(
                         build_options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=build_options.package_dir,
                     ),
                 )

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -492,7 +492,7 @@ def build(options: Options, tmp_path: Path) -> None:
                     build_options.build_verbosity,
                     prepare_config_settings(
                         build_options.config_settings,
-                        project=".",
+                        project=Path.cwd(),
                         package=options.globals.package_dir,
                     ),
                 )


### PR DESCRIPTION
While the `project="."` pattern is consistent across all platforms and all our build stages, it's specifically incorrect for `config-settings`, because that value is passed to `python -m build` and consumed by the build backend, which may run from a different CWD. It's better to pass the absolute path to the project root in `prepare_config_settings` in this case. This only failed on Windows and macOS, as `{project}` on Linux was always absolute (we set it as `/project` via the container there).

I think we should add a test or something for this, but I'm not sure what would be best. Should I add a project that cross-compiles a wheel using a Meson cross file (like I use this functionality)? Or perhaps `test/test_projects/meson.py` can stay as is, but I add a `--native-file` since it's resolved the same way a cross file is?

xref #2827