### PR TITLE
Update to Pyodide 314.0.3

### DIFF
--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -217,7 +217,7 @@ python_configurations = [
 python_configurations = [
   { identifier = "cp312-pyodide_wasm32", version = "3.12", default_pyodide_version = "0.27.7", node_version = "v22", sha256 = "0c2e7db42efa5d1dac38b50f8b3d659a1e3885d0a233494831b8206281307d52" },
   { identifier = "cp313-pyodide_wasm32", version = "3.13", default_pyodide_version = "0.29.4", node_version = "v22", sha256 = "a29fc4a076408a18fc29eb4b280f80c6dddc95c19514c874c29e590d0931c02a" },
-  { identifier = "cp314-pyodide_wasm32", version = "3.14", default_pyodide_version = "314.0.2", node_version = "v24", sha256 = "01ab1b229bf2031603bf20ad4ceb9c1059ba680b26df7bda2db4748906dfd78a" },
+  { identifier = "cp314-pyodide_wasm32", version = "3.14", default_pyodide_version = "314.0.3", node_version = "v24", sha256 = "fa341e162e3e9e46fff8caa20e5f319feb6443252aebdb8494ee6a5f697ac2c6" },
 ]
 
 [android]


### PR DESCRIPTION
See https://github.com/pyodide/pyodide/releases/tag/314.0.3 (and see [CHANGELOG](https://pyodide.org/en/stable/project/changelog.html#version-314-0-3)). Note that we also now publish `.tar.gz` archives as PyPy does, but unlike it, we retain access to the xbuildenvs via `pyodide xbuildenv install`, which handled the change via `shutil.unpack_archive()`