### PR TITLE
Update Android Python versions

### DIFF
--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -222,12 +222,6 @@ def setup_target_python(config: PythonConfiguration, build_path: Path) -> Path:
     python_dir = build_path / "python"
     python_dir.mkdir()
     shutil.unpack_archive(python_tgz, python_dir)
-
-    # Work around https://github.com/python/cpython/issues/138800. This can be removed
-    # once we've updated to Python versions that include the fix.
-    pc_path = python_dir / f"prefix/lib/pkgconfig/python-{config.version}.pc"
-    pc_path.write_text(pc_path.read_text().replace("$(BLDLIBRARY)", f"-lpython{config.version}"))
-
     return python_dir
 
 

--- a/cibuildwheel/resources/build-platforms.toml
+++ b/cibuildwheel/resources/build-platforms.toml
@@ -223,10 +223,10 @@ python_configurations = [
 
 [android]
 python_configurations = [
-  { identifier = "cp313-android_arm64_v8a", version = "3.13", url = "https://repo.maven.apache.org/maven2/com/chaquo/python/python/3.13.14/python-3.13.14-aarch64-linux-android.tar.gz", sha256 = "2541c4fa77b6543504c97fa90a71c745225b5800fe25bc8c73a6516b594d0cbc" },
-  { identifier = "cp313-android_x86_64", version = "3.13", url = "https://repo.maven.apache.org/maven2/com/chaquo/python/python/3.13.14/python-3.13.14-x86_64-linux-android.tar.gz", sha256 = "9d96f7e077677b6651b2e756034ed41ab4479f5f8bf3168a814f458bc2ac137e" },
-  { identifier = "cp314-android_arm64_v8a", version = "3.14", url = "https://www.python.org/ftp/python/3.14.6/python-3.14.6-aarch64-linux-android.tar.gz", sha256 = "38bbe77d3167b5cd554e03b1021324926f09f3825202b065951dd7638e9c37e5" },
-  { identifier = "cp314-android_x86_64", version = "3.14", url = "https://www.python.org/ftp/python/3.14.6/python-3.14.6-x86_64-linux-android.tar.gz", sha256 = "e04eb26607627e68d148f89de793372f54a345c91b13628567f24abcdd3bfa3e" },
+  { identifier = "cp313-android_arm64_v8a", version = "3.13", url = "https://repo.maven.apache.org/maven2/com/chaquo/python/python/3.13.15/python-3.13.15-aarch64-linux-android.tar.gz", sha256 = "a51d1e153f68f1c40f612a5431e9f79870d993da795173b3d27564e42b056271" },
+  { identifier = "cp313-android_x86_64", version = "3.13", url = "https://repo.maven.apache.org/maven2/com/chaquo/python/python/3.13.15/python-3.13.15-x86_64-linux-android.tar.gz", sha256 = "2096ecd6e180274ad1637cf140f7d6c2a160fe5ef9bfb47fd318e3d963f2d929" },
+  { identifier = "cp314-android_arm64_v8a", version = "3.14", url = "https://www.python.org/ftp/python/3.14.7/python-3.14.7-aarch64-linux-android.tar.gz", sha256 = "6d50cc3aa66e414a439594089bcdfb5f1264358155c70c1f00471c24cfb477fb" },
+  { identifier = "cp314-android_x86_64", version = "3.14", url = "https://www.python.org/ftp/python/3.14.7/python-3.14.7-x86_64-linux-android.tar.gz", sha256 = "2c16ce2359565cd8c24f86cfb75630768ba6607e732946b294b969797f583b60" },
   { identifier = "cp315-android_arm64_v8a", version = "3.15", url = "https://www.python.org/ftp/python/3.15.0/python-3.15.0rc1-aarch64-linux-android.tar.gz", sha256 = "7d6fb28a69368841656f919a08141b0e3720837ac67987388037ee9d2a5c5492" },
   { identifier = "cp315-android_x86_64", version = "3.15", url = "https://www.python.org/ftp/python/3.15.0/python-3.15.0rc1-x86_64-linux-android.tar.gz", sha256 = "f048f5c60b538efc64e4c26399a0a21202ce430949d5b2c10369d624548a5dc3" },
 ]


### PR DESCRIPTION
This should fix the CI issue discussed at https://github.com/pypa/cibuildwheel/pull/2933#issuecomment-4821042715.

These Python versions have also fixed the content of their .pc files, allowing a workaround to be removed.

And they update the Android testbed Gradle version, making it compatible with Java 25 (#2950).