### PR TITLE
fix: support platform-specific test runtime environment variables

### DIFF
--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -821,7 +821,6 @@ class Options:
 
             test_runtime_str = self.reader.get(
                 "test-runtime",
-                env_plat=False,
                 option_format=ShlexTableFormat(sep="; ", pair_sep=":", allow_merge=False),
             )
             if not test_runtime_str:

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -833,6 +833,31 @@ def test_test_runtime_handling(
 
 
 @pytest.mark.parametrize(
+    ("platform", "platform_envvar"),
+    [
+        ("android", "CIBW_TEST_RUNTIME_ANDROID"),
+        ("ios", "CIBW_TEST_RUNTIME_IOS"),
+    ],
+)
+def test_test_runtime_platform_environment(
+    tmp_path: Path, platform: PlatformName, platform_envvar: str
+) -> None:
+    args = CommandLineArguments.defaults()
+    args.package_dir = tmp_path
+
+    options = Options(
+        platform=platform,
+        command_line_arguments=args,
+        env={
+            "CIBW_TEST_RUNTIME": "args: --global",
+            platform_envvar: "args: --platform-specific",
+        },
+    )
+
+    assert options.build_options(None).test_runtime.args == ["--platform-specific"]
+
+
+@pytest.mark.parametrize(
     ("definition", "expected"),
     [
         ("", None),


### PR DESCRIPTION
## Summary

- enable platform-specific environment lookup for `test-runtime`
- cover both Android and iOS override precedence

## Why

The documentation exposes `CIBW_TEST_RUNTIME_ANDROID` and `CIBW_TEST_RUNTIME_IOS`, but `test-runtime` explicitly disabled platform environment variables in the option reader. As a result, both variables were ignored.

Closes #2936.

## Validation

- `uv run pytest unit_test/options_test.py -q` (99 passed, 3 existing xfails)
- `uv run pytest unit_test -q` (824 passed, 69 skipped, 3 existing xfails)
- `uvx prek -a`
- `uvx nox -s pylint` (10.00/10)
- `git diff --check`