### PR TITLE
feat: add log fold mode override

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,13 @@ The following diagram summarises the steps that cibuildwheel takes on each platf
 |  | [`test-skip`](https://cibuildwheel.pypa.io/en/stable/options/#test-skip) | Skip running tests on some builds |
 |  | [`test-environment`](https://cibuildwheel.pypa.io/en/stable/options/#test-environment) | Set environment variables for the test environment |
 |  | [`test-runtime`](https://cibuildwheel.pypa.io/en/stable/options/#test-runtime) | Controls how the tests will be executed. |
-| **Debugging** | [`debug-keep-container`](https://cibuildwheel.pypa.io/en/stable/options/#debug-keep-container) | Keep the container after running for debugging. |
+| **Debugging** | [`log-fold-mode`](https://cibuildwheel.pypa.io/en/stable/options/#log-fold-mode) | Control CI log folding. |
+|  | [`debug-keep-container`](https://cibuildwheel.pypa.io/en/stable/options/#debug-keep-container) | Keep the container after running for debugging. |
 |  | [`debug-traceback`](https://cibuildwheel.pypa.io/en/stable/options/#debug-traceback) | Print full traceback when errors occur. |
 |  | [`build-verbosity`](https://cibuildwheel.pypa.io/en/stable/options/#build-verbosity) | Increase/decrease the output of the build |
 
 
-<!--[[[end]]] (sum: Of/28Z7Nut) -->
+<!--[[[end]]] (sum: BGrKGe9Hjz) -->
 
 These options can be specified in a pyproject.toml file, or as environment variables, see [configuration docs](https://cibuildwheel.pypa.io/en/latest/configuration/).
 

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ The following diagram summarises the steps that cibuildwheel takes on each platf
 |  | [`test-skip`](https://cibuildwheel.pypa.io/en/stable/options/#test-skip) | Skip running tests on some builds |
 |  | [`test-environment`](https://cibuildwheel.pypa.io/en/stable/options/#test-environment) | Set environment variables for the test environment |
 |  | [`test-runtime`](https://cibuildwheel.pypa.io/en/stable/options/#test-runtime) | Controls how the tests will be executed. |
-| **Debugging** | [`log-fold-mode`](https://cibuildwheel.pypa.io/en/stable/options/#log-fold-mode) | Control CI log folding. |
+| **Debugging** | [`build-verbosity`](https://cibuildwheel.pypa.io/en/stable/options/#build-verbosity) | Increase/decrease the output of the build |
 |  | [`debug-keep-container`](https://cibuildwheel.pypa.io/en/stable/options/#debug-keep-container) | Keep the container after running for debugging. |
 |  | [`debug-traceback`](https://cibuildwheel.pypa.io/en/stable/options/#debug-traceback) | Print full traceback when errors occur. |
-|  | [`build-verbosity`](https://cibuildwheel.pypa.io/en/stable/options/#build-verbosity) | Increase/decrease the output of the build |
+|  | [`log-fold-mode`](https://cibuildwheel.pypa.io/en/stable/options/#log-fold-mode) | Control CI log folding. |
 
 
-<!--[[[end]]] (sum: BGrKGe9Hjz) -->
+<!--[[[end]]] (sum: iao/k2ZuR1) -->
 
 These options can be specified in a pyproject.toml file, or as environment variables, see [configuration docs](https://cibuildwheel.pypa.io/en/latest/configuration/).
 

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -169,6 +169,18 @@ class Logger:
                 self.fold_mode = "disabled"
                 self.colors_enabled = file_supports_color(sys.stdout)
 
+        match os.environ.get("CIBW_LOG_FOLD_MODE"):
+            case None:
+                pass
+            case "azure" | "github" | "travis" | "disabled" as fold_mode:
+                self.fold_mode = fold_mode
+            case invalid_fold_mode:
+                msg = (
+                    "CIBW_LOG_FOLD_MODE must be one of azure, github, travis, "
+                    f"or disabled; got {invalid_fold_mode!r}"
+                )
+                raise ValueError(msg)
+
         self.summary = []
 
     def build_start(self, identifier: str) -> None:

--- a/docs/options.md
+++ b/docs/options.md
@@ -1871,6 +1871,19 @@ Platform-specific environment variables are also available:<br/>
 
 ## Debugging
 
+### `log-fold-mode` {: #log-fold-mode env-var}
+> Control CI log folding.
+
+Set the host environment variable `CIBW_LOG_FOLD_MODE` to override automatic
+CI log-fold detection. Accepted values are `azure`, `github`, `travis`, and
+`disabled`. Use `disabled` to keep build steps expanded in the job log.
+
+#### Examples
+
+```shell
+export CIBW_LOG_FOLD_MODE=disabled
+```
+
 ### `debug-keep-container` {: #debug-keep-container env-var}
 > Keep the container after running for debugging.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1871,18 +1871,34 @@ Platform-specific environment variables are also available:<br/>
 
 ## Debugging
 
-### `log-fold-mode` {: #log-fold-mode env-var}
-> Control CI log folding.
+### `build-verbosity` {: #build-verbosity env-var toml}
+> Increase/decrease the output of the build
 
-Set the host environment variable `CIBW_LOG_FOLD_MODE` to override automatic
-CI log-fold detection. Accepted values are `azure`, `github`, `travis`, and
-`disabled`. Use `disabled` to keep build steps expanded in the job log.
+This setting controls `-v`/`-q` flags to the build frontend. Since there is
+no communication between the build backend and the build frontend, build
+messages from the build backend will always be shown with `1`; higher levels
+will not produce more logging about the build itself. Other levels only affect
+the build frontend output, which is usually things like resolving and
+downloading dependencies. The settings are:
 
-#### Examples
+|             | build | pip    | uv    | pyodide-build | desc                                   |
+|-------------|-------|--------|-------|---------------|----------------------------------------|
+| -2          | `-qq` | `-qq`  | `-qq` |               | even more quiet, where supported       |
+| -1          | `-q`  | `-q`   | `-q`  |               | quiet mode, where supported            |
+| 0 (default) |       |        |       |               | default for build tool                 |
+| 1           |       | `-v`   |       | `-v`          | print backend output                   |
+| 2           | `-v`  | `-vv`  | `-v`  | `-vv`         | print log messages e.g. resolving info |
+| 3           | `-vv` | `-vvv` | `-vv` |               | print even more debug info             |
 
-```shell
-export CIBW_LOG_FOLD_MODE=disabled
-```
+Settings that are not supported for a specific frontend will log a warning.
+The default build frontend is `build`, which does show build backend output by
+default.
+
+On Android and iOS, a positive verbosity level will also show more detailed logs from
+the test harness.
+
+Platform-specific environment variables are also available:<br/>
+`CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX` | `CIBW_BUILD_VERBOSITY_ANDROID` | `CIBW_BUILD_VERBOSITY_IOS` | `CIBW_BUILD_VERBOSITY_PYODIDE`
 
 ### `debug-keep-container` {: #debug-keep-container env-var}
 > Keep the container after running for debugging.
@@ -1915,34 +1931,18 @@ This option can also be set using the [command-line option](#command-line) `--de
 export CIBW_DEBUG_TRACEBACK=TRUE
 ```
 
-### `build-verbosity` {: #build-verbosity env-var toml}
-> Increase/decrease the output of the build
+### `log-fold-mode` {: #log-fold-mode env-var}
+> Control CI log folding.
 
-This setting controls `-v`/`-q` flags to the build frontend. Since there is
-no communication between the build backend and the build frontend, build
-messages from the build backend will always be shown with `1`; higher levels
-will not produce more logging about the build itself. Other levels only affect
-the build frontend output, which is usually things like resolving and
-downloading dependencies. The settings are:
+Set the host environment variable `CIBW_LOG_FOLD_MODE` to override automatic
+CI log-fold detection. Accepted values are `azure`, `github`, `travis`, and
+`disabled`. Use `disabled` to keep build steps expanded in the job log.
 
-|             | build | pip    | uv    | pyodide-build | desc                                   |
-|-------------|-------|--------|-------|---------------|----------------------------------------|
-| -2          | `-qq` | `-qq`  | `-qq` |               | even more quiet, where supported       |
-| -1          | `-q`  | `-q`   | `-q`  |               | quiet mode, where supported            |
-| 0 (default) |       |        |       |               | default for build tool                 |
-| 1           |       | `-v`   |       | `-v`          | print backend output                   |
-| 2           | `-v`  | `-vv`  | `-v`  | `-vv`         | print log messages e.g. resolving info |
-| 3           | `-vv` | `-vvv` | `-vv` |               | print even more debug info             |
+#### Examples
 
-Settings that are not supported for a specific frontend will log a warning.
-The default build frontend is `build`, which does show build backend output by
-default.
-
-On Android and iOS, a positive verbosity level will also show more detailed logs from
-the test harness.
-
-Platform-specific environment variables are also available:<br/>
-`CIBW_BUILD_VERBOSITY_MACOS` | `CIBW_BUILD_VERBOSITY_WINDOWS` | `CIBW_BUILD_VERBOSITY_LINUX` | `CIBW_BUILD_VERBOSITY_ANDROID` | `CIBW_BUILD_VERBOSITY_IOS` | `CIBW_BUILD_VERBOSITY_PYODIDE`
+```shell
+export CIBW_LOG_FOLD_MODE=disabled
+```
 
 #### Examples
 

--- a/unit_test/wheel_print_test.py
+++ b/unit_test/wheel_print_test.py
@@ -2,11 +2,32 @@ from pathlib import Path
 
 import pytest
 
+from cibuildwheel.ci import CIProvider
 from cibuildwheel.logger import BuildInfo, Logger
 from cibuildwheel.options import CommandLineArguments, Options
 
 OPTIONS_DEFAULTS = Options("linux", CommandLineArguments.defaults(), {}, defaults=True)
 FILE = Path(__file__)
+
+
+@pytest.mark.parametrize("fold_mode", ["azure", "github", "travis", "disabled"])
+def test_log_fold_mode_environment_override(
+    monkeypatch: pytest.MonkeyPatch, fold_mode: str
+) -> None:
+    monkeypatch.setenv("CIBW_LOG_FOLD_MODE", fold_mode)
+    monkeypatch.setattr(
+        "cibuildwheel.logger.detect_ci_provider",
+        lambda: CIProvider.github_actions,
+    )
+
+    assert Logger().fold_mode == fold_mode
+
+
+def test_invalid_log_fold_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CIBW_LOG_FOLD_MODE", "unknown")
+
+    with pytest.raises(ValueError, match="CIBW_LOG_FOLD_MODE must be one of"):
+        Logger()
 
 
 def test_printout_wheels(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

- add `CIBW_LOG_FOLD_MODE` as a per-run override for CI log folding
- support `azure`, `github`, `travis`, and `disabled`
- reject invalid values with a clear error
- document the environment variable and cover every accepted mode

Closes #2971

## Validation

- `pytest -q unit_test/wheel_print_test.py` (7 passed)
- Ruff check and format checks pass
- relevant pre-commit hooks pass; unrelated Windows/environment checks still report existing failures