### PR TITLE
fix: pin pip on GraalPy

### DIFF
--- a/cibuildwheel/resources/constraints-python312.txt
+++ b/cibuildwheel/resources/constraints-python312.txt
@@ -55,7 +55,8 @@ pefile==2024.8.26
     # via
     #   abi3audit
     #   delvewheel
-pip==26.1.2; implementation_name != "graalpy" or platform_system != "Windows"
+pip==26.1.2; implementation_name != "graalpy"
+pip==26.1.2; implementation_name == "graalpy" and platform_system != "Windows"
 pip==26.0.1; implementation_name == "graalpy" and platform_system == "Windows"
     # via -r cibuildwheel/resources/constraints.in
 pkgconf==3.0.1.post0

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,18 +70,21 @@ def tests(session: nox.Session) -> None:
 # GraalPy (matching `graalpy_marker`) gets `held`, everything else
 # (`other_marker`) tracks the freshly compiled version.
 GRAALPY_HELD_BACK = (
-    # Newer pip breaks GraalPy on Windows.
+    # Newer pip breaks GraalPy on macOS and Windows.
     {
         "package": "pip",
-        "held": "26.0.1",
-        "graalpy_marker": 'implementation_name == "graalpy" and platform_system == "Windows"',
-        "other_marker": 'implementation_name != "graalpy" or platform_system != "Windows"',
+        "held": ("26.1.2", "26.0.1"),
+        "graalpy_marker": (
+            'implementation_name == "graalpy" and platform_system != "Windows"',
+            'implementation_name == "graalpy" and platform_system == "Windows"',
+        ),
+        "other_marker": 'implementation_name != "graalpy"',
     },
     # filelock >=3.30 imports errno.ENOTSUP, which GraalPy lacks (fix due ~2026-08).
     {
         "package": "filelock",
-        "held": "3.29.7",
-        "graalpy_marker": 'implementation_name == "graalpy"',
+        "held": ("3.29.7",),
+        "graalpy_marker": ('implementation_name == "graalpy"',),
         "other_marker": 'implementation_name != "graalpy"',
     },
 )
@@ -90,11 +93,15 @@ GRAALPY_HELD_BACK = (
 def _pin_graalpy_workarounds(output_file: Path) -> None:
     text = output_file.read_text()
     for pin in GRAALPY_HELD_BACK:
+        assert isinstance(pin["package"], str)
         package = re.escape(pin["package"])
+        graalpy_pins = "\n".join(
+            f"{pin['package']}=={pin['held'][i]}; {pin['graalpy_marker'][i]}"
+            for i in range(len(pin["held"]))
+        )
         text = re.sub(
             rf"^{package}==(?P<version>[^\s;]+)$",
-            f"{pin['package']}==\\g<version>; {pin['other_marker']}\n"
-            f"{pin['package']}=={pin['held']}; {pin['graalpy_marker']}",
+            f"{pin['package']}==\\g<version>; {pin['other_marker']}\n{graalpy_pins}",
             text,
             flags=re.MULTILINE,
         )


### PR DESCRIPTION
issue seen on macOS in #2952 that will re-appear when the update workflow re-runs tomorrow.

cc @timfel 

```python-traceback
/private/var/folders/_5/zjnzxgh147qcg3bb5cg2wvqw0000gn/T/cibw-run-qke0fsin/gp312_250-macosx_arm64/build/venv/bin/pip:6: RuntimeWarning: You are using an untested version of pip. GraalPy provides patches and workarounds for a number of packages when used with compatible pip versions. We recommend to stick with the pip version that ships with this version of GraalPy.
  from pip._internal.cli.main import main
/private/var/folders/_5/zjnzxgh147qcg3bb5cg2wvqw0000gn/T/cibw-run-qke0fsin/gp312_250-macosx_arm64/build/venv/bin/pip:6: RuntimeWarning: You are using an untested version of pip. GraalPy provides patches and workarounds for a number of packages when used with compatible pip versions. We recommend to stick with the pip version that ships with this version of GraalPy.
  from pip._internal.cli.main import main
/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'GraalVM JSSE'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
WARNING: Disabling truststore because platform isn't supported
ERROR: Exception:
Traceback (most recent call last):
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/cli/base_command.py", line 109, in _run_wrapper
    status = _inner_run()
             ^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/cli/base_command.py", line 102, in _inner_run
    return self.run(options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/cli/req_command.py", line 106, in wrapper
    return func(self, options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/commands/install.py", line 478, in run
    requirement_set = resolver.resolve(
                      ^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/resolver.py", line 103, in resolve
    result = self._result = resolver.resolve(
                            ^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/resolvers/resolution.py", line 601, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/resolvers/resolution.py", line 513, in resolve
    failure_criterion = self._attempt_to_pin_criterion(name)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/resolvers/resolution.py", line 220, in _attempt_to_pin_criterion
    criteria = self._get_updated_criteria(candidate)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/resolvers/resolution.py", line 211, in _get_updated_criteria
    self._add_to_criteria(criteria, requirement, parent=candidate)
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/resolvers/resolution.py", line 150, in _add_to_criteria
    if not criterion.candidates:
       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/resolvelib/structs.py", line 194, in __bool__
    return bool(self._sequence)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/found_candidates.py", line 165, in __bool__
    self._bool = any(self)
                 ^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/found_candidates.py", line 149, in <genexpr>
    return (c for c in iterator if id(c) not in self._incompatible_ids)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/found_candidates.py", line 39, in _iter_built
    candidate = func()
                ^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/factory.py", line 181, in _make_candidate_from_link
    base: BaseCandidate | None = self._make_base_candidate_from_link(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/factory.py", line 227, in _make_base_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
                                       ^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/candidates.py", line 325, in __init__
    super().__init__(
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/candidates.py", line 167, in __init__
    self.dist = self._prepare()
                ^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/candidates.py", line 245, in _prepare
    dist = self._prepare_distribution()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/resolution/resolvelib/candidates.py", line 336, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/operations/prepare.py", line 652, in prepare_linked_requirement
    metadata_dist = self._fetch_metadata_only(req)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/operations/prepare.py", line 507, in _fetch_metadata_only
    return self._fetch_metadata_using_link_data_attr(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/operations/prepare.py", line 527, in _fetch_metadata_using_link_data_attr
    metadata_file = get_http_url(
                    ^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/operations/prepare.py", line 126, in get_http_url
    from_path, content_type = download(link, temp_dir.path)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/network/download.py", line 207, in __call__
    resp = self._http_get(link)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/network/download.py", line 379, in _http_get
    resp = self._session.get(target_url, headers=headers, stream=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/requests/sessions.py", line 671, in get
    return self.request("GET", url, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_internal/network/session.py", line 522, in request
    return super().request(method, url, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/requests/sessions.py", line 651, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/requests/sessions.py", line 784, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/cachecontrol/adapter.py", line 76, in send
    resp = super().send(request, stream, timeout, verify, cert, proxies)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/requests/adapters.py", line 696, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/connectionpool.py", line 788, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/connectionpool.py", line 1106, in _validate_conn
    conn.connect()
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/connection.py", line 796, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/connection.py", line 928, in _ssl_wrap_socket_and_match_hostname
    context = create_urllib3_context(
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/virtualenv/wheel/3.12/image/1/SymlinkPipInstall/pip-26.2-py3-none-any/pip/_vendor/urllib3/util/ssl_.py", line 220, in create_urllib3_context
    raise TypeError("Can't create an SSLContext object without an ssl module")
TypeError: Can't create an SSLContext object without an ssl module
```