### PR TITLE
fix: preserve backslashes in container-engine create_args

### DIFF
--- a/cibuildwheel/util/helpers.py
+++ b/cibuildwheel/util/helpers.py
@@ -116,6 +116,9 @@ def parse_key_value_string(
     shlexer = shlex.shlex(key_value_string, posix=True, punctuation_chars=";")
     shlexer.commenters = ""
     shlexer.whitespace_split = True
+    # POSIX shlex treats `\` as an escape, so unquoted Windows paths in
+    # create_args become C:Usersfoo. Spaces still need quotes.
+    shlexer.escape = "\0"
     parts = list(shlexer)
     # parts now looks like
     # ['docker', ';', 'create_args:', '--some-option=value', 'another-option']

--- a/docs/options.md
+++ b/docs/options.md
@@ -1192,7 +1192,7 @@ Options can be supplied after the name.
 
 | Option name | Description
 |---|---
-| `create_args` | Space-separated strings, which are passed to the container engine on the command line when it's creating the container. If you want to include spaces inside a parameter, use shell-style quoting.
+| `create_args` | Space-separated strings, which are passed to the container engine on the command line when it's creating the container. If you want to include spaces inside a parameter, use shell-style quoting. Backslashes are kept as-is, so Windows host paths such as `C:\cache` work without extra escaping.
 | `disable_host_mount` | By default, cibuildwheel will mount the root of the host filesystem as a volume at `/host` in the container. To disable the host mount, pass `true` to this option.
 
 
@@ -1217,6 +1217,9 @@ Options can be supplied after the name.
     # pass command line options to 'docker create'
     container-engine = { name = "docker", create-args = ["--gpus", "all"]}
 
+    # Windows host bind-mount; backslashes in the path are preserved
+    container-engine = { name = "docker", create-args = ["--volume=C:\\cache:/cache"] }
+
     # disable the /host mount
     container-engine = { name = "docker", disable-host-mount = true }
     ```
@@ -1229,6 +1232,9 @@ Options can be supplied after the name.
 
     # pass command line options to 'docker create'
     CIBW_CONTAINER_ENGINE: "docker; create_args: --gpus all"
+
+    # Windows host bind-mount; backslashes in the path are preserved
+    CIBW_CONTAINER_ENGINE: 'docker; create_args: --volume=C:\cache:/cache'
 
     # disable the /host mount
     CIBW_CONTAINER_ENGINE: "docker; disable_host_mount: true"

--- a/unit_test/oci_container_test.py
+++ b/unit_test/oci_container_test.py
@@ -483,6 +483,16 @@ def test_create_args_volume(tmp_path: Path, container_engine: OCIContainerEngine
             ("--some-option=value with spaces",),
         ),
         (
+            r"docker; create_args: --volume=C:\Users\foo\bar:/data",
+            "docker",
+            (r"--volume=C:\Users\foo\bar:/data",),
+        ),
+        (
+            r'docker; create_args: --volume="C:\Users\John Doe\data:/data"',
+            "docker",
+            (r"--volume=C:\Users\John Doe\data:/data",),
+        ),
+        (
             'docker; create_args: --some-option="value; with; semicolons" --another-option',
             "docker",
             ("--some-option=value; with; semicolons", "--another-option"),

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -344,6 +344,12 @@ def test_toml_environment_quoting(tmp_path: Path, toml_assignment: str, result_v
             False,
         ),
         (
+            r'container-engine = "docker; create_args: --volume=C:\\Users\\foo\\cache:/cache"',
+            "docker",
+            (r"--volume=C:\Users\foo\cache:/cache",),
+            False,
+        ),
+        (
             'container-engine = {name = "docker", create-args = ["--some-option"]}',
             "docker",
             ("--some-option",),

--- a/unit_test/utils_test.py
+++ b/unit_test/utils_test.py
@@ -212,6 +212,24 @@ def test_parse_key_value_string() -> None:
         "create_args": [],
     }
 
+    # Windows host paths: backslashes must not be eaten as POSIX escapes
+    assert parse_key_value_string(
+        r"docker; create_args: --volume=C:\Users\foo\bar:/data",
+        positional_arg_names=["name"],
+        kw_arg_names=["create_args"],
+    ) == {
+        "name": ["docker"],
+        "create_args": [r"--volume=C:\Users\foo\bar:/data"],
+    }
+    assert parse_key_value_string(
+        r'docker; create_args: --volume="C:\Users\John Doe\data:/data"',
+        positional_arg_names=["name"],
+        kw_arg_names=["create_args"],
+    ) == {
+        "name": ["docker"],
+        "create_args": [r"--volume=C:\Users\John Doe\data:/data"],
+    }
+
 
 def test_parse_key_value_string_unknown_name() -> None:
     # Unknown fields are not allowed by default.


### PR DESCRIPTION
## Summary

- keep backslashes literal in `parse_key_value_string` (used by `container-engine` / `create_args`)
- add unit tests for unquoted and quoted Windows volume paths
- note the behaviour in the `container-engine` docs

## Why

`parse_key_value_string` tokenizes with POSIX `shlex`, which treats `\` as an escape. An unquoted Windows bind-mount such as

```
docker; create_args: --volume=C:\Users\foo\bar:/data
```

was parsed as `--volume=C:Usersfoobar:/data`. Quoted values with spaces already worked; unquoted Windows paths did not.

Same quoting class as #2886 (`{project}` / `{package}` backslashes eaten by a later `shlex.split`) and #2913 (`test-requires` split on spaces). Spaces inside a `create_args` value still need quotes, as documented.

## Validation

- `uv run pytest unit_test/utils_test.py::test_parse_key_value_string unit_test/oci_container_test.py::test_parse_engine_config unit_test/options_test.py::test_container_engine_option -q` (23 passed)
- `uv run pytest unit_test/utils_test.py unit_test/options_test.py -q` (142 passed, 3 existing xfails)
- `uvx prek run --files cibuildwheel/util/helpers.py unit_test/utils_test.py unit_test/options_test.py docs/options.md`
- `git diff --check`
