### PR TITLE
fix(schema): default is fine for pyodide too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ site/
 
 # This file should be a symlink or contain "See @AGENTS.md"
 CLAUDE.md
+.claude/

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -35,7 +35,7 @@ $defs:
       - pyodide-prerelease
       - pypy
       - pypy-eol
-  description: A Python version or flavor to enable.
+    description: A Python version or flavor to enable.
 additionalProperties: false
 description: cibuildwheel's settings.
 type: object

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -354,6 +354,25 @@ overrides["items"]["properties"] |= non_global_options.copy()
 
 del overrides["items"]["properties"]["archs"]
 
+# An override can select the pyodide platform, so it also accepts pyodide-build.
+overrides["items"]["properties"]["build-frontend"] = {
+    **schema["properties"]["build-frontend"],
+    "oneOf": [
+        *copy.deepcopy(schema["properties"]["build-frontend"]["oneOf"]),
+        {"type": "string", "pattern": "^pyodide-build; ?args:"},
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["name"],
+            "properties": {
+                "name": {"enum": ["pyodide-build"]},
+                "args": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+    ],
+}
+overrides["items"]["properties"]["build-frontend"]["oneOf"][0]["enum"].append("pyodide-build")
+
 not_linux = non_global_options.copy()
 
 del not_linux["environment-pass"]

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -398,7 +398,7 @@ oses["pyodide"]["properties"]["build-frontend"] = {
     "default": "pyodide-build",
     "description": 'On the pyodide platform, the build frontend must be "pyodide-build"',
     "oneOf": [
-        {"enum": ["pyodide-build"]},
+        {"enum": ["pyodide-build", "default"]},
         {"type": "string", "pattern": "^pyodide-build; ?args:"},
         {
             "type": "object",

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -62,31 +62,7 @@ properties:
     default: ['*']
     description: Choose the Python versions to build.
     type: string_array
-  build-frontend:
-    default: default
-    description: Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip" ("pyodide-build" for pyodide)
-    oneOf:
-      - enum: [pip, build, "build[uv]", uv, pyodide-build, default]
-      - type: string
-        pattern: '^pip; ?args:'
-      - type: string
-        pattern: '^build; ?args:'
-      - type: string
-        pattern: '^build\\[uv\\]; ?args:'
-      - type: string
-        pattern: '^uv; ?args:'
-      - type: string
-        pattern: '^pyodide-build; ?args:'
-      - type: object
-        additionalProperties: false
-        required: [name]
-        properties:
-          name:
-            enum: [pip, build, "build[uv]", uv, pyodide-build]
-          args:
-            type: array
-            items:
-              type: string
+  build-frontend: {}  # filled in by build_frontend_schema below
   build-verbosity:
     type: integer
     minimum: -3
@@ -294,6 +270,43 @@ string_table = yaml.safe_load(
 """
 )
 
+FRONTENDS = ["pip", "build", "build[uv]", "uv"]
+
+
+def build_frontend_schema(
+    names: list[str], description: str, default: str = "default"
+) -> dict[str, Any]:
+    """
+    A frontend is a name, a "name; args: ..." string, or a table with a name and args.
+    """
+    # Only the brackets in "build[uv]" need escaping
+    patterns = [name.replace("[", r"\[").replace("]", r"\]") for name in names]
+    return {
+        "default": default,
+        "description": description,
+        "oneOf": [
+            {"enum": [*names, "default"]},
+            *({"type": "string", "pattern": f"^{pattern}; ?args:"} for pattern in patterns),
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["name"],
+                "properties": {
+                    "name": {"enum": names},
+                    "args": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        ],
+        "title": "CIBW_BUILD_FRONTEND",
+    }
+
+
+schema["properties"]["build-frontend"] = build_frontend_schema(
+    [*FRONTENDS, "pyodide-build"],
+    'Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip"'
+    ' ("pyodide-build" for pyodide)',
+)
+
 for value in schema["properties"].values():
     match value:
         case {"type": "string_array"}:
@@ -396,40 +409,19 @@ for os_name, command in [
 del oses["linux"]["properties"]["dependency-versions"]
 
 
-def select_build_frontends(names: set[str]) -> dict[str, Any]:
-    """
-    Keep only the given frontends in a copy of the build-frontend schema.
-    """
-    one_of: list[dict[str, Any]] = []
-    for item in copy.deepcopy(schema["properties"]["build-frontend"]["oneOf"]):
-        match item:
-            case {"enum": [*values]}:
-                item["enum"] = [v for v in values if v in names]
-            case {"pattern": str(pattern)}:
-                if pattern.removeprefix("^").partition(";")[0].replace("\\", "") not in names:
-                    continue
-            case {"properties": {"name": {"enum": [*values]}}}:
-                item["properties"]["name"]["enum"] = [v for v in values if v in names]
-        one_of.append(item)
-    return {**schema["properties"]["build-frontend"], "oneOf": one_of}
+schema["$defs"]["build-frontend-no-pyodide"] = build_frontend_schema(
+    FRONTENDS,
+    'Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip"',
+)
 
+for os_val in oses.values():
+    os_val["properties"]["build-frontend"] = {"$ref": "#/$defs/build-frontend-no-pyodide"}
 
-all_frontends = set(schema["properties"]["build-frontend"]["oneOf"][0]["enum"])
-
-schema["$defs"]["build-frontend-no-pyodide"] = {
-    **select_build_frontends(all_frontends - {"pyodide-build"}),
-    "description": 'Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip"',
-}
-
-for os_name, os_val in oses.items():
-    if os_name == "pyodide":
-        os_val["properties"]["build-frontend"] = {
-            **select_build_frontends({"pyodide-build", "default"}),
-            "default": "pyodide-build",
-            "description": 'On the pyodide platform, the build frontend must be "pyodide-build"',
-        }
-    else:
-        os_val["properties"]["build-frontend"] = {"$ref": "#/$defs/build-frontend-no-pyodide"}
+oses["pyodide"]["properties"]["build-frontend"] = build_frontend_schema(
+    ["pyodide-build"],
+    'On the pyodide platform, the build frontend must be "pyodide-build"',
+    default="pyodide-build",
+)
 
 schema["properties"]["overrides"] = overrides
 schema["properties"] |= oses

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -64,9 +64,9 @@ properties:
     type: string_array
   build-frontend:
     default: default
-    description: Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip"
+    description: Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip" ("pyodide-build" for pyodide)
     oneOf:
-      - enum: [pip, build, "build[uv]", uv, default]
+      - enum: [pip, build, "build[uv]", uv, pyodide-build, default]
       - type: string
         pattern: '^pip; ?args:'
       - type: string
@@ -75,12 +75,14 @@ properties:
         pattern: '^build\\[uv\\]; ?args:'
       - type: string
         pattern: '^uv; ?args:'
+      - type: string
+        pattern: '^pyodide-build; ?args:'
       - type: object
         additionalProperties: false
         required: [name]
         properties:
           name:
-            enum: [pip, build, "build[uv]", uv]
+            enum: [pip, build, "build[uv]", uv, pyodide-build]
           args:
             type: array
             items:
@@ -353,25 +355,6 @@ overrides["items"]["properties"]["select"]["oneOf"] = string_array
 overrides["items"]["properties"] |= non_global_options.copy()
 
 del overrides["items"]["properties"]["archs"]
-
-# An override can select the pyodide platform, so it also accepts pyodide-build.
-overrides["items"]["properties"]["build-frontend"] = {
-    **schema["properties"]["build-frontend"],
-    "oneOf": [
-        *copy.deepcopy(schema["properties"]["build-frontend"]["oneOf"]),
-        {"type": "string", "pattern": "^pyodide-build; ?args:"},
-        {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["name"],
-            "properties": {
-                "name": {"enum": ["pyodide-build"]},
-                "args": {"type": "array", "items": {"type": "string"}},
-            },
-        },
-    ],
-}
-overrides["items"]["properties"]["build-frontend"]["oneOf"][0]["enum"].append("pyodide-build")
 
 not_linux = non_global_options.copy()
 

--- a/bin/generate_schema.py
+++ b/bin/generate_schema.py
@@ -395,24 +395,41 @@ for os_name, command in [
 
 del oses["linux"]["properties"]["dependency-versions"]
 
-oses["pyodide"]["properties"]["build-frontend"] = {
-    **schema["properties"]["build-frontend"],
-    "default": "pyodide-build",
-    "description": 'On the pyodide platform, the build frontend must be "pyodide-build"',
-    "oneOf": [
-        {"enum": ["pyodide-build", "default"]},
-        {"type": "string", "pattern": "^pyodide-build; ?args:"},
-        {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["name"],
-            "properties": {
-                "name": {"enum": ["pyodide-build"]},
-                "args": {"type": "array", "items": {"type": "string"}},
-            },
-        },
-    ],
+
+def select_build_frontends(names: set[str]) -> dict[str, Any]:
+    """
+    Keep only the given frontends in a copy of the build-frontend schema.
+    """
+    one_of: list[dict[str, Any]] = []
+    for item in copy.deepcopy(schema["properties"]["build-frontend"]["oneOf"]):
+        match item:
+            case {"enum": [*values]}:
+                item["enum"] = [v for v in values if v in names]
+            case {"pattern": str(pattern)}:
+                if pattern.removeprefix("^").partition(";")[0].replace("\\", "") not in names:
+                    continue
+            case {"properties": {"name": {"enum": [*values]}}}:
+                item["properties"]["name"]["enum"] = [v for v in values if v in names]
+        one_of.append(item)
+    return {**schema["properties"]["build-frontend"], "oneOf": one_of}
+
+
+all_frontends = set(schema["properties"]["build-frontend"]["oneOf"][0]["enum"])
+
+schema["$defs"]["build-frontend-no-pyodide"] = {
+    **select_build_frontends(all_frontends - {"pyodide-build"}),
+    "description": 'Set the tool to use to build, either "build" (default), "build[uv]", "uv", or "pip"',
 }
+
+for os_name, os_val in oses.items():
+    if os_name == "pyodide":
+        os_val["properties"]["build-frontend"] = {
+            **select_build_frontends({"pyodide-build", "default"}),
+            "default": "pyodide-build",
+            "description": 'On the pyodide platform, the build frontend must be "pyodide-build"',
+        }
+    else:
+        os_val["properties"]["build-frontend"] = {"$ref": "#/$defs/build-frontend-no-pyodide"}
 
 schema["properties"]["overrides"] = overrides
 schema["properties"] |= oses

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -20,7 +20,62 @@
         "pypy-eol"
       ]
     },
-    "description": "A Python version or flavor to enable."
+    "description": "A Python version or flavor to enable.",
+    "build-frontend-no-pyodide": {
+      "default": "default",
+      "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\"",
+      "oneOf": [
+        {
+          "enum": [
+            "pip",
+            "build",
+            "build[uv]",
+            "uv",
+            "default"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^pip; ?args:"
+        },
+        {
+          "type": "string",
+          "pattern": "^build; ?args:"
+        },
+        {
+          "type": "string",
+          "pattern": "^build\\[uv\\]; ?args:"
+        },
+        {
+          "type": "string",
+          "pattern": "^uv; ?args:"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "enum": [
+                "pip",
+                "build",
+                "build[uv]",
+                "uv"
+              ]
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "title": "CIBW_BUILD_FRONTEND"
+    }
   },
   "additionalProperties": false,
   "description": "cibuildwheel's settings.",
@@ -900,7 +955,7 @@
           "$ref": "#/properties/before-test"
         },
         "build-frontend": {
-          "$ref": "#/properties/build-frontend"
+          "$ref": "#/$defs/build-frontend-no-pyodide"
         },
         "build-verbosity": {
           "$ref": "#/properties/build-verbosity"
@@ -1039,7 +1094,7 @@
           "$ref": "#/properties/before-test"
         },
         "build-frontend": {
-          "$ref": "#/properties/build-frontend"
+          "$ref": "#/$defs/build-frontend-no-pyodide"
         },
         "build-verbosity": {
           "$ref": "#/properties/build-verbosity"
@@ -1124,7 +1179,7 @@
           "$ref": "#/properties/before-test"
         },
         "build-frontend": {
-          "$ref": "#/properties/build-frontend"
+          "$ref": "#/$defs/build-frontend-no-pyodide"
         },
         "build-verbosity": {
           "$ref": "#/properties/build-verbosity"
@@ -1315,7 +1370,7 @@
           "$ref": "#/properties/before-test"
         },
         "build-frontend": {
-          "$ref": "#/properties/build-frontend"
+          "$ref": "#/$defs/build-frontend-no-pyodide"
         },
         "build-verbosity": {
           "$ref": "#/properties/build-verbosity"
@@ -1400,7 +1455,7 @@
           "$ref": "#/properties/before-test"
         },
         "build-frontend": {
-          "$ref": "#/properties/build-frontend"
+          "$ref": "#/$defs/build-frontend-no-pyodide"
         },
         "build-verbosity": {
           "$ref": "#/properties/build-verbosity"

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -1208,7 +1208,8 @@
           "oneOf": [
             {
               "enum": [
-                "pyodide-build"
+                "pyodide-build",
+                "default"
               ]
             },
             {

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -18,9 +18,9 @@
         "pyodide-prerelease",
         "pypy",
         "pypy-eol"
-      ]
+      ],
+      "description": "A Python version or flavor to enable."
     },
-    "description": "A Python version or flavor to enable.",
     "build-frontend-no-pyodide": {
       "default": "default",
       "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\"",

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -764,7 +764,84 @@
             "$ref": "#/properties/before-test"
           },
           "build-frontend": {
-            "$ref": "#/properties/build-frontend"
+            "default": "default",
+            "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\"",
+            "oneOf": [
+              {
+                "enum": [
+                  "pip",
+                  "build",
+                  "build[uv]",
+                  "uv",
+                  "default",
+                  "pyodide-build"
+                ]
+              },
+              {
+                "type": "string",
+                "pattern": "^pip; ?args:"
+              },
+              {
+                "type": "string",
+                "pattern": "^build; ?args:"
+              },
+              {
+                "type": "string",
+                "pattern": "^build\\[uv\\]; ?args:"
+              },
+              {
+                "type": "string",
+                "pattern": "^uv; ?args:"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "enum": [
+                      "pip",
+                      "build",
+                      "build[uv]",
+                      "uv"
+                    ]
+                  },
+                  "args": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "string",
+                "pattern": "^pyodide-build; ?args:"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "enum": [
+                      "pyodide-build"
+                    ]
+                  },
+                  "args": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ],
+            "title": "CIBW_BUILD_FRONTEND"
           },
           "build-verbosity": {
             "$ref": "#/properties/build-verbosity"

--- a/cibuildwheel/resources/cibuildwheel.schema.json
+++ b/cibuildwheel/resources/cibuildwheel.schema.json
@@ -136,7 +136,7 @@
     },
     "build-frontend": {
       "default": "default",
-      "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\"",
+      "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\" (\"pyodide-build\" for pyodide)",
       "oneOf": [
         {
           "enum": [
@@ -144,6 +144,7 @@
             "build",
             "build[uv]",
             "uv",
+            "pyodide-build",
             "default"
           ]
         },
@@ -164,6 +165,10 @@
           "pattern": "^uv; ?args:"
         },
         {
+          "type": "string",
+          "pattern": "^pyodide-build; ?args:"
+        },
+        {
           "type": "object",
           "additionalProperties": false,
           "required": [
@@ -175,7 +180,8 @@
                 "pip",
                 "build",
                 "build[uv]",
-                "uv"
+                "uv",
+                "pyodide-build"
               ]
             },
             "args": {
@@ -764,84 +770,7 @@
             "$ref": "#/properties/before-test"
           },
           "build-frontend": {
-            "default": "default",
-            "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", \"uv\", or \"pip\"",
-            "oneOf": [
-              {
-                "enum": [
-                  "pip",
-                  "build",
-                  "build[uv]",
-                  "uv",
-                  "default",
-                  "pyodide-build"
-                ]
-              },
-              {
-                "type": "string",
-                "pattern": "^pip; ?args:"
-              },
-              {
-                "type": "string",
-                "pattern": "^build; ?args:"
-              },
-              {
-                "type": "string",
-                "pattern": "^build\\[uv\\]; ?args:"
-              },
-              {
-                "type": "string",
-                "pattern": "^uv; ?args:"
-              },
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "enum": [
-                      "pip",
-                      "build",
-                      "build[uv]",
-                      "uv"
-                    ]
-                  },
-                  "args": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              {
-                "type": "string",
-                "pattern": "^pyodide-build; ?args:"
-              },
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "enum": [
-                      "pyodide-build"
-                    ]
-                  },
-                  "args": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            ],
-            "title": "CIBW_BUILD_FRONTEND"
+            "$ref": "#/properties/build-frontend"
           },
           "build-verbosity": {
             "$ref": "#/properties/build-verbosity"

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -143,6 +143,39 @@ def test_overrides_invalid_inherit_value(validator: validate_pyproject.api.Valid
         validator(example)
 
 
+def test_overrides_pyodide_build_frontend(validator: validate_pyproject.api.Validator) -> None:
+    """
+    An override can select the pyodide platform, where pyodide-build is valid.
+    """
+    example = tomllib.loads(
+        """
+        [[tool.cibuildwheel.overrides]]
+        select = "*pyodide*"
+        build-frontend = "pyodide-build"
+        """
+    )
+
+    assert validator(example) is not None
+
+
+@pytest.mark.parametrize("platform", ["linux", "macos", "windows", "ios", "android"])
+def test_bad_pyodide_build_frontend(
+    validator: validate_pyproject.api.Validator, platform: str
+) -> None:
+    """
+    pyodide-build is not a valid frontend for the other platforms.
+    """
+    example = tomllib.loads(
+        f"""
+        [tool.cibuildwheel.{platform}]
+        build-frontend = "pyodide-build"
+        """
+    )
+
+    with pytest.raises(validate_pyproject.error_reporting.ValidationError):
+        validator(example)
+
+
 def test_docs_examples(validator: validate_pyproject.api.Validator) -> None:
     """
     Parse out all the configuration examples, build valid TOML out of them, and

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -143,32 +143,36 @@ def test_overrides_invalid_inherit_value(validator: validate_pyproject.api.Valid
         validator(example)
 
 
-def test_overrides_pyodide_build_frontend(validator: validate_pyproject.api.Validator) -> None:
+def test_pyodide_build_frontend(validator: validate_pyproject.api.Validator) -> None:
     """
-    An override can select the pyodide platform, where pyodide-build is valid.
+    pyodide-build is accepted anywhere the frontend can be set, as an override
+    or a global value can apply to pyodide builds only.
     """
     example = tomllib.loads(
         """
+        [tool.cibuildwheel]
+        build-frontend = "pyodide-build"
+
+        [tool.cibuildwheel.pyodide]
+        build-frontend = { name = "pyodide-build", args = ["--some-arg"] }
+
         [[tool.cibuildwheel.overrides]]
         select = "*pyodide*"
-        build-frontend = "pyodide-build"
+        build-frontend = "pyodide-build; args: --some-arg"
         """
     )
 
     assert validator(example) is not None
 
 
-@pytest.mark.parametrize("platform", ["linux", "macos", "windows", "ios", "android"])
-def test_bad_pyodide_build_frontend(
-    validator: validate_pyproject.api.Validator, platform: str
-) -> None:
+def test_pyodide_bad_build_frontend(validator: validate_pyproject.api.Validator) -> None:
     """
-    pyodide-build is not a valid frontend for the other platforms.
+    The pyodide table only accepts the pyodide-build frontend.
     """
     example = tomllib.loads(
-        f"""
-        [tool.cibuildwheel.{platform}]
-        build-frontend = "pyodide-build"
+        """
+        [tool.cibuildwheel.pyodide]
+        build-frontend = "uv"
         """
     )
 

--- a/unit_test/validate_schema_test.py
+++ b/unit_test/validate_schema_test.py
@@ -165,14 +165,36 @@ def test_pyodide_build_frontend(validator: validate_pyproject.api.Validator) -> 
     assert validator(example) is not None
 
 
-def test_pyodide_bad_build_frontend(validator: validate_pyproject.api.Validator) -> None:
+@pytest.mark.parametrize("frontend", ['"uv"', '"build; args: --some-arg"', '{ name = "pip" }'])
+def test_pyodide_bad_build_frontend(
+    validator: validate_pyproject.api.Validator, frontend: str
+) -> None:
     """
     The pyodide table only accepts the pyodide-build frontend.
     """
     example = tomllib.loads(
-        """
+        f"""
         [tool.cibuildwheel.pyodide]
-        build-frontend = "uv"
+        build-frontend = {frontend}
+        """
+    )
+
+    with pytest.raises(validate_pyproject.error_reporting.ValidationError):
+        validator(example)
+
+
+@pytest.mark.parametrize("platform", ["linux", "macos", "windows", "ios", "android"])
+@pytest.mark.parametrize("frontend", ["pyodide-build", "pyodide-build; args: --some-arg"])
+def test_bad_pyodide_build_frontend(
+    validator: validate_pyproject.api.Validator, platform: str, frontend: str
+) -> None:
+    """
+    Only the pyodide table accepts the pyodide-build frontend.
+    """
+    example = tomllib.loads(
+        f"""
+        [tool.cibuildwheel.{platform}]
+        build-frontend = "{frontend}"
         """
     )
 


### PR DESCRIPTION
The schema claims pyodide-build is required, but default is fine too.

Also adding `.claude`, so users can symlink `.claude/skills` to `.agent/skills`.
