### PR TITLE
feat: add support for container_engine=none

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,3 +370,74 @@ jobs:
         CIBW_BUILD: cp314-*
         CIBW_BUILD_FRONTEND: 'build[uv]'
         CIBW_PLATFORM: ${{ matrix.test_select }}
+
+  test-native-linux:
+    needs: sample
+    name: Test native linux on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: quay.io/pypa/manylinux_2_28:latest # zizmor: ignore[unpinned-images]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
+    steps:
+    - name: Prepare container
+      shell: bash
+      run: |
+        exec 2>&1
+        CPYTHON_DIR="${RUNNER_TOOL_CACHE}/Python"
+        if [ -d "${CPYTHON_DIR}" ]; then
+          echo "::group::Removing existing CPython tool cache"
+          set -x
+          rm -rf "${CPYTHON_DIR}"
+          set +x
+          echo "::endgroup::"
+        fi
+        for SOURCE_DIR in /opt/_internal/cpython-*; do
+          echo "::group::Adding '${SOURCE_DIR}' to the tool cache"
+          set -x
+          VERSION_MANYLINUX=${SOURCE_DIR:23}
+          case "${VERSION_MANYLINUX}" in
+            *-nogil) ARCH="${RUNNER_ARCH,,}-freethreaded";;
+            *) ARCH="${RUNNER_ARCH,,}";;
+          esac
+          VERSION=${VERSION_MANYLINUX%%-*}
+          case "${VERSION}" in
+            *a*) VERSION=${VERSION/a/-alpha.};;
+            *b*) VERSION=${VERSION/b/-beta.};;
+            *rc*) VERSION=${VERSION/rc/-rc.};;
+          esac
+          DEST_DIR="${CPYTHON_DIR}/${VERSION}"
+          mkdir -p "${DEST_DIR}"
+          ln -s ${SOURCE_DIR} "${DEST_DIR}/${ARCH}"
+          touch "${DEST_DIR}/${ARCH}.complete"
+          set +x
+          echo "::endgroup::"
+        done
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Download a sample project
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sample_proj
+        path: sample_proj
+    - name: Run a sample build (GitHub Action)
+      uses: ./
+      with:
+        package-dir: sample_proj
+        output-dir: wheelhouse
+      env:
+        CIBW_CONTAINER_ENGINE: "none"
+        CIBW_BUILD_FRONTEND: 'build[uv]'
+        CIBW_SKIP: "*-musllinux*"
+
+    - name: Install dependencies
+      run: uv sync --no-dev --group test
+
+    - name: Test cibuildwheel
+      env:
+        CIBW_CONTAINER_ENGINE: "none"
+        CIBW_PLATFORM: "linux"
+      run: uv run --no-sync bin/run_tests.py --test-select=native

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,3 +374,74 @@ jobs:
         CIBW_BUILD: cp314-*
         CIBW_BUILD_FRONTEND: 'build[uv]'
         CIBW_PLATFORM: ${{ matrix.test_select }}
+
+  test-native-linux:
+    needs: sample
+    name: Test native linux on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: quay.io/pypa/manylinux_2_28:latest # zizmor: ignore[unpinned-images]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
+    steps:
+    - name: Prepare container
+      shell: bash
+      run: |
+        exec 2>&1
+        CPYTHON_DIR="${RUNNER_TOOL_CACHE}/Python"
+        if [ -d "${CPYTHON_DIR}" ]; then
+          echo "::group::Removing existing CPython tool cache"
+          set -x
+          rm -rf "${CPYTHON_DIR}"
+          set +x
+          echo "::endgroup::"
+        fi
+        for SOURCE_DIR in /opt/_internal/cpython-*; do
+          echo "::group::Adding '${SOURCE_DIR}' to the tool cache"
+          set -x
+          VERSION_MANYLINUX=${SOURCE_DIR:23}
+          case "${VERSION_MANYLINUX}" in
+            *-nogil) ARCH="${RUNNER_ARCH,,}-freethreaded";;
+            *) ARCH="${RUNNER_ARCH,,}";;
+          esac
+          VERSION=${VERSION_MANYLINUX%%-*}
+          case "${VERSION}" in
+            *a*) VERSION=${VERSION/a/-alpha.};;
+            *b*) VERSION=${VERSION/b/-beta.};;
+            *rc*) VERSION=${VERSION/rc/-rc.};;
+          esac
+          DEST_DIR="${CPYTHON_DIR}/${VERSION}"
+          mkdir -p "${DEST_DIR}"
+          ln -s ${SOURCE_DIR} "${DEST_DIR}/${ARCH}"
+          touch "${DEST_DIR}/${ARCH}.complete"
+          set +x
+          echo "::endgroup::"
+        done
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Download a sample project
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sample_proj
+        path: sample_proj
+    - name: Run a sample build (GitHub Action)
+      uses: ./
+      with:
+        package-dir: sample_proj
+        output-dir: wheelhouse
+      env:
+        CIBW_CONTAINER_ENGINE: "none"
+        CIBW_BUILD_FRONTEND: 'build[uv]'
+        CIBW_SKIP: "*-musllinux*"
+
+    - name: Install dependencies
+      run: uv sync --no-dev --group test
+
+    - name: Test cibuildwheel
+      env:
+        CIBW_CONTAINER_ENGINE: "none"
+        CIBW_PLATFORM: "linux"
+      run: uv run --no-sync bin/run_tests.py --test-select=native

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -96,7 +96,7 @@ properties:
     type: string_table_array
   container-engine:
     oneOf:
-      - enum: [docker, podman]
+      - enum: [docker, podman, none]
       - type: string
         pattern: '^docker; ?(create_args|disable_host_mount):'
       - type: string

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -74,7 +74,7 @@ properties:
     type: string_table_array
   container-engine:
     oneOf:
-      - enum: [docker, podman]
+      - enum: [docker, podman, none]
       - type: string
         pattern: '^docker; ?(create_args|disable_host_mount):'
       - type: string

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
     if (
         sys.platform.startswith("linux")
         and os.environ.get("CIBW_PLATFORM", "linux") == "linux"
+        and os.environ.get("CIBW_CONTAINER_ENGINE", "docker") != "none"
         and args.test_select in ["all", "native"]
     ):
         # run the docker unit tests only on Linux

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -6,6 +6,7 @@ __lazy_modules__ = {
     "cibuildwheel.logger",
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
+    "cibuildwheel.util.file",
     "cibuildwheel.util.helpers",
     "contextlib",
     "io",
@@ -32,13 +33,13 @@ import textwrap
 import typing
 import uuid
 from enum import Enum
-from pathlib import PurePosixPath
 from typing import Literal, assert_never
 
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.errors import OCIEngineTooOldError
 from cibuildwheel.logger import log
 from cibuildwheel.util.cmd import call
+from cibuildwheel.util.file import RemotePath, RemotePosixPath
 from cibuildwheel.util.helpers import FlexibleVersion, parse_key_value_string, strtobool
 
 TYPE_CHECKING = False
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
     from types import TracebackType
     from typing import IO, Self
 
-    from cibuildwheel.typing import PathOrStr
+    from cibuildwheel.typing import PathOrStr, PathT
 
 ContainerEngineName = Literal["docker", "podman"]
 
@@ -94,13 +95,15 @@ class OCIContainerEngineConfig:
     disable_host_mount: bool = False
 
     @classmethod
-    def from_config_string(cls, config_string: str) -> Self:
+    def from_config_string(cls, config_string: str) -> Self | None:
         config_dict = parse_key_value_string(
             config_string,
             ["name"],
             ["create_args", "create-args", "disable_host_mount", "disable-host-mount"],
         )
         name = " ".join(config_dict["name"])
+        if name == "none":
+            return None
         if name not in {"docker", "podman"}:
             msg = f"unknown container engine {name}"
             raise ValueError(msg)
@@ -208,6 +211,8 @@ class OCIContainer:
         >>> from cibuildwheel.oci_container import *  # NOQA
         >>> from cibuildwheel.options import _get_pinned_container_images
         >>> import pytest
+        >>> if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        ...     pytest.skip('needs a container engine')
         >>> try:
         ...     oci_platform = OCIPlatform.native()
         ... except OSError as ex:
@@ -439,7 +444,8 @@ class OCIContainer:
             log.warning(msg)
         self.name = None
 
-    def copy_into(self, from_path: Path, to_path: PurePath) -> None:
+    def copy_into(self, from_path: Path, to_path: RemotePath) -> None:
+        assert isinstance(to_path, RemotePosixPath)
         if from_path.is_dir():
             self.call(["mkdir", "-p", to_path])
             subprocess.run(
@@ -475,12 +481,15 @@ class OCIContainer:
                         exec_process.returncode, exec_process.args, None, None
                     )
 
-    def copy_out(self, from_path: PurePath, to_path: Path) -> None:
+    def copy_out(self, from_path: RemotePath, to_path: Path) -> None:
         # note: we assume from_path is a dir
+        assert isinstance(from_path, RemotePosixPath)
         to_path.mkdir(parents=True, exist_ok=True)
         call(self.engine.name, "cp", f"{self.name}:{from_path}/.", to_path)
 
-    def glob(self, path: PurePosixPath, pattern: str) -> list[PurePosixPath]:
+    def glob(self, path: PathT, pattern: str) -> list[PathT]:
+        assert isinstance(path, RemotePosixPath)
+        result_type = type(path)
         glob_pattern = path.joinpath(pattern)
 
         path_strings = json.loads(
@@ -494,7 +503,7 @@ class OCIContainer:
             )
         )
 
-        return [PurePosixPath(p) for p in path_strings]
+        return [result_type(p) for p in path_strings]
 
     def call(
         self,

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -162,7 +162,7 @@ class BuildOptions:
     build_verbosity: int
     build_frontend: BuildFrontendConfig
     config_settings: str
-    container_engine: OCIContainerEngineConfig
+    container_engine: OCIContainerEngineConfig | None
     pyodide_version: str | None
 
     @property

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -5,27 +5,26 @@ __lazy_modules__ = {
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
     "cibuildwheel.util",
-    "cibuildwheel.util.file",
+    "cibuildwheel.util.cmd",
     "cibuildwheel.util.helpers",
     "cibuildwheel.util.packaging",
     "collections",
     "contextlib",
-    "pathlib",
     "shutil",
     "subprocess",
     "textwrap",
-    "typing",
 }
 
 import contextlib
 import dataclasses
+import os
 import shutil
 import subprocess
 import sys
 import textwrap
 from collections import OrderedDict
 from pathlib import Path, PurePath, PurePosixPath
-from typing import assert_never
+from typing import Final, Literal, Protocol, Self, assert_never, cast
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
@@ -34,17 +33,23 @@ from cibuildwheel.frontend import get_build_frontend_extra_flags, prepare_config
 from cibuildwheel.logger import log
 from cibuildwheel.oci_container import OCIContainer, OCIContainerEngineConfig, OCIPlatform
 from cibuildwheel.util import resources
-from cibuildwheel.util.file import copy_test_sources
+from cibuildwheel.util.cmd import call
+from cibuildwheel.util.file import RemotePath, RemotePosixPath, copy_into_local, copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence, Set
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence, Set
+    from types import TracebackType
 
     from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
-    from cibuildwheel.typing import PathOrStr
+    from cibuildwheel.typing import PathOrStr, PathT
+
+
+BuilderPath = Path | RemotePath
+
 
 ARCHITECTURE_OCI_PLATFORM_MAP = {
     Architecture.x86_64: OCIPlatform.AMD64,
@@ -72,8 +77,101 @@ class PythonConfiguration:
 class BuildStep:
     platform_configs: list[PythonConfiguration]
     platform_tag: str
-    container_engine: OCIContainerEngineConfig
+    container_engine: OCIContainerEngineConfig | None
     container_image: str
+
+
+class Builder(Protocol):
+    image: str
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
+
+    def copy_into(self, from_path: Path, to_path: RemotePath) -> None: ...
+
+    def copy_out(self, from_path: RemotePath, to_path: Path) -> None: ...
+
+    def get_environment(self) -> dict[str, str]: ...
+
+    def glob(self, path: PathT, pattern: str) -> list[PathT]: ...
+
+    def call(
+        self,
+        args: Sequence[PathOrStr],
+        env: Mapping[str, str] | None = None,
+        capture_output: Literal[True, False] = False,
+        cwd: PathOrStr | None = None,
+    ) -> str: ...
+
+    def environment_executor(self, command: Sequence[str], environment: dict[str, str]) -> str: ...
+
+
+class LocalBuilder:
+    def __init__(
+        self,
+        *,
+        oci_platform: OCIPlatform,
+        cwd: PathOrStr | None = None,
+    ):
+        self.image = "native"
+        assert oci_platform == OCIPlatform.native()
+        if cwd is not None:
+            assert Path().samefile(cwd)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def copy_into(self, from_path: Path, to_path: RemotePath) -> None:
+        raise NotImplementedError()
+
+    def copy_out(self, from_path: RemotePath, to_path: Path) -> None:
+        raise NotImplementedError()
+
+    def get_environment(self) -> dict[str, str]:
+        return os.environ.copy()
+
+    def glob(self, path: PathT, pattern: str) -> list[PathT]:
+        assert isinstance(path, Path)
+        return list(path.glob(pattern))
+
+    def call(
+        self,
+        args: Sequence[PathOrStr],
+        env: Mapping[str, str] | None = None,
+        capture_output: Literal[True, False] = False,
+        cwd: PathOrStr | None = None,
+    ) -> str:
+        return call(*args, env=env, cwd=cwd, capture_stdout=capture_output) or ""
+
+    def environment_executor(self, command: Sequence[str], environment: dict[str, str]) -> str:
+        return self.call(command, env=environment, capture_output=True)
+
+
+def create_builder(
+    *,
+    image: str,
+    oci_platform: OCIPlatform,
+    cwd: BuilderPath | None = None,
+    engine: OCIContainerEngineConfig | None,
+) -> Builder:
+    if engine is None:
+        return LocalBuilder(oci_platform=oci_platform, cwd=cwd)
+    else:
+        return OCIContainer(image=image, oci_platform=oci_platform, cwd=cwd, engine=engine)
 
 
 def all_python_configurations() -> list[PythonConfiguration]:
@@ -124,7 +222,8 @@ def get_build_steps(
     Groups PythonConfigurations into BuildSteps. Each BuildStep represents a
     separate container instance.
     """
-    steps = OrderedDict[tuple[str, str, str, OCIContainerEngineConfig], BuildStep]()
+    steps = OrderedDict[tuple[str, str, str, OCIContainerEngineConfig | None], BuildStep]()
+    local_builds = []
 
     for config in python_configurations:
         _, platform_tag = config.identifier.split("-", 1)
@@ -146,12 +245,24 @@ def get_build_steps(
                 container_engine=container_engine,
                 container_image=container_image,
             )
+            if container_engine is None:
+                local_builds.append(steps[step_key])
+
+    if len(local_builds) > 1:
+        msg = (
+            "multiple local builds are configured, only one is supported when "
+            "container-engine=none (consider setting CIBW_BUILD/CIBW_ARCHS or CIBW_SKIP):"
+        )
+        for build_step in local_builds:
+            ids_to_build = [x.identifier for x in build_step.platform_configs]
+            msg += f"\n- {', '.join(ids_to_build)}"
+        raise errors.ConfigurationError(msg)
 
     yield from steps.values()
 
 
 def check_all_python_exist(
-    *, platform_configs: Iterable[PythonConfiguration], container: OCIContainer
+    *, platform_configs: Iterable[PythonConfiguration], container: Builder
 ) -> None:
     exist = True
     has_manylinux_interpreters = False
@@ -190,17 +301,19 @@ def build_in_container(
     *,
     options: Options,
     platform_configs: Sequence[PythonConfiguration],
-    container: OCIContainer,
-    container_project_path: PurePath,
-    container_package_dir: PurePath,
+    container: Builder,
+    container_project_path: BuilderPath,
+    container_package_dir: BuilderPath,
     local_tmp_dir: Path,
 ) -> None:
-    container_output_dir = PurePosixPath("/output")
-
     check_all_python_exist(platform_configs=platform_configs, container=container)
 
-    log.step("Copying project into container...")
-    container.copy_into(Path.cwd(), container_project_path)
+    if not isinstance(container_project_path, RemotePath):
+        container_output_dir: BuilderPath = options.globals.output_dir
+    else:
+        container_output_dir = RemotePosixPath("/output")
+        log.step("Copying project into container...")
+        container.copy_into(Path.cwd(), container_project_path)
 
     before_all_options_identifier = platform_configs[0].identifier
     before_all_options = options.build_options(before_all_options_identifier)
@@ -223,7 +336,7 @@ def build_in_container(
         )
         container.call(["sh", "-c", before_all_prepared], env=env)
 
-    built_wheels: list[PurePosixPath] = []
+    built_wheels: list[BuilderPath] = []
 
     for config in platform_configs:
         log.build_start(config.identifier)
@@ -241,9 +354,12 @@ def build_in_container(
             tmp_dir=local_identifier_tmp_dir,
         )
         if local_constraints_file:
-            container_constraints_file = PurePosixPath("/constraints.txt")
-            container.copy_into(local_constraints_file, container_constraints_file)
-            dependency_constraint_flags = ["-c", container_constraints_file]
+            if isinstance(container_output_dir, RemotePath):
+                container_constraints_file = RemotePosixPath("/constraints.txt")
+                container.copy_into(local_constraints_file, container_constraints_file)
+                dependency_constraint_flags = ["-c", container_constraints_file]
+            else:
+                dependency_constraint_flags = ["-c", local_constraints_file]
 
         env = container.get_environment()
         env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
@@ -302,7 +418,11 @@ def build_in_container(
 
             log.step("Building wheel...")
 
-            temp_dir = PurePosixPath("/tmp/cibuildwheel")
+            if isinstance(container_output_dir, RemotePath):
+                temp_dir: BuilderPath = RemotePosixPath("/tmp/cibuildwheel")
+            else:
+                temp_dir = local_identifier_tmp_dir
+
             built_wheel_dir = temp_dir / "built_wheel"
             container.call(["rm", "-rf", built_wheel_dir])
             container.call(["mkdir", "-p", built_wheel_dir])
@@ -408,8 +528,11 @@ def build_in_container(
                 local_abi3audit_dir = local_identifier_tmp_dir / "audit"
                 local_abi3audit_dir.mkdir(parents=True, exist_ok=True)
                 try:
-                    container.copy_out(repaired_wheel_dir, local_abi3audit_dir)
-                    local_wheel = local_abi3audit_dir / repaired_wheel.name
+                    if isinstance(repaired_wheel, RemotePath):
+                        container.copy_out(repaired_wheel.parent, local_abi3audit_dir)
+                        local_wheel = local_abi3audit_dir / repaired_wheel.name
+                    else:
+                        local_wheel = repaired_wheel
                     run_audit(tmp_dir=local_tmp_dir, build_options=build_options, wheel=local_wheel)
                 finally:
                     shutil.rmtree(local_abi3audit_dir, ignore_errors=True)
@@ -424,9 +547,7 @@ def build_in_container(
                     ["pip", "install", "virtualenv", *dependency_constraint_flags], env=env
                 )
 
-            testing_temp_dir = PurePosixPath(
-                container.call(["mktemp", "-d"], capture_output=True).strip()
-            )
+            testing_temp_dir = temp_dir / "testing"
             venv_dir = testing_temp_dir / "venv"
 
             if use_uv:
@@ -474,17 +595,21 @@ def build_in_container(
             test_cwd = testing_temp_dir / "test_cwd"
             container.call(["mkdir", "-p", test_cwd])
 
+            copy_into = cast(
+                "Callable[[Path, PurePath], None]",
+                container.copy_into if isinstance(test_cwd, RemotePath) else copy_into_local,
+            )
             if build_options.test_sources:
                 copy_test_sources(
                     build_options.test_sources,
                     Path.cwd(),
                     test_cwd,
-                    copy_into=container.copy_into,
+                    copy_into=copy_into,
                 )
             else:
                 # Use the test_fail.py file to raise a nice error if the user
                 # tries to run tests in the cwd
-                container.copy_into(resources.TEST_FAIL_CWD_FILE, test_cwd / "test_fail.py")
+                copy_into(resources.TEST_FAIL_CWD_FILE, test_cwd / "test_fail.py")
 
             container.call(["sh", "-c", test_command_prepared], cwd=test_cwd, env=virtualenv_env)
 
@@ -501,10 +626,11 @@ def build_in_container(
 
         log.build_end(output_wheel)
 
-    log.step("Copying wheels back to host...")
-    # copy the output back into the host
-    container.copy_out(container_output_dir, options.globals.output_dir)
-    log.step_end()
+    if isinstance(container_output_dir, RemotePath):
+        log.step("Copying wheels back to host...")
+        # copy the output back into the host
+        container.copy_out(container_output_dir, options.globals.output_dir)
+        log.step_end()
 
 
 def build(options: Options, tmp_path: Path) -> None:
@@ -512,43 +638,52 @@ def build(options: Options, tmp_path: Path) -> None:
         options.globals.build_selector, options.globals.architectures
     )
 
-    cwd = Path.cwd()
-    abs_package_dir = options.globals.package_dir.resolve()
+    cwd: Final = Path.cwd()
+    abs_package_dir: Final = options.globals.package_dir.resolve()
     if cwd != abs_package_dir and cwd not in abs_package_dir.parents:
         msg = "package_dir must be inside the working directory"
         raise errors.ConfigurationError(msg)
 
-    container_project_path = PurePosixPath("/project")
-    container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
-
     for build_step in get_build_steps(options, python_configurations):
-        try:
-            # check the container engine is installed
-            subprocess.run(
-                [build_step.container_engine.name, "--version"],
-                check=True,
-                stdout=subprocess.DEVNULL,
-            )
-        except subprocess.CalledProcessError as error:
-            msg = unwrap(
-                f"""
-                {build_step.container_engine.name} not found. An OCI exe like
-                Docker or Podman is required to run Linux builds. If you're
-                building on Travis CI, add `services: [docker]` to your
-                .travis.yml. If you're building on Circle CI in Linux, add a
-                `setup_remote_docker` step to your .circleci/config.yml.
-                """
-            )
-            raise errors.ConfigurationError(msg) from error
+        if build_step.container_engine is None:
+            container_project_path: BuilderPath = Path(cwd)
+            container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
+        else:
+            container_project_path = RemotePosixPath("/project")
+            container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
+            try:
+                # check the container engine is installed
+                subprocess.run(
+                    [build_step.container_engine.name, "--version"],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError as error:
+                msg = unwrap(
+                    f"""
+                    {build_step.container_engine.name} not found. An OCI exe like
+                    Docker or Podman is required to run Linux builds. If you're
+                    building on Travis CI, add `services: [docker]` to your
+                    .travis.yml. If you're building on Circle CI in Linux, add a
+                    `setup_remote_docker` step to your .circleci/config.yml.
+                    """
+                )
+                raise errors.ConfigurationError(msg) from error
 
         try:
             ids_to_build = [x.identifier for x in build_step.platform_configs]
-            log.step(f"Starting container image {build_step.container_image}...")
+            if build_step.container_engine is None:
+                log.step("Starting native build...")
+                print(
+                    f"info: This native build will host the build for {', '.join(ids_to_build)}..."
+                )
+            else:
+                log.step(f"Starting container image {build_step.container_image}...")
+                print(f"info: This container will host the build for {', '.join(ids_to_build)}...")
 
-            print(f"info: This container will host the build for {', '.join(ids_to_build)}...")
             architecture = Architecture(build_step.platform_tag.split("_", 1)[1])
 
-            with OCIContainer(
+            with create_builder(
                 image=build_step.container_image,
                 oci_platform=ARCHITECTURE_OCI_PLATFORM_MAP[architecture],
                 cwd=container_project_path,
@@ -577,16 +712,39 @@ def _matches_prepared_command(error_cmd: Sequence[str], command_template: str) -
 
 
 def troubleshoot(options: Options, error: Exception) -> None:
-    if isinstance(error, subprocess.CalledProcessError) and (
-        error.cmd[0:4] == ["python", "-m", "pip", "wheel"]
-        or error.cmd[0:2] == ["uv", "build"]
-        or error.cmd[0:3] == ["python", "-m", "build"]
+    if not isinstance(error, subprocess.CalledProcessError):
+        return
+
+    def _to_str(item: str | bytes | os.PathLike[str] | os.PathLike[bytes]) -> str:
+        if isinstance(item, str):
+            return item
+        return os.fsdecode(item)
+
+    if isinstance(error.cmd, (str, bytes, os.PathLike)):
+        cmd = [_to_str(error.cmd)]
+    else:
+        cmd = list(map(_to_str, error.cmd))
+    if cmd[0].endswith("/python"):
+        cmd[0] = "python"
+    elif cmd[0].endswith("/uv"):
+        cmd[0] = "uv"
+    elif cmd[0].endswith("/sh"):
+        cmd[0] = "sh"
+    if (
+        cmd[0:4] == ["python", "-m", "pip", "wheel"]
+        or cmd[0:2] == ["uv", "build"]
+        or cmd[0:3] == ["python", "-m", "build"]
         or _matches_prepared_command(
-            error.cmd, options.build_options(None).repair_command
+            cmd, options.build_options(None).repair_command
         )  # TODO allow matching of overrides too?
     ):
         # the wheel build step or the repair step failed
-        so_files = list(options.globals.package_dir.glob("**/*.so"))
+        setuptools_build_path = options.globals.package_dir / "build"
+        so_files = [
+            path
+            for path in options.globals.package_dir.glob("**/*.so")
+            if setuptools_build_path not in path.parents  # remove setuptools extensions
+        ]
 
         if so_files:
             print(

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -5,27 +5,26 @@ __lazy_modules__ = {
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
     "cibuildwheel.util",
-    "cibuildwheel.util.file",
+    "cibuildwheel.util.cmd",
     "cibuildwheel.util.helpers",
     "cibuildwheel.util.packaging",
     "collections",
     "contextlib",
-    "pathlib",
     "shutil",
     "subprocess",
     "textwrap",
-    "typing",
 }
 
 import contextlib
 import dataclasses
+import os
 import shutil
 import subprocess
 import sys
 import textwrap
 from collections import OrderedDict
-from pathlib import Path, PurePath, PurePosixPath
-from typing import assert_never
+from pathlib import Path, PurePosixPath
+from typing import Final, Literal, Protocol, Self, assert_never, cast
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
@@ -34,17 +33,24 @@ from cibuildwheel.frontend import get_build_frontend_extra_flags, prepare_config
 from cibuildwheel.logger import log
 from cibuildwheel.oci_container import OCIContainer, OCIContainerEngineConfig, OCIPlatform
 from cibuildwheel.util import resources
-from cibuildwheel.util.file import copy_test_sources
+from cibuildwheel.util.cmd import call
+from cibuildwheel.util.file import RemotePath, RemotePosixPath, copy_into_local, copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence, Set
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence, Set
+    from pathlib import PurePath
+    from types import TracebackType
 
     from cibuildwheel.options import BuildOptions, Options
     from cibuildwheel.selector import BuildSelector
-    from cibuildwheel.typing import PathOrStr
+    from cibuildwheel.typing import PathOrStr, PathT
+
+
+BuilderPath = Path | RemotePath
+
 
 ARCHITECTURE_OCI_PLATFORM_MAP = {
     Architecture.x86_64: OCIPlatform.AMD64,
@@ -72,8 +78,101 @@ class PythonConfiguration:
 class BuildStep:
     platform_configs: list[PythonConfiguration]
     platform_tag: str
-    container_engine: OCIContainerEngineConfig
+    container_engine: OCIContainerEngineConfig | None
     container_image: str
+
+
+class Builder(Protocol):
+    image: str
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
+
+    def copy_into(self, from_path: Path, to_path: RemotePath) -> None: ...
+
+    def copy_out(self, from_path: RemotePath, to_path: Path) -> None: ...
+
+    def get_environment(self) -> dict[str, str]: ...
+
+    def glob(self, path: PathT, pattern: str) -> list[PathT]: ...
+
+    def call(
+        self,
+        args: Sequence[PathOrStr],
+        env: Mapping[str, str] | None = None,
+        capture_output: Literal[True, False] = False,
+        cwd: PathOrStr | None = None,
+    ) -> str: ...
+
+    def environment_executor(self, command: Sequence[str], environment: dict[str, str]) -> str: ...
+
+
+class LocalBuilder:
+    def __init__(
+        self,
+        *,
+        oci_platform: OCIPlatform,
+        cwd: PathOrStr | None = None,
+    ):
+        self.image = "native"
+        assert oci_platform == OCIPlatform.native()
+        if cwd is not None:
+            assert Path().samefile(cwd)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def copy_into(self, from_path: Path, to_path: RemotePath) -> None:
+        raise NotImplementedError()
+
+    def copy_out(self, from_path: RemotePath, to_path: Path) -> None:
+        raise NotImplementedError()
+
+    def get_environment(self) -> dict[str, str]:
+        return os.environ.copy()
+
+    def glob(self, path: PathT, pattern: str) -> list[PathT]:
+        assert isinstance(path, Path)
+        return list(path.glob(pattern))
+
+    def call(
+        self,
+        args: Sequence[PathOrStr],
+        env: Mapping[str, str] | None = None,
+        capture_output: Literal[True, False] = False,
+        cwd: PathOrStr | None = None,
+    ) -> str:
+        return call(*args, env=env, cwd=cwd, capture_stdout=capture_output) or ""
+
+    def environment_executor(self, command: Sequence[str], environment: dict[str, str]) -> str:
+        return self.call(command, env=environment, capture_output=True)
+
+
+def create_builder(
+    *,
+    image: str,
+    oci_platform: OCIPlatform,
+    cwd: BuilderPath | None = None,
+    engine: OCIContainerEngineConfig | None,
+) -> Builder:
+    if engine is None:
+        return LocalBuilder(oci_platform=oci_platform, cwd=cwd)
+    else:
+        return OCIContainer(image=image, oci_platform=oci_platform, cwd=cwd, engine=engine)
 
 
 def all_python_configurations() -> list[PythonConfiguration]:
@@ -124,7 +223,8 @@ def get_build_steps(
     Groups PythonConfigurations into BuildSteps. Each BuildStep represents a
     separate container instance.
     """
-    steps = OrderedDict[tuple[str, str, str, OCIContainerEngineConfig], BuildStep]()
+    steps = OrderedDict[tuple[str, str, str, OCIContainerEngineConfig | None], BuildStep]()
+    local_builds = []
 
     for config in python_configurations:
         _, platform_tag = config.identifier.split("-", 1)
@@ -146,12 +246,24 @@ def get_build_steps(
                 container_engine=container_engine,
                 container_image=container_image,
             )
+            if container_engine is None:
+                local_builds.append(steps[step_key])
+
+    if len(local_builds) > 1:
+        msg = (
+            "multiple local builds are configured, only one is supported when "
+            "container-engine=none (consider setting CIBW_BUILD/CIBW_ARCHS or CIBW_SKIP):"
+        )
+        for build_step in local_builds:
+            ids_to_build = [x.identifier for x in build_step.platform_configs]
+            msg += f"\n- {', '.join(ids_to_build)}"
+        raise errors.ConfigurationError(msg)
 
     yield from steps.values()
 
 
 def check_all_python_exist(
-    *, platform_configs: Iterable[PythonConfiguration], container: OCIContainer
+    *, platform_configs: Iterable[PythonConfiguration], container: Builder
 ) -> None:
     exist = True
     has_manylinux_interpreters = False
@@ -190,17 +302,19 @@ def build_in_container(
     *,
     options: Options,
     platform_configs: Sequence[PythonConfiguration],
-    container: OCIContainer,
-    container_project_path: PurePath,
-    container_package_dir: PurePath,
+    container: Builder,
+    container_project_path: BuilderPath,
+    container_package_dir: BuilderPath,
     local_tmp_dir: Path,
 ) -> None:
-    container_output_dir = PurePosixPath("/output")
-
     check_all_python_exist(platform_configs=platform_configs, container=container)
 
-    log.step("Copying project into container...")
-    container.copy_into(Path.cwd(), container_project_path)
+    if not isinstance(container_project_path, RemotePath):
+        container_output_dir: BuilderPath = options.globals.output_dir
+    else:
+        container_output_dir = RemotePosixPath("/output")
+        log.step("Copying project into container...")
+        container.copy_into(Path.cwd(), container_project_path)
 
     before_all_options_identifier = platform_configs[0].identifier
     before_all_options = options.build_options(before_all_options_identifier)
@@ -223,7 +337,7 @@ def build_in_container(
         )
         container.call(["sh", "-c", before_all_prepared], env=env)
 
-    built_wheels: list[PurePosixPath] = []
+    built_wheels: list[BuilderPath] = []
 
     for config in platform_configs:
         log.build_start(config.identifier)
@@ -241,9 +355,12 @@ def build_in_container(
             tmp_dir=local_identifier_tmp_dir,
         )
         if local_constraints_file:
-            container_constraints_file = PurePosixPath("/constraints.txt")
-            container.copy_into(local_constraints_file, container_constraints_file)
-            dependency_constraint_flags = ["-c", container_constraints_file]
+            if isinstance(container_output_dir, RemotePath):
+                container_constraints_file = RemotePosixPath("/constraints.txt")
+                container.copy_into(local_constraints_file, container_constraints_file)
+                dependency_constraint_flags = ["-c", container_constraints_file]
+            else:
+                dependency_constraint_flags = ["-c", local_constraints_file]
 
         env = container.get_environment()
         env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
@@ -274,6 +391,11 @@ def build_in_container(
                 msg = "pip available on PATH doesn't match our installed instance. If you have modified PATH, ensure that you don't overwrite cibuildwheel's entry or insert pip above it."
                 raise errors.FatalError(msg)
 
+        if isinstance(container_output_dir, RemotePath):
+            temp_dir: BuilderPath = RemotePosixPath("/tmp/cibuildwheel")
+        else:
+            temp_dir = local_identifier_tmp_dir
+
         compatible_wheel = find_compatible_wheel(built_wheels, config.identifier)
         if compatible_wheel:
             log.step_end()
@@ -302,7 +424,6 @@ def build_in_container(
 
             log.step("Building wheel...")
 
-            temp_dir = PurePosixPath("/tmp/cibuildwheel")
             built_wheel_dir = temp_dir / "built_wheel"
             container.call(["rm", "-rf", built_wheel_dir])
             container.call(["mkdir", "-p", built_wheel_dir])
@@ -408,8 +529,11 @@ def build_in_container(
                 local_abi3audit_dir = local_identifier_tmp_dir / "audit"
                 local_abi3audit_dir.mkdir(parents=True, exist_ok=True)
                 try:
-                    container.copy_out(repaired_wheel_dir, local_abi3audit_dir)
-                    local_wheel = local_abi3audit_dir / repaired_wheel.name
+                    if isinstance(repaired_wheel, RemotePath):
+                        container.copy_out(repaired_wheel.parent, local_abi3audit_dir)
+                        local_wheel = local_abi3audit_dir / repaired_wheel.name
+                    else:
+                        local_wheel = repaired_wheel
                     run_audit(tmp_dir=local_tmp_dir, build_options=build_options, wheel=local_wheel)
                 finally:
                     shutil.rmtree(local_abi3audit_dir, ignore_errors=True)
@@ -424,9 +548,7 @@ def build_in_container(
                     ["pip", "install", "virtualenv", *dependency_constraint_flags], env=env
                 )
 
-            testing_temp_dir = PurePosixPath(
-                container.call(["mktemp", "-d"], capture_output=True).strip()
-            )
+            testing_temp_dir = temp_dir / "testing"
             venv_dir = testing_temp_dir / "venv"
 
             if use_uv:
@@ -474,17 +596,21 @@ def build_in_container(
             test_cwd = testing_temp_dir / "test_cwd"
             container.call(["mkdir", "-p", test_cwd])
 
+            copy_into = cast(
+                "Callable[[Path, PurePath], None]",
+                container.copy_into if isinstance(test_cwd, RemotePath) else copy_into_local,
+            )
             if build_options.test_sources:
                 copy_test_sources(
                     build_options.test_sources,
                     Path.cwd(),
                     test_cwd,
-                    copy_into=container.copy_into,
+                    copy_into=copy_into,
                 )
             else:
                 # Use the test_fail.py file to raise a nice error if the user
                 # tries to run tests in the cwd
-                container.copy_into(resources.TEST_FAIL_CWD_FILE, test_cwd / "test_fail.py")
+                copy_into(resources.TEST_FAIL_CWD_FILE, test_cwd / "test_fail.py")
 
             container.call(["sh", "-c", test_command_prepared], cwd=test_cwd, env=virtualenv_env)
 
@@ -501,10 +627,11 @@ def build_in_container(
 
         log.build_end(output_wheel)
 
-    log.step("Copying wheels back to host...")
-    # copy the output back into the host
-    container.copy_out(container_output_dir, options.globals.output_dir)
-    log.step_end()
+    if isinstance(container_output_dir, RemotePath):
+        log.step("Copying wheels back to host...")
+        # copy the output back into the host
+        container.copy_out(container_output_dir, options.globals.output_dir)
+        log.step_end()
 
 
 def build(options: Options, tmp_path: Path) -> None:
@@ -512,43 +639,52 @@ def build(options: Options, tmp_path: Path) -> None:
         options.globals.build_selector, options.globals.architectures
     )
 
-    cwd = Path.cwd()
-    abs_package_dir = options.globals.package_dir.resolve()
+    cwd: Final = Path.cwd()
+    abs_package_dir: Final = options.globals.package_dir.resolve()
     if cwd != abs_package_dir and cwd not in abs_package_dir.parents:
         msg = "package_dir must be inside the working directory"
         raise errors.ConfigurationError(msg)
 
-    container_project_path = PurePosixPath("/project")
-    container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
-
     for build_step in get_build_steps(options, python_configurations):
-        try:
-            # check the container engine is installed
-            subprocess.run(
-                [build_step.container_engine.name, "--version"],
-                check=True,
-                stdout=subprocess.DEVNULL,
-            )
-        except subprocess.CalledProcessError as error:
-            msg = unwrap(
-                f"""
-                {build_step.container_engine.name} not found. An OCI exe like
-                Docker or Podman is required to run Linux builds. If you're
-                building on Travis CI, add `services: [docker]` to your
-                .travis.yml. If you're building on Circle CI in Linux, add a
-                `setup_remote_docker` step to your .circleci/config.yml.
-                """
-            )
-            raise errors.ConfigurationError(msg) from error
+        if build_step.container_engine is None:
+            container_project_path: BuilderPath = Path(cwd)
+            container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
+        else:
+            container_project_path = RemotePosixPath("/project")
+            container_package_dir = container_project_path / abs_package_dir.relative_to(cwd)
+            try:
+                # check the container engine is installed
+                subprocess.run(
+                    [build_step.container_engine.name, "--version"],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError as error:
+                msg = unwrap(
+                    f"""
+                    {build_step.container_engine.name} not found. An OCI exe like
+                    Docker or Podman is required to run Linux builds. If you're
+                    building on Travis CI, add `services: [docker]` to your
+                    .travis.yml. If you're building on Circle CI in Linux, add a
+                    `setup_remote_docker` step to your .circleci/config.yml.
+                    """
+                )
+                raise errors.ConfigurationError(msg) from error
 
         try:
             ids_to_build = [x.identifier for x in build_step.platform_configs]
-            log.step(f"Starting container image {build_step.container_image}...")
+            if build_step.container_engine is None:
+                log.step("Starting native build...")
+                print(
+                    f"info: This native build will host the build for {', '.join(ids_to_build)}..."
+                )
+            else:
+                log.step(f"Starting container image {build_step.container_image}...")
+                print(f"info: This container will host the build for {', '.join(ids_to_build)}...")
 
-            print(f"info: This container will host the build for {', '.join(ids_to_build)}...")
             architecture = Architecture(build_step.platform_tag.split("_", 1)[1])
 
-            with OCIContainer(
+            with create_builder(
                 image=build_step.container_image,
                 oci_platform=ARCHITECTURE_OCI_PLATFORM_MAP[architecture],
                 cwd=container_project_path,
@@ -577,16 +713,39 @@ def _matches_prepared_command(error_cmd: Sequence[str], command_template: str) -
 
 
 def troubleshoot(options: Options, error: Exception) -> None:
-    if isinstance(error, subprocess.CalledProcessError) and (
-        error.cmd[0:4] == ["python", "-m", "pip", "wheel"]
-        or error.cmd[0:2] == ["uv", "build"]
-        or error.cmd[0:3] == ["python", "-m", "build"]
+    if not isinstance(error, subprocess.CalledProcessError):
+        return
+
+    def _to_str(item: str | bytes | os.PathLike[str] | os.PathLike[bytes]) -> str:
+        if isinstance(item, str):
+            return item
+        return os.fsdecode(item)
+
+    if isinstance(error.cmd, (str, bytes, os.PathLike)):
+        cmd = [_to_str(error.cmd)]
+    else:
+        cmd = list(map(_to_str, error.cmd))
+    if cmd[0].endswith("/python"):
+        cmd[0] = "python"
+    elif cmd[0].endswith("/uv"):
+        cmd[0] = "uv"
+    elif cmd[0].endswith("/sh"):
+        cmd[0] = "sh"
+    if (
+        cmd[0:4] == ["python", "-m", "pip", "wheel"]
+        or cmd[0:2] == ["uv", "build"]
+        or cmd[0:3] == ["python", "-m", "build"]
         or _matches_prepared_command(
-            error.cmd, options.build_options(None).repair_command
+            cmd, options.build_options(None).repair_command
         )  # TODO allow matching of overrides too?
     ):
         # the wheel build step or the repair step failed
-        so_files = list(options.globals.package_dir.glob("**/*.so"))
+        setuptools_build_path = options.globals.package_dir / "build"
+        so_files = [
+            path
+            for path in options.globals.package_dir.glob("**/*.so")
+            if setuptools_build_path not in path.parents  # remove setuptools extensions
+        ]
 
         if so_files:
             print(

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -230,7 +230,8 @@
         {
           "enum": [
             "docker",
-            "podman"
+            "podman",
+            "none"
           ]
         },
         {

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -291,7 +291,8 @@
         {
           "enum": [
             "docker",
-            "podman"
+            "podman",
+            "none"
           ]
         },
         {

--- a/cibuildwheel/typing.py
+++ b/cibuildwheel/typing.py
@@ -1,6 +1,6 @@
 import os
 import typing
-from typing import Final, Literal, Protocol
+from typing import Final, Literal, Protocol, TypeVar
 
 __all__ = (
     "PLATFORMS",
@@ -10,7 +10,7 @@ __all__ = (
 
 
 PathOrStr = str | os.PathLike[str]
-
+PathT = TypeVar("PathT", bound=os.PathLike[str])
 
 PlatformName = Literal["linux", "macos", "windows", "pyodide", "android", "ios"]
 PLATFORMS: Final[frozenset[PlatformName]] = frozenset(typing.get_args(PlatformName))

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -7,7 +7,6 @@ __lazy_modules__ = {
     "shutil",
     "ssl",
     "tarfile",
-    "typing",
     "urllib",
     "urllib.request",
     "zipfile",
@@ -22,8 +21,8 @@ import tarfile
 import time
 import urllib.request
 from contextlib import contextmanager
-from pathlib import Path, PurePath
-from typing import Final
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from typing import Final, final
 from zipfile import ZipFile
 
 import certifi
@@ -39,6 +38,19 @@ DEFAULT_CIBW_CACHE_PATH: Final[Path] = user_cache_path(appname="cibuildwheel", a
 CIBW_CACHE_PATH: Final[Path] = Path(
     os.environ.get("CIBW_CACHE_PATH", DEFAULT_CIBW_CACHE_PATH)
 ).resolve()
+
+
+@final
+class RemotePosixPath(PurePosixPath):
+    pass
+
+
+@final
+class RemoteWindowsPath(PureWindowsPath):
+    pass
+
+
+RemotePath = RemotePosixPath | RemoteWindowsPath
 
 
 @contextmanager

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -7,7 +7,6 @@ __lazy_modules__ = {
     "shutil",
     "ssl",
     "tarfile",
-    "typing",
     "urllib",
     "urllib.error",
     "urllib.request",
@@ -24,8 +23,8 @@ import time
 import urllib.error
 import urllib.request
 from contextlib import contextmanager
-from pathlib import Path, PurePath
-from typing import Final
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from typing import Final, final
 from zipfile import ZipFile
 
 import certifi
@@ -41,6 +40,19 @@ DEFAULT_CIBW_CACHE_PATH: Final[Path] = user_cache_path(appname="cibuildwheel", a
 CIBW_CACHE_PATH: Final[Path] = Path(
     os.environ.get("CIBW_CACHE_PATH", DEFAULT_CIBW_CACHE_PATH)
 ).resolve()
+
+
+@final
+class RemotePosixPath(PurePosixPath):
+    pass
+
+
+@final
+class RemoteWindowsPath(PureWindowsPath):
+    pass
+
+
+RemotePath = RemotePosixPath | RemoteWindowsPath
 
 
 @contextmanager

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -158,7 +158,11 @@ def docker_warmup_fixture(
     request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory, worker_id: str
 ) -> Generator[None, None, None]:
     # if we're in CI testing linux, let's warm-up docker images
-    if detect_ci_provider() is None or get_platform() != "linux":
+    if (
+        detect_ci_provider() is None
+        or get_platform() != "linux"
+        or os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none"
+    ):
         images = None
     elif request.config.getoption("--run-emulation", default=None) is not None:
         # emulation tests only run one test in CI, caching the image only slows down the test
@@ -239,7 +243,11 @@ def build_frontend_env(request: pytest.FixtureRequest) -> Generator[dict[str, st
 @pytest.fixture
 def docker_cleanup() -> Generator[None, None, None]:
     def get_images() -> set[str]:
-        if detect_ci_provider() is None or get_platform() != "linux":
+        if (
+            detect_ci_provider() is None
+            or get_platform() != "linux"
+            or os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none"
+        ):
             return set()
         images = subprocess.run(
             ["docker", "image", "ls", "--format", "{{json .ID}}"],

--- a/test/test_before_all.py
+++ b/test/test_before_all.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import textwrap
 
@@ -84,15 +85,14 @@ def test_failing_command(tmp_path: Path) -> None:
 def test_cwd(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     test_projects.new_c_project().generate(project_dir)
-
-    actual_wheels = utils.cibuildwheel_run(
-        project_dir,
-        add_env={
-            "CIBW_BEFORE_ALL": f'''python -c "import os; assert os.getcwd() == {str(project_dir)!r}"''',
-            "CIBW_BEFORE_ALL_LINUX": '''python -c "import os; assert os.getcwd() == '/project'"''',
-        },
-        single_python=True,
-    )
+    add_env = {
+        "CIBW_BEFORE_ALL": f'''python -c "import os; assert os.getcwd() == {str(project_dir)!r}"''',
+    }
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") != "none":
+        add_env["CIBW_BEFORE_ALL_LINUX"] = (
+            '''python -c "import os; assert os.getcwd() == '/project'"'''
+        )
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env=add_env, single_python=True)
 
     expected_wheels = utils.expected_wheels("spam", "0.1.0", single_python=True)
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_before_build.py
+++ b/test/test_before_build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import textwrap
 
@@ -89,14 +90,14 @@ def test_cwd(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     test_projects.new_c_project().generate(project_dir)
 
-    actual_wheels = utils.cibuildwheel_run(
-        project_dir,
-        add_env={
-            "CIBW_BEFORE_BUILD": f'''python -c "import os; assert os.getcwd() == {str(project_dir)!r}"''',
-            "CIBW_BEFORE_BUILD_LINUX": '''python -c "import os; assert os.getcwd() == '/project'"''',
-        },
-        single_python=True,
-    )
+    add_env = {
+        "CIBW_BEFORE_BUILD": f'''python -c "import os; assert os.getcwd() == {str(project_dir)!r}"''',
+    }
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") != "none":
+        add_env["CIBW_BEFORE_BUILD_LINUX"] = (
+            '''python -c "import os; assert os.getcwd() == '/project'"'''
+        )
+    actual_wheels = utils.cibuildwheel_run(project_dir, add_env=add_env, single_python=True)
 
     expected_wheels = utils.expected_wheels("spam", "0.1.0", single_python=True)
     assert set(actual_wheels) == set(expected_wheels)

--- a/test/test_container_engine.py
+++ b/test/test_container_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from . import test_projects, utils
@@ -19,7 +21,6 @@ def test_podman(
 ) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the test is only relevant to the linux build")
-
     if not request.config.getoption("--run-podman"):
         pytest.skip("needs --run-podman option to run")
 
@@ -52,7 +53,8 @@ def test_podman(
 def test_create_args(tmp_path: Path, capfd: pytest.CaptureFixture[str]) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the test is only relevant to the linux build")
-
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        pytest.skip("the test is only relevant for CIBW_CONTAINER_ENGINE != 'none'")
     project_dir = tmp_path / "project"
     basic_project.generate(project_dir)
 

--- a/test/test_container_images.py
+++ b/test/test_container_images.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import textwrap
 
@@ -31,6 +32,8 @@ dockcross_only_project = test_projects.new_c_project(
 def test(tmp_path: Path) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the test is only relevant to the linux build")
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        pytest.skip("the test is only relevant for CIBW_CONTAINER_ENGINE != 'none'")
     if platform.machine() not in ["x86_64", "i686"]:
         pytest.skip(
             "this test is currently only possible on x86_64/i686 due to availability of alternative images"

--- a/test/test_from_sdist.py
+++ b/test/test_from_sdist.py
@@ -45,6 +45,9 @@ def cibuildwheel_from_sdist_run(
         env.update(add_env)
 
     env["CIBW_BUILD"] = "cp{}{}-*".format(*utils.SINGLE_PYTHON_VERSION)
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        skip = env.get("CIBW_SKIP", "")
+        env["CIBW_SKIP"] = f"{skip} *-musllinux_*".strip()
 
     with TemporaryDirectory() as tmp_output_dir:
         subprocess.run(

--- a/test/test_linux_python.py
+++ b/test/test_linux_python.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import subprocess
 
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 def test_python_exist(tmp_path: Path, capfd: pytest.CaptureFixture[str]) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the test is only relevant to the linux build")
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        pytest.skip("the test is only relevant for CIBW_CONTAINER_ENGINE != 'none'")
     machine = platform.machine()
     if machine not in ["x86_64", "i686"]:
         pytest.skip(

--- a/test/test_manylinuxXXXX_only.py
+++ b/test/test_manylinuxXXXX_only.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import textwrap
 
@@ -70,6 +71,8 @@ project_with_manylinux_symbols = test_projects.new_c_project(
 def test(manylinux_image: str, tmp_path: Path) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the container image test is only relevant to the linux build")
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        pytest.skip("the test is only relevant for CIBW_CONTAINER_ENGINE != 'none'")
 
     project_dir = tmp_path / "project"
     project_with_manylinux_symbols.generate(project_dir)

--- a/test/test_musllinux_X_Y_only.py
+++ b/test/test_musllinux_X_Y_only.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import textwrap
 
 import pytest
@@ -36,6 +37,8 @@ project_with_manylinux_symbols = test_projects.new_c_project(
 def test(musllinux_image: str, tmp_path: Path) -> None:
     if utils.get_platform() != "linux":
         pytest.skip("the container image test is only relevant to the linux build")
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        pytest.skip("the test is only relevant for CIBW_CONTAINER_ENGINE != 'none'")
 
     project_dir = tmp_path / "project"
     project_with_manylinux_symbols.generate(project_dir)

--- a/test/utils.py
+++ b/test/utils.py
@@ -79,6 +79,10 @@ def cibuildwheel_get_build_identifiers(
     if env is None:
         env = os.environ.copy()
 
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        skip = env.get("CIBW_SKIP", "")
+        env["CIBW_SKIP"] = f"{skip} *-musllinux_*".strip()
+
     cmd_output = subprocess.run(
         cmd,
         text=True,
@@ -144,6 +148,10 @@ def cibuildwheel_run(
     if single_python:
         env["CIBW_BUILD"] = "cp{}{}-*".format(*SINGLE_PYTHON_VERSION)
 
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        skip = env.get("CIBW_SKIP", "")
+        env["CIBW_SKIP"] = f"{skip} *-musllinux_*".strip()
+
     with TemporaryDirectory() as tmp_output_dir:
         subprocess.run(
             [
@@ -204,6 +212,10 @@ def expected_wheels(
 
     if android_api_level is None:
         android_api_level = int(os.environ.get("ANDROID_API_LEVEL", "24"))
+
+    if os.environ.get("CIBW_CONTAINER_ENGINE", "docker") == "none":
+        full_auto = False
+        musllinux_versions = []
 
     architectures = [machine_arch]
     if not single_arch:

--- a/unit_test/linux_build_steps_test.py
+++ b/unit_test/linux_build_steps_test.py
@@ -67,7 +67,7 @@ def test_linux_container_split(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     def container_engines(
         step: cibuildwheel.platforms.linux.BuildStep,
-    ) -> list[OCIContainerEngineConfig]:
+    ) -> list[OCIContainerEngineConfig | None]:
         return [options.build_options(c.identifier).container_engine for c in step.platform_configs]
 
     pprint(build_steps)

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -10,7 +10,6 @@ import sys
 import textwrap
 import time
 from contextlib import nullcontext
-from pathlib import Path, PurePath, PurePosixPath
 
 import pytest
 import tomli_w
@@ -25,10 +24,12 @@ from cibuildwheel.oci_container import (
     OCIPlatform,
     _check_engine_version,
 )
+from cibuildwheel.util.file import RemotePosixPath
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 # Test utilities
 
@@ -254,7 +255,7 @@ def test_file_operation(
         original_test_file.parent.mkdir(parents=True, exist_ok=True)
         original_test_file.write_bytes(test_binary_data)
 
-        dst_file = PurePath("/tmp") / file_path
+        dst_file = RemotePosixPath("/tmp") / file_path
 
         container.copy_into(original_test_file, dst_file)
 
@@ -279,7 +280,7 @@ def test_dir_operations(tmp_path: Path, container_engine: OCIContainerEngineConf
         test_file = test_dir / "test.dat"
         shutil.copyfile(original_test_file, test_file)
 
-        dst_dir = PurePosixPath("/tmp/test_dir")
+        dst_dir = RemotePosixPath("/tmp/test_dir")
         dst_file = dst_dir / "test.dat"
         container.copy_into(test_dir, dst_dir)
 
@@ -387,7 +388,7 @@ def test_podman_vfs(
 
         # test copying a file into the container
         (tmp_path / "some_file.txt").write_text("1234")
-        container.copy_into(tmp_path / "some_file.txt", PurePosixPath("some_file.txt"))
+        container.copy_into(tmp_path / "some_file.txt", RemotePosixPath("some_file.txt"))
         assert container.call(["cat", "some_file.txt"], capture_output=True) == "1234"
 
     # Clean up
@@ -485,6 +486,7 @@ def test_parse_engine_config(
     config: str, name: str, create_args: tuple[str, ...], capsys: pytest.CaptureFixture[str]
 ) -> None:
     engine_config = OCIContainerEngineConfig.from_config_string(config)
+    assert engine_config is not None
     assert engine_config.name == name
     assert engine_config.create_args == create_args
     if "--platform" in config:
@@ -493,6 +495,11 @@ def test_parse_engine_config(
             "Using '--platform' in 'container-engine::create_args' is deprecated. It will be ignored."
             in captured.err
         )
+
+
+def test_parse_engine_config_none() -> None:
+    engine_config = OCIContainerEngineConfig.from_config_string("none")
+    assert engine_config is None
 
 
 @pytest.mark.skipif(DEFAULT_OCI_PLATFORM != OCIPlatform.AMD64, reason="Only runs on x86_64")
@@ -531,6 +538,7 @@ def test_disable_host_mount(
         pytest.skip("Skipping test because docker on this platform does not support host mounts")
 
     engine = OCIContainerEngineConfig.from_config_string(config.format(name=container_engine.name))
+    assert engine is not None
 
     sentinel_file = tmp_path / "sentinel"
     sentinel_file.write_text("12345")
@@ -864,5 +872,6 @@ def test_engine_version(
 
     monkeypatch.setattr(cibuildwheel.oci_container, "call", mockcall)
     engine = OCIContainerEngineConfig.from_config_string(engine_name)
+    assert engine is not None
     with context:
         _check_engine_version(engine)

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -10,7 +10,7 @@ import sys
 import textwrap
 import time
 from contextlib import nullcontext
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import Path
 
 import pytest
 import tomli_w
@@ -25,6 +25,7 @@ from cibuildwheel.oci_container import (
     OCIPlatform,
     _check_engine_version,
 )
+from cibuildwheel.util.file import RemotePosixPath
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -268,7 +269,7 @@ def test_file_operation(
         original_test_file.parent.mkdir(parents=True, exist_ok=True)
         original_test_file.write_bytes(test_binary_data)
 
-        dst_file = PurePath("/tmp") / file_path
+        dst_file = RemotePosixPath("/tmp") / file_path
 
         container.copy_into(original_test_file, dst_file)
 
@@ -293,7 +294,7 @@ def test_dir_operations(tmp_path: Path, container_engine: OCIContainerEngineConf
         test_file = test_dir / "test.dat"
         shutil.copyfile(original_test_file, test_file)
 
-        dst_dir = PurePosixPath("/tmp/test_dir")
+        dst_dir = RemotePosixPath("/tmp/test_dir")
         dst_file = dst_dir / "test.dat"
         container.copy_into(test_dir, dst_dir)
 
@@ -415,7 +416,7 @@ def test_podman_vfs(
 
         # test copying a file into the container
         (tmp_path / "some_file.txt").write_text("1234")
-        container.copy_into(tmp_path / "some_file.txt", PurePosixPath("some_file.txt"))
+        container.copy_into(tmp_path / "some_file.txt", RemotePosixPath("some_file.txt"))
         assert container.call(["cat", "some_file.txt"], capture_output=True) == "1234"
 
     # Clean up
@@ -513,6 +514,7 @@ def test_parse_engine_config(
     config: str, name: str, create_args: tuple[str, ...], capsys: pytest.CaptureFixture[str]
 ) -> None:
     engine_config = OCIContainerEngineConfig.from_config_string(config)
+    assert engine_config is not None
     assert engine_config.name == name
     assert engine_config.create_args == create_args
     if "--platform" in config:
@@ -521,6 +523,11 @@ def test_parse_engine_config(
             "Using '--platform' in 'container-engine::create_args' is deprecated. It will be ignored."
             in captured.err
         )
+
+
+def test_parse_engine_config_none() -> None:
+    engine_config = OCIContainerEngineConfig.from_config_string("none")
+    assert engine_config is None
 
 
 @pytest.mark.skipif(DEFAULT_OCI_PLATFORM != OCIPlatform.AMD64, reason="Only runs on x86_64")
@@ -559,6 +566,7 @@ def test_disable_host_mount(
         pytest.skip("Skipping test because docker on this platform does not support host mounts")
 
     engine = OCIContainerEngineConfig.from_config_string(config.format(name=container_engine.name))
+    assert engine is not None
 
     sentinel_file = tmp_path / "sentinel"
     sentinel_file.write_text("12345")
@@ -892,5 +900,6 @@ def test_engine_version(
 
     monkeypatch.setattr(cibuildwheel.oci_container, "call", mockcall)
     engine = OCIContainerEngineConfig.from_config_string(engine_name)
+    assert engine is not None
     with context:
         _check_engine_version(engine)

--- a/unit_test/option_prepare_test.py
+++ b/unit_test/option_prepare_test.py
@@ -34,12 +34,13 @@ def mock_build_container(monkeypatch: pytest.MonkeyPatch) -> None:
         return nullcontext(kwargs)
 
     monkeypatch.setenv("CIBW_PLATFORM", "linux")
+    monkeypatch.setenv("CIBW_CONTAINER_ENGINE", "docker")
     monkeypatch.setattr(platform_module, "machine", lambda: "x86_64")
 
     monkeypatch.setattr(subprocess, "Popen", fail_on_call)
     monkeypatch.setattr(subprocess, "run", ignore_call)
     monkeypatch.setattr(file, "download", fail_on_call)
-    monkeypatch.setattr("cibuildwheel.platforms.linux.OCIContainer", ignore_context_call)
+    monkeypatch.setattr("cibuildwheel.platforms.linux.create_builder", ignore_context_call)
 
     monkeypatch.setattr(
         "cibuildwheel.platforms.linux.build_in_container",

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -373,12 +373,18 @@ def test_toml_environment_quoting(tmp_path: Path, toml_assignment: str, result_v
             (),
             True,
         ),
+        (
+            'container-engine = "none"',
+            None,
+            (),
+            False,
+        ),
     ],
 )
 def test_container_engine_option(
     tmp_path: Path,
     toml_assignment: str,
-    result_name: str,
+    result_name: str | None,
     result_create_args: tuple[str, ...],
     result_disable_host_mount: bool,
 ) -> None:
@@ -396,10 +402,13 @@ def test_container_engine_option(
 
     options = Options(platform="linux", command_line_arguments=args, env={})
     parsed_container_engine = options.build_options(None).container_engine
-
-    assert parsed_container_engine.name == result_name
-    assert parsed_container_engine.create_args == result_create_args
-    assert parsed_container_engine.disable_host_mount == result_disable_host_mount
+    if result_name is not None:
+        assert parsed_container_engine is not None
+        assert parsed_container_engine.name == result_name
+        assert parsed_container_engine.create_args == result_create_args
+        assert parsed_container_engine.disable_host_mount == result_disable_host_mount
+    else:
+        assert parsed_container_engine is None
 
 
 def test_environment_pass_references() -> None:


### PR DESCRIPTION
This is one way to provide support for building natively on Linux as requested in #2875 if we want to add support for this.
It might be better to wait for #2907 or include this feature as part of it.

In this PR, the linux platforms uses a LocalBuilder with the same protocol as an OCIContainer to reduce the amount of patching to places copying files into & out of the container.

No documentation update while the PR is in draft.